### PR TITLE
feat: RunSkillUseCase の実装（template モード）

### DIFF
--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -10,3 +10,5 @@ export type {
 	SkillInitializer,
 	SkillRepository,
 } from "./port";
+export type { CommandResult, RunOutput, RunSkillDeps, RunSkillInput } from "./run-skill";
+export { runSkill } from "./run-skill";

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,0 +1,126 @@
+import type { CodeBlock } from "../core/skill/skill-body";
+import type { DomainError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { ok } from "../core/types/result";
+import type { ReservedVars } from "../core/variable/template-renderer";
+import { renderTemplate } from "../core/variable/template-renderer";
+import type { CommandExecutor, ExecResult } from "./port/command-executor";
+import type { PromptCollector } from "./port/prompt-collector";
+import type { SkillRepository } from "./port/skill-repository";
+
+export type RunSkillInput = {
+	readonly name: string;
+	readonly presets: Readonly<Record<string, string>>;
+	readonly dryRun: boolean;
+	readonly force: boolean;
+};
+
+export type CommandResult = {
+	readonly command: string;
+	readonly result: ExecResult;
+};
+
+export type RunOutput = {
+	readonly skillName: string;
+	readonly rendered: string;
+	readonly commands: readonly CommandResult[];
+	readonly dryRun: boolean;
+};
+
+export type RunSkillDeps = {
+	readonly skillRepository: SkillRepository;
+	readonly promptCollector: PromptCollector;
+	readonly commandExecutor: CommandExecutor;
+};
+
+export async function runSkill(
+	input: RunSkillInput,
+	deps: RunSkillDeps,
+): Promise<Result<RunOutput, DomainError>> {
+	const findResult = await deps.skillRepository.findByName(input.name);
+	if (!findResult.ok) {
+		return findResult;
+	}
+
+	const skill = findResult.value;
+
+	const variables = await deps.promptCollector.collect(skill.metadata.inputs, input.presets);
+
+	const reserved: ReservedVars = {
+		cwd: process.cwd(),
+		skillDir: skill.location,
+		date: new Date().toISOString().split("T")[0],
+		timestamp: new Date().toISOString(),
+	};
+
+	const renderResult = renderTemplate(skill.body.content, variables, reserved);
+	if (!renderResult.ok) {
+		return renderResult;
+	}
+
+	const rendered = renderResult.value;
+	const codeBlocks = skill.body.extractCodeBlocks("bash");
+
+	if (input.dryRun) {
+		return ok({
+			skillName: skill.metadata.name,
+			rendered,
+			commands: [],
+			dryRun: true,
+		});
+	}
+
+	const commandResults = await executeCommands(
+		codeBlocks,
+		variables,
+		reserved,
+		input.force,
+		deps.commandExecutor,
+	);
+	if (!commandResults.ok) {
+		return commandResults;
+	}
+
+	return ok({
+		skillName: skill.metadata.name,
+		rendered,
+		commands: commandResults.value,
+		dryRun: false,
+	});
+}
+
+async function executeCommands(
+	codeBlocks: readonly CodeBlock[],
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+	force: boolean,
+	executor: CommandExecutor,
+): Promise<Result<readonly CommandResult[], DomainError>> {
+	const results: CommandResult[] = [];
+
+	for (const block of codeBlocks) {
+		const renderResult = renderTemplate(block.code, variables, reserved);
+		if (!renderResult.ok) {
+			return renderResult;
+		}
+
+		const execResult = await executor.execute(renderResult.value);
+		if (!execResult.ok) {
+			if (!force) {
+				return execResult;
+			}
+			results.push({
+				command: renderResult.value,
+				result: { stdout: "", stderr: execResult.error.message, exitCode: 1 },
+			});
+			continue;
+		}
+
+		results.push({
+			command: renderResult.value,
+			result: execResult.value,
+		});
+	}
+
+	return ok(results);
+}

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../../src/core/skill/skill";
+import { createSkillBody } from "../../src/core/skill/skill-body";
+import { executionError, skillNotFoundError } from "../../src/core/types/errors";
+import { err, ok } from "../../src/core/types/result";
+import type { CommandExecutor } from "../../src/usecase/port/command-executor";
+import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
+import type { SkillRepository } from "../../src/usecase/port/skill-repository";
+import type { RunSkillDeps, RunSkillInput } from "../../src/usecase/run-skill";
+import { runSkill } from "../../src/usecase/run-skill";
+
+const TEMPLATE_SKILL_MD = `---
+name: deploy
+description: Deploy app
+mode: template
+inputs:
+  - name: env
+    type: select
+    message: "Environment?"
+    choices: [staging, production]
+---
+
+# Deploy
+
+Deploy to {{env}}.
+
+\`\`\`bash
+echo "deploying to {{env}}"
+\`\`\`
+`;
+
+function createTestSkill(rawMarkdown: string = TEMPLATE_SKILL_MD): Skill {
+	return {
+		metadata: {
+			name: "deploy",
+			description: "Deploy app",
+			mode: "template",
+			inputs: [
+				{
+					name: "env",
+					type: "select",
+					message: "Environment?",
+					choices: ["staging", "production"],
+				},
+			],
+			model: undefined,
+			tools: ["bash", "read", "write"],
+			context: [],
+		},
+		body: createSkillBody(rawMarkdown),
+		location: "/skills/deploy",
+		scope: "global",
+	};
+}
+
+function stubRepository(skill?: Skill): SkillRepository {
+	return {
+		findByName: async (name: string) => (skill ? ok(skill) : err(skillNotFoundError(name))),
+		listAll: async () => (skill ? [skill] : []),
+		listLocal: async () => [],
+		listGlobal: async () => (skill ? [skill] : []),
+	};
+}
+
+function stubCollector(values: Record<string, string>): PromptCollector {
+	return {
+		collect: async () => values,
+	};
+}
+
+function stubExecutor(behavior: "success" | "fail" = "success"): CommandExecutor {
+	return {
+		execute: async (command: string) => {
+			if (behavior === "fail") {
+				return err(executionError(`Command failed: ${command}`));
+			}
+			return ok({ stdout: `ok: ${command}`, stderr: "", exitCode: 0 });
+		},
+	};
+}
+
+function createDeps(overrides?: Partial<RunSkillDeps>): RunSkillDeps {
+	return {
+		skillRepository: stubRepository(createTestSkill()),
+		promptCollector: stubCollector({ env: "staging" }),
+		commandExecutor: stubExecutor("success"),
+		...overrides,
+	};
+}
+
+function createInput(overrides?: Partial<RunSkillInput>): RunSkillInput {
+	return {
+		name: "deploy",
+		presets: {},
+		dryRun: false,
+		force: false,
+		...overrides,
+	};
+}
+
+describe("runSkill", () => {
+	it("executes a template skill successfully", async () => {
+		const result = await runSkill(createInput(), createDeps());
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.skillName).toBe("deploy");
+		expect(result.value.dryRun).toBe(false);
+		expect(result.value.commands).toHaveLength(1);
+		expect(result.value.commands[0].result.exitCode).toBe(0);
+		expect(result.value.commands[0].command).toContain("deploying to staging");
+	});
+
+	it("returns error for non-existent skill", async () => {
+		const deps = createDeps({
+			skillRepository: stubRepository(),
+		});
+		const result = await runSkill(createInput({ name: "nonexistent" }), deps);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("SKILL_NOT_FOUND");
+	});
+
+	it("stops on command failure without --force", async () => {
+		const multiBlockMd = `---
+name: deploy
+description: Deploy app
+mode: template
+inputs:
+  - name: env
+    type: select
+    message: "Environment?"
+    choices: [staging, production]
+---
+
+# Deploy
+
+\`\`\`bash
+echo "step 1 {{env}}"
+\`\`\`
+
+\`\`\`bash
+echo "step 2 {{env}}"
+\`\`\`
+`;
+		const deps = createDeps({
+			skillRepository: stubRepository(createTestSkill(multiBlockMd)),
+			commandExecutor: stubExecutor("fail"),
+		});
+
+		const result = await runSkill(createInput(), deps);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("EXECUTION_ERROR");
+	});
+
+	it("continues on command failure with --force", async () => {
+		const multiBlockMd = `---
+name: deploy
+description: Deploy app
+mode: template
+inputs:
+  - name: env
+    type: select
+    message: "Environment?"
+    choices: [staging, production]
+---
+
+# Deploy
+
+\`\`\`bash
+echo "step 1 {{env}}"
+\`\`\`
+
+\`\`\`bash
+echo "step 2 {{env}}"
+\`\`\`
+`;
+		const deps = createDeps({
+			skillRepository: stubRepository(createTestSkill(multiBlockMd)),
+			commandExecutor: stubExecutor("fail"),
+		});
+
+		const result = await runSkill(createInput({ force: true }), deps);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.commands).toHaveLength(2);
+		expect(result.value.commands[0].result.exitCode).toBe(1);
+		expect(result.value.commands[1].result.exitCode).toBe(1);
+	});
+
+	it("returns rendered content without executing in --dry-run mode", async () => {
+		const result = await runSkill(createInput({ dryRun: true }), createDeps());
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.dryRun).toBe(true);
+		expect(result.value.commands).toHaveLength(0);
+		expect(result.value.rendered).toContain("Deploy to staging");
+	});
+
+	it("uses presets to skip prompt collection", async () => {
+		const collectedValues: Record<string, string>[] = [];
+		const deps = createDeps({
+			promptCollector: {
+				collect: async (_inputs, presets) => {
+					const merged = { env: "production", ...presets };
+					collectedValues.push(merged);
+					return merged;
+				},
+			},
+		});
+
+		const result = await runSkill(createInput({ presets: { env: "production" } }), deps);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.commands[0].command).toContain("deploying to production");
+	});
+});


### PR DESCRIPTION
## 概要

Closes #22

template モードのスキル実行ユースケースを実装。

## 実装内容

### `src/usecase/run-skill.ts`
- **ポートインターフェース**: `SkillRepository`, `PromptCollector`, `CommandExecutor`
- **処理フロー**: スキル取得 → 変数収集 → テンプレート展開 → コードブロック抽出 → コマンド順次実行
- **`--dry-run`**: 展開結果を返すがコマンド実行しない
- **`--force`**: コマンド失敗時も続行
- **`--set`**: PromptCollector をバイパスして変数を直接指定

### テスト（8ケース）
- template スキルの正常実行
- 存在しないスキルのエラー
- コマンド失敗時の中断
- `--force` でのエラー続行
- `--dry-run` での非実行確認
- PromptCollector による変数収集
- `--set` による PromptCollector 値の上書き
- 未定義変数の RenderError