### PR TITLE
feat(variable): implement TemplateRenderer with reserved variables

### DIFF
--- a/src/core/variable/index.ts
+++ b/src/core/variable/index.ts
@@ -1,1 +1,2 @@
 // Variable domain models
+export { type ReservedVars, renderTemplate } from "./template-renderer";

--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -1,0 +1,63 @@
+import { type RenderError, renderError } from "../types/errors";
+import { err, ok, type Result } from "../types/result";
+
+export type ReservedVars = {
+	readonly cwd: string;
+	readonly skillDir: string;
+	readonly date: string;
+	readonly timestamp: string;
+};
+
+const VARIABLE_PATTERN = /\{\{(\w+)\}\}/g;
+
+const RESERVED_VAR_MAP: Record<string, keyof ReservedVars> = {
+	__cwd__: "cwd",
+	__skill_dir__: "skillDir",
+	__date__: "date",
+	__timestamp__: "timestamp",
+};
+
+function resolveVariable(
+	name: string,
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+): string | undefined {
+	const reservedKey = RESERVED_VAR_MAP[name];
+	if (reservedKey !== undefined) {
+		return reserved[reservedKey];
+	}
+	return variables[name];
+}
+
+function findUndefinedVariables(
+	template: string,
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+): readonly string[] {
+	const undefined_: string[] = [];
+	for (const match of template.matchAll(VARIABLE_PATTERN)) {
+		const name = match[1];
+		if (resolveVariable(name, variables, reserved) === undefined) {
+			undefined_.push(name);
+		}
+	}
+	return [...new Set(undefined_)];
+}
+
+export function renderTemplate(
+	template: string,
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+): Result<string, RenderError> {
+	const undefinedVars = findUndefinedVariables(template, variables, reserved);
+	if (undefinedVars.length > 0) {
+		return err(renderError(`Undefined variables: ${undefinedVars.join(", ")}`));
+	}
+
+	const rendered = template.replace(VARIABLE_PATTERN, (_, name: string) => {
+		const value = resolveVariable(name, variables, reserved);
+		return value as string;
+	});
+
+	return ok(rendered);
+}

--- a/tests/core/variable/template-renderer.test.ts
+++ b/tests/core/variable/template-renderer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { ReservedVars } from "../../../src/core/variable/template-renderer";
+import { renderTemplate } from "../../../src/core/variable/template-renderer";
+
+const RESERVED: ReservedVars = {
+	cwd: "/home/user/project",
+	skillDir: "/home/user/.taskp/skills/deploy",
+	date: "2026-03-19",
+	timestamp: "2026-03-19T12:00:00.000Z",
+};
+
+describe("renderTemplate", () => {
+	it("expands a single variable", () => {
+		const result = renderTemplate("Hello {{name}}!", { name: "World" }, RESERVED);
+		expect(result).toEqual({ ok: true, value: "Hello World!" });
+	});
+
+	it("expands multiple variables", () => {
+		const result = renderTemplate(
+			"Deploy {{branch}} to {{env}}",
+			{ branch: "main", env: "production" },
+			RESERVED,
+		);
+		expect(result).toEqual({
+			ok: true,
+			value: "Deploy main to production",
+		});
+	});
+
+	it("expands reserved variables", () => {
+		const result = renderTemplate(
+			"cwd={{__cwd__}} dir={{__skill_dir__}} date={{__date__}} ts={{__timestamp__}}",
+			{},
+			RESERVED,
+		);
+		expect(result).toEqual({
+			ok: true,
+			value: `cwd=${RESERVED.cwd} dir=${RESERVED.skillDir} date=${RESERVED.date} ts=${RESERVED.timestamp}`,
+		});
+	});
+
+	it("returns error for undefined variables", () => {
+		const result = renderTemplate("{{unknown}} and {{missing}}", {}, RESERVED);
+		expect(result).toEqual({
+			ok: false,
+			error: { type: "RENDER_ERROR", message: "Undefined variables: unknown, missing" },
+		});
+	});
+
+	it("passes through template without variables", () => {
+		const result = renderTemplate("No variables here.", {}, RESERVED);
+		expect(result).toEqual({ ok: true, value: "No variables here." });
+	});
+
+	it("expands the same variable appearing multiple times", () => {
+		const result = renderTemplate("{{x}} + {{x}} = 2 * {{x}}", { x: "5" }, RESERVED);
+		expect(result).toEqual({ ok: true, value: "5 + 5 = 2 * 5" });
+	});
+
+	it("returns deduplicated undefined variable names", () => {
+		const result = renderTemplate("{{a}} {{a}} {{b}}", {}, RESERVED);
+		expect(result).toEqual({
+			ok: false,
+			error: { type: "RENDER_ERROR", message: "Undefined variables: a, b" },
+		});
+	});
+});


### PR DESCRIPTION
## 変更内容

- `renderTemplate()` を実装（`{{variable}}` 構文のテンプレート変数展開）
- 予約変数対応: `{{__cwd__}}`, `{{__skill_dir__}}`, `{{__date__}}`, `{{__timestamp__}}`
- 未定義変数の検出 → `RenderError` 返却
- `src/core/variable/index.ts` からエクスポート

## テスト（7ケース）

- 単一変数の展開
- 複数変数の展開
- 予約変数の展開
- 未定義変数でのエラー
- 変数なしテンプレートのパススルー
- 同一変数の複数回出現
- 未定義変数名の重複排除

Closes #19