### PR TITLE
feat: テストフィクスチャの作成 (#12)

### DIFF
--- a/tests/fixtures/skills/invalid-frontmatter/SKILL.md
+++ b/tests/fixtures/skills/invalid-frontmatter/SKILL.md
@@ -1,0 +1,8 @@
+---
+mode: template
+inputs: "not-an-array"
+---
+
+# Invalid Skill
+
+This skill has no name, no description, and inputs is not an array.

--- a/tests/fixtures/skills/multi-codeblock/SKILL.md
+++ b/tests/fixtures/skills/multi-codeblock/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: setup
+description: プロジェクトをセットアップする
+mode: template
+inputs:
+  - name: project
+    type: text
+    message: "プロジェクト名は？"
+---
+
+# Setup {{project}}
+
+## 依存関係のインストール
+
+```bash
+cd {{project}}
+npm install
+```
+
+## データベースのセットアップ
+
+```bash
+npm run db:migrate
+```
+
+## 初期データの投入
+
+```bash
+npm run db:seed
+```

--- a/tests/fixtures/skills/no-inputs/SKILL.md
+++ b/tests/fixtures/skills/no-inputs/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: hello
+description: 挨拶を表示する
+mode: template
+---
+
+# Hello
+
+```bash
+echo "Hello, World!"
+```

--- a/tests/fixtures/skills/valid-agent/SKILL.md
+++ b/tests/fixtures/skills/valid-agent/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: コードレビューを実行する
+mode: agent
+model: claude-sonnet-4-20250514
+inputs:
+  - name: target
+    type: text
+    message: "レビュー対象のファイルまたはディレクトリは？"
+    default: "."
+  - name: focus
+    type: text
+    message: "特に注目してほしい観点は？"
+    required: false
+tools:
+  - bash
+  - read
+---
+
+# コードレビュー
+
+以下の観点で {{target}} をレビューしてください:
+
+1. バグの可能性がある箇所
+2. パフォーマンスの問題
+3. 可読性・保守性の改善点

--- a/tests/fixtures/skills/valid-template/SKILL.md
+++ b/tests/fixtures/skills/valid-template/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: deploy
+description: アプリケーションをデプロイする
+mode: template
+inputs:
+  - name: environment
+    type: select
+    message: "デプロイ先を選んでください"
+    choices: [staging, production]
+  - name: branch
+    type: text
+    message: "ブランチ名は？"
+    default: main
+---
+
+# Deploy to {{environment}}
+
+{{environment}} 環境に {{branch}} ブランチをデプロイします。
+
+```bash
+git checkout {{branch}}
+git pull origin {{branch}}
+npm run build
+npm run deploy:{{environment}}
+```

--- a/tests/fixtures/skills/with-context/SKILL.md
+++ b/tests/fixtures/skills/with-context/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: refactor
+description: コードをリファクタリングする
+mode: agent
+inputs:
+  - name: target
+    type: text
+    message: "リファクタリング対象のファイルは？"
+context:
+  - type: file
+    path: "{{target}}"
+  - type: glob
+    pattern: "src/**/*.ts"
+  - type: command
+    run: "git diff --cached"
+  - type: url
+    url: "https://example.com/style-guide"
+tools:
+  - bash
+  - read
+  - write
+---
+
+# リファクタリング
+
+{{target}} をリファクタリングしてください。
+
+コンテキストとして以下が提供されます:
+- 対象ファイルの内容
+- プロジェクト内の TypeScript ファイル
+- ステージ済みの差分
+- スタイルガイド


### PR DESCRIPTION
## 概要

テスト用の SKILL.md ファイル群を `tests/fixtures/skills/` に配置。

## 追加フィクスチャ

| フィクスチャ | 用途 |
|---|---|
| `valid-template/` | 有効な template モードスキル |
| `valid-agent/` | 有効な agent モードスキル |
| `no-inputs/` | 入力なしスキル |
| `invalid-frontmatter/` | 不正なフロントマター |
| `multi-codeblock/` | 複数コードブロック |
| `with-context/` | ContextSource 付きスキル |

Closes #12