### PR TITLE
feat: SkillMetadata 型の定義・パース・テスト

### DIFF
--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const inputTypeSchema = z.enum(["text", "select", "confirm", "number", "password"]);
+
+const skillInputSchema = z
+	.object({
+		name: z.string().min(1),
+		type: inputTypeSchema,
+		message: z.string().min(1),
+		default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+		choices: z.array(z.string()).optional(),
+		required: z.boolean().optional(),
+		validate: z.string().optional(),
+	})
+	.refine((input) => input.type !== "select" || (input.choices && input.choices.length > 0), {
+		message: "choices is required for select type",
+	});
+
+const contextSourceSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("file"), path: z.string().min(1) }),
+	z.object({ type: z.literal("glob"), pattern: z.string().min(1) }),
+	z.object({ type: z.literal("command"), run: z.string().min(1) }),
+	z.object({ type: z.literal("url"), url: z.string().min(1) }),
+]);
+
+const skillModeSchema = z.enum(["template", "agent"]);
+
+const DEFAULT_TOOLS = ["bash", "read", "write"] as const;
+
+const skillMetadataSchema = z.object({
+	name: z.string().min(1),
+	description: z.string().min(1),
+	mode: skillModeSchema.default("template"),
+	inputs: z.array(skillInputSchema).default([]),
+	model: z.string().min(1).optional(),
+	tools: z.array(z.string().min(1)).default([...DEFAULT_TOOLS]),
+	context: z.array(contextSourceSchema).default([]),
+});
+
+type SkillInput = z.infer<typeof skillInputSchema>;
+type ContextSource = z.infer<typeof contextSourceSchema>;
+type SkillMode = z.infer<typeof skillModeSchema>;
+type SkillMetadata = z.infer<typeof skillMetadataSchema>;
+
+function parseSkillMetadata(data: unknown): SkillMetadata {
+	return skillMetadataSchema.parse(data);
+}
+
+export type { ContextSource, SkillInput, SkillMetadata, SkillMode };
+export { parseSkillMetadata, skillInputSchema, skillMetadataSchema };

--- a/tests/core/skill/skill-metadata.test.ts
+++ b/tests/core/skill/skill-metadata.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { parseSkillMetadata } from "../../../src/core/skill/skill-metadata";
+
+describe("parseSkillMetadata", () => {
+	it("最小限のフロントマター（name + description のみ）でデフォルト値が設定される", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "アプリケーションをデプロイする",
+		});
+
+		expect(result).toStrictEqual({
+			name: "deploy",
+			description: "アプリケーションをデプロイする",
+			mode: "template",
+			inputs: [],
+			tools: ["bash", "read", "write"],
+			context: [],
+		});
+	});
+
+	it("全フィールド指定で正しくパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "code-review",
+			description: "コードレビューを実行する",
+			mode: "agent",
+			model: "claude-sonnet-4-20250514",
+			inputs: [
+				{
+					name: "target",
+					type: "text",
+					message: "レビュー対象は？",
+					default: ".",
+				},
+				{
+					name: "env",
+					type: "select",
+					message: "環境を選んでください",
+					choices: ["staging", "production"],
+				},
+			],
+			tools: ["bash", "read"],
+			context: [
+				{ type: "file", path: "src/index.ts" },
+				{ type: "glob", pattern: "src/**/*.ts" },
+				{ type: "command", run: "git diff --cached" },
+				{ type: "url", url: "https://example.com/docs" },
+			],
+		});
+
+		expect(result.name).toBe("code-review");
+		expect(result.mode).toBe("agent");
+		expect(result.model).toBe("claude-sonnet-4-20250514");
+		expect(result.inputs).toHaveLength(2);
+		expect(result.tools).toStrictEqual(["bash", "read"]);
+		expect(result.context).toHaveLength(4);
+	});
+
+	it("無効な mode でエラーになる", () => {
+		expect(() =>
+			parseSkillMetadata({
+				name: "test",
+				description: "test",
+				mode: "invalid",
+			}),
+		).toThrow();
+	});
+
+	it("name が空文字でエラーになる", () => {
+		expect(() =>
+			parseSkillMetadata({
+				name: "",
+				description: "test",
+			}),
+		).toThrow();
+	});
+
+	it("description が空文字でエラーになる", () => {
+		expect(() =>
+			parseSkillMetadata({
+				name: "test",
+				description: "",
+			}),
+		).toThrow();
+	});
+
+	it("inputs の select タイプに choices がない場合エラーになる", () => {
+		expect(() =>
+			parseSkillMetadata({
+				name: "test",
+				description: "test",
+				inputs: [
+					{
+						name: "env",
+						type: "select",
+						message: "環境を選んでください",
+					},
+				],
+			}),
+		).toThrow();
+	});
+
+	it("inputs の各フィールドが正しくパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "test",
+			description: "test",
+			inputs: [
+				{
+					name: "confirm",
+					type: "confirm",
+					message: "よろしいですか？",
+					default: true,
+					required: false,
+				},
+				{
+					name: "count",
+					type: "number",
+					message: "回数は？",
+					default: 5,
+					validate: "^[1-9][0-9]*$",
+				},
+			],
+		});
+
+		expect(result.inputs[0].name).toBe("confirm");
+		expect(result.inputs[0].type).toBe("confirm");
+		expect(result.inputs[0].default).toBe(true);
+		expect(result.inputs[0].required).toBe(false);
+		expect(result.inputs[1].validate).toBe("^[1-9][0-9]*$");
+	});
+
+	it("name が未指定でエラーになる", () => {
+		expect(() =>
+			parseSkillMetadata({
+				description: "test",
+			}),
+		).toThrow();
+	});
+});


### PR DESCRIPTION
## 概要

SKILL.md のフロントマターを表すドメインモデルを実装。

## 変更内容

- `src/core/skill/skill-metadata.ts`: SkillMetadata, SkillInput, ContextSource, SkillMode 型 + Zod スキーマ + parseSkillMetadata 関数
- `tests/core/skill/skill-metadata.test.ts`: 8 テストケース

## 完了条件

- [x] SkillMetadata 型・パース実装
- [x] テスト通過（8 ケース）

Closes #15