### PR TITLE
feat: ContextSource 型の定義と Zod パース実装

### DIFF
--- a/src/core/skill/context-source.ts
+++ b/src/core/skill/context-source.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+const fileSourceSchema = z.object({
+	type: z.literal("file"),
+	path: z.string(),
+});
+
+const globSourceSchema = z.object({
+	type: z.literal("glob"),
+	pattern: z.string(),
+});
+
+const commandSourceSchema = z.object({
+	type: z.literal("command"),
+	run: z.string(),
+});
+
+const urlSourceSchema = z.object({
+	type: z.literal("url"),
+	url: z.string(),
+});
+
+export const contextSourceSchema = z.discriminatedUnion("type", [
+	fileSourceSchema,
+	globSourceSchema,
+	commandSourceSchema,
+	urlSourceSchema,
+]);
+
+export type ContextSource = z.infer<typeof contextSourceSchema>;
+
+export function parseContextSource(input: unknown): ContextSource {
+	return contextSourceSchema.parse(input);
+}

--- a/tests/unit/skill/context-source.test.ts
+++ b/tests/unit/skill/context-source.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { parseContextSource } from "../../../src/core/skill/context-source";
+
+describe("parseContextSource", () => {
+	it("parses file type", () => {
+		const result = parseContextSource({
+			type: "file",
+			path: "src/{{target}}",
+		});
+		expect(result).toEqual({ type: "file", path: "src/{{target}}" });
+	});
+
+	it("parses glob type", () => {
+		const result = parseContextSource({
+			type: "glob",
+			pattern: "src/**/*.ts",
+		});
+		expect(result).toEqual({ type: "glob", pattern: "src/**/*.ts" });
+	});
+
+	it("parses command type", () => {
+		const result = parseContextSource({
+			type: "command",
+			run: "git diff --cached",
+		});
+		expect(result).toEqual({ type: "command", run: "git diff --cached" });
+	});
+
+	it("parses url type", () => {
+		const result = parseContextSource({
+			type: "url",
+			url: "https://example.com/api-docs",
+		});
+		expect(result).toEqual({
+			type: "url",
+			url: "https://example.com/api-docs",
+		});
+	});
+
+	it("throws on invalid type", () => {
+		expect(() => parseContextSource({ type: "invalid" })).toThrow();
+	});
+
+	it("throws on missing required field for file", () => {
+		expect(() => parseContextSource({ type: "file" })).toThrow();
+	});
+
+	it("throws on missing required field for glob", () => {
+		expect(() => parseContextSource({ type: "glob" })).toThrow();
+	});
+
+	it("throws on missing required field for command", () => {
+		expect(() => parseContextSource({ type: "command" })).toThrow();
+	});
+
+	it("throws on missing required field for url", () => {
+		expect(() => parseContextSource({ type: "url" })).toThrow();
+	});
+
+	it("throws on missing type", () => {
+		expect(() => parseContextSource({ path: "src/foo" })).toThrow();
+	});
+
+	it("preserves template variables as strings", () => {
+		const result = parseContextSource({
+			type: "file",
+			path: "{{__cwd__}}/src/{{module}}/index.ts",
+		});
+		expect(result).toEqual({
+			type: "file",
+			path: "{{__cwd__}}/src/{{module}}/index.ts",
+		});
+	});
+});


### PR DESCRIPTION
## 概要

Closes #16

スキルのコンテキストソース定義を型として実装。

## 変更内容

- `src/core/skill/context-source.ts`: ContextSource 型・スキーマ・パース関数
  - file / glob / command / url の 4 種類
  - Zod discriminatedUnion によるバリデーション
  - `{{変数}}` はこの時点では文字列として保持
- `tests/unit/skill/context-source.test.ts`: 11 テストケース
  - 各 type の正常パース
  - 不正な type / 必須フィールド欠落でのエラー
  - テンプレート変数の保持確認

## 完了条件

- [x] ContextSource 型・パース実装
- [x] テスト通過