### PR TITLE
feat: define Port interfaces for UseCase layer

### DIFF
--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,1 +1,12 @@
 // Use cases
+
+// Ports (interfaces for adapters)
+export type {
+	CommandExecutor,
+	ExecOptions,
+	ExecResult,
+	InitOptions,
+	PromptCollector,
+	SkillInitializer,
+	SkillRepository,
+} from "./port";

--- a/src/usecase/port/command-executor.ts
+++ b/src/usecase/port/command-executor.ts
@@ -1,0 +1,21 @@
+import type { ExecutionError } from "../../core/types/errors";
+import type { Result } from "../../core/types/result";
+
+export type ExecOptions = {
+	readonly cwd?: string;
+	readonly env?: Readonly<Record<string, string>>;
+	readonly timeout?: number;
+};
+
+export type ExecResult = {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number;
+};
+
+export type CommandExecutor = {
+	readonly execute: (
+		command: string,
+		options?: ExecOptions,
+	) => Promise<Result<ExecResult, ExecutionError>>;
+};

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -1,0 +1,4 @@
+export type { CommandExecutor, ExecOptions, ExecResult } from "./command-executor";
+export type { PromptCollector } from "./prompt-collector";
+export type { InitOptions, SkillInitializer } from "./skill-initializer";
+export type { SkillRepository } from "./skill-repository";

--- a/src/usecase/port/prompt-collector.ts
+++ b/src/usecase/port/prompt-collector.ts
@@ -1,0 +1,8 @@
+import type { SkillInput } from "../../core/skill/skill-metadata";
+
+export type PromptCollector = {
+	readonly collect: (
+		inputs: readonly SkillInput[],
+		presets: Readonly<Record<string, string>>,
+	) => Promise<Readonly<Record<string, string>>>;
+};

--- a/src/usecase/port/skill-initializer.ts
+++ b/src/usecase/port/skill-initializer.ts
@@ -1,0 +1,10 @@
+import type { Result } from "../../core/types/result";
+
+export type InitOptions = {
+	readonly mode: "template" | "agent";
+	readonly description: string;
+};
+
+export type SkillInitializer = {
+	readonly create: (name: string, options: InitOptions) => Promise<Result<string, Error>>;
+};

--- a/src/usecase/port/skill-repository.ts
+++ b/src/usecase/port/skill-repository.ts
@@ -1,0 +1,10 @@
+import type { Skill } from "../../core/skill/skill";
+import type { SkillNotFoundError } from "../../core/types/errors";
+import type { Result } from "../../core/types/result";
+
+export type SkillRepository = {
+	readonly findByName: (name: string) => Promise<Result<Skill, SkillNotFoundError>>;
+	readonly listAll: () => Promise<Skill[]>;
+	readonly listLocal: () => Promise<Skill[]>;
+	readonly listGlobal: () => Promise<Skill[]>;
+};


### PR DESCRIPTION
## Summary

UseCase 層が依存する Adapter のインターフェース（Port）を4つ定義。

### Added
- `src/usecase/port/skill-repository.ts` — スキルの読み込み・一覧
- `src/usecase/port/command-executor.ts` — シェルコマンド実行
- `src/usecase/port/prompt-collector.ts` — インタラクティブ質問
- `src/usecase/port/skill-initializer.ts` — スキル雛形生成
- `src/usecase/port/index.ts` — barrel export

### Verification
- `tsc --noEmit` ✅
- `biome check` ✅
- `vitest run` (56 tests passed) ✅

Closes #21