### PR TITLE
feat: ドメインエラー型の定義

### DIFF
--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -1,0 +1,69 @@
+export const ErrorType = {
+	SkillNotFound: "SKILL_NOT_FOUND",
+	Parse: "PARSE_ERROR",
+	Render: "RENDER_ERROR",
+	Execution: "EXECUTION_ERROR",
+	Config: "CONFIG_ERROR",
+} as const;
+
+export type ErrorType = (typeof ErrorType)[keyof typeof ErrorType];
+
+export type SkillNotFoundError = {
+	readonly type: typeof ErrorType.SkillNotFound;
+	readonly name: string;
+};
+
+export type ParseError = {
+	readonly type: typeof ErrorType.Parse;
+	readonly message: string;
+};
+
+export type RenderError = {
+	readonly type: typeof ErrorType.Render;
+	readonly message: string;
+};
+
+export type ExecutionError = {
+	readonly type: typeof ErrorType.Execution;
+	readonly message: string;
+};
+
+export type ConfigError = {
+	readonly type: typeof ErrorType.Config;
+	readonly message: string;
+};
+
+export type DomainError =
+	| SkillNotFoundError
+	| ParseError
+	| RenderError
+	| ExecutionError
+	| ConfigError;
+
+export const EXIT_CODE: Record<ErrorType, number> = {
+	[ErrorType.Execution]: 1,
+	[ErrorType.SkillNotFound]: 2,
+	[ErrorType.Parse]: 3,
+	[ErrorType.Config]: 4,
+	[ErrorType.Render]: 1,
+};
+
+export function skillNotFoundError(name: string): SkillNotFoundError {
+	return { type: ErrorType.SkillNotFound, name };
+}
+
+export function parseError(message: string): ParseError {
+	return { type: ErrorType.Parse, message };
+}
+
+export function renderError(message: string): RenderError {
+	return { type: ErrorType.Render, message };
+}
+
+export function executionError(message: string): ExecutionError {
+	return { type: ErrorType.Execution, message };
+}
+
+export function configError(message: string): ConfigError {
+	return { type: ErrorType.Config, message };
+}


### PR DESCRIPTION
## 概要
Issue #10 の対応。`src/core/types/errors.ts` にドメイン固有のエラー型を定義。

## 変更内容
- `SkillNotFoundError`, `ParseError`, `RenderError`, `ExecutionError`, `ConfigError` の5つのエラー型
- `ErrorType` const object + type による discriminant
- `DomainError` discriminated union（`type` フィールドで switch 可能）
- `EXIT_CODE` マップ（CLI-SPEC.md の終了コード 1-4 と対応）
- 各エラー型のファクトリ関数

## 参照
- docs/arch/error-handling.md
- docs/CLI-SPEC.md

Closes #10