### PR TITLE
feat: Result型と基本ユーティリティの実装

### DIFF
--- a/src/core/types/result.ts
+++ b/src/core/types/result.ts
@@ -1,0 +1,40 @@
+export type Result<T, E> =
+	| { readonly ok: true; readonly value: T }
+	| { readonly ok: false; readonly error: E };
+
+export function ok<T>(value: T): Result<T, never> {
+	return { ok: true, value };
+}
+
+export function err<E>(error: E): Result<never, E> {
+	return { ok: false, error };
+}
+
+export function isOk<T, E>(
+	result: Result<T, E>,
+): result is { readonly ok: true; readonly value: T } {
+	return result.ok;
+}
+
+export function isErr<T, E>(
+	result: Result<T, E>,
+): result is { readonly ok: false; readonly error: E } {
+	return !result.ok;
+}
+
+export function map<T, U, E>(result: Result<T, E>, fn: (value: T) => U): Result<U, E> {
+	if (result.ok) {
+		return ok(fn(result.value));
+	}
+	return result;
+}
+
+export function flatMap<T, U, E>(
+	result: Result<T, E>,
+	fn: (value: T) => Result<U, E>,
+): Result<U, E> {
+	if (result.ok) {
+		return fn(result.value);
+	}
+	return result;
+}

--- a/tests/core/types/result.test.ts
+++ b/tests/core/types/result.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { Result } from "../../../src/core/types/result";
+import { err, flatMap, isErr, isOk, map, ok } from "../../../src/core/types/result";
+
+describe("Result", () => {
+	describe("ok", () => {
+		it("ok値を持つResultを生成する", () => {
+			const result = ok(42);
+			expect(result).toStrictEqual({ ok: true, value: 42 });
+		});
+	});
+
+	describe("err", () => {
+		it("エラー値を持つResultを生成する", () => {
+			const result = err("something failed");
+			expect(result).toStrictEqual({ ok: false, error: "something failed" });
+		});
+	});
+
+	describe("isOk", () => {
+		it("ok Resultに対してtrueを返す", () => {
+			const result: Result<number, string> = ok(1);
+			expect(isOk(result)).toBe(true);
+		});
+
+		it("err Resultに対してfalseを返す", () => {
+			const result: Result<number, string> = err("fail");
+			expect(isOk(result)).toBe(false);
+		});
+
+		it("型ガードとして機能する", () => {
+			const result: Result<number, string> = ok(42);
+			if (isOk(result)) {
+				const value: number = result.value;
+				expect(value).toBe(42);
+			}
+		});
+	});
+
+	describe("isErr", () => {
+		it("err Resultに対してtrueを返す", () => {
+			const result: Result<number, string> = err("fail");
+			expect(isErr(result)).toBe(true);
+		});
+
+		it("ok Resultに対してfalseを返す", () => {
+			const result: Result<number, string> = ok(1);
+			expect(isErr(result)).toBe(false);
+		});
+
+		it("型ガードとして機能する", () => {
+			const result: Result<number, string> = err("fail");
+			if (isErr(result)) {
+				const error: string = result.error;
+				expect(error).toBe("fail");
+			}
+		});
+	});
+
+	describe("map", () => {
+		it("ok Resultの値を変換する", () => {
+			const result: Result<number, string> = ok(2);
+			const mapped = map(result, (v) => v * 3);
+			expect(mapped).toStrictEqual({ ok: true, value: 6 });
+		});
+
+		it("err Resultはそのまま返す", () => {
+			const result: Result<number, string> = err("fail");
+			const mapped = map(result, (v) => v * 3);
+			expect(mapped).toStrictEqual({ ok: false, error: "fail" });
+		});
+	});
+
+	describe("flatMap", () => {
+		it("ok Resultに対して関数を適用する", () => {
+			const result: Result<number, string> = ok(10);
+			const chained = flatMap(result, (v) => (v > 0 ? ok(v.toString()) : err("must be positive")));
+			expect(chained).toStrictEqual({ ok: true, value: "10" });
+		});
+
+		it("ok Resultに対してerrを返す関数を適用できる", () => {
+			const result: Result<number, string> = ok(-1);
+			const chained = flatMap(result, (v) => (v > 0 ? ok(v.toString()) : err("must be positive")));
+			expect(chained).toStrictEqual({ ok: false, error: "must be positive" });
+		});
+
+		it("err Resultはそのまま返す", () => {
+			const result: Result<number, string> = err("initial error");
+			const chained = flatMap(result, (v) => ok(v.toString()));
+			expect(chained).toStrictEqual({ ok: false, error: "initial error" });
+		});
+	});
+});


### PR DESCRIPTION
## 概要
Issue #9 の実装。

## 変更内容
- `src/core/types/result.ts`: Result<T, E> discriminated union型、ok/err ファクトリ、isOk/isErr 型ガード、map/flatMap ユーティリティ
- `tests/core/types/result.test.ts`: 13テスト（全パス）

## チェックリスト
- [x] Result 型が実装済み
- [x] テスト通過
- [x] typecheck通過
- [x] biome lint通過

Closes #9