### PR TITLE
feat: ListSkillsUseCase の実装

### DIFF
--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,4 +1,6 @@
 // Use cases
+export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./list-skills";
+export { createListSkillsUseCase } from "./list-skills";
 
 // Ports (interfaces for adapters)
 export type {

--- a/src/usecase/list-skills.ts
+++ b/src/usecase/list-skills.ts
@@ -1,0 +1,48 @@
+import type { Skill, SkillScope } from "../core/skill/skill";
+import type { SkillRepository } from "./port/skill-repository";
+
+export type ListSkillsFilter = {
+	readonly scope?: SkillScope;
+};
+
+export type ListOutput = {
+	readonly skills: readonly Skill[];
+};
+
+export type ListSkillsUseCase = {
+	readonly execute: (filter: ListSkillsFilter) => Promise<ListOutput>;
+};
+
+export function createListSkillsUseCase(repository: SkillRepository): ListSkillsUseCase {
+	return {
+		execute: async (filter) => {
+			const skills = await fetchByScope(repository, filter.scope);
+			return { skills: deduplicateByLocalPriority(skills) };
+		},
+	};
+}
+
+async function fetchByScope(
+	repository: SkillRepository,
+	scope: SkillScope | undefined,
+): Promise<Skill[]> {
+	switch (scope) {
+		case "local":
+			return repository.listLocal();
+		case "global":
+			return repository.listGlobal();
+		default:
+			return repository.listAll();
+	}
+}
+
+function deduplicateByLocalPriority(skills: readonly Skill[]): readonly Skill[] {
+	const seen = new Map<string, Skill>();
+	for (const skill of skills) {
+		const existing = seen.get(skill.metadata.name);
+		if (!existing || skill.scope === "local") {
+			seen.set(skill.metadata.name, skill);
+		}
+	}
+	return [...seen.values()];
+}

--- a/tests/usecase/list-skills.test.ts
+++ b/tests/usecase/list-skills.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { Skill, SkillScope } from "../../src/core/skill/skill";
+import { skillNotFoundError } from "../../src/core/types/errors";
+import { err, ok } from "../../src/core/types/result";
+import { createListSkillsUseCase } from "../../src/usecase/list-skills";
+import type { SkillRepository } from "../../src/usecase/port/skill-repository";
+
+function createSkill(name: string, scope: SkillScope): Skill {
+	return {
+		metadata: {
+			name,
+			description: `${name} skill`,
+			mode: "template",
+			inputs: [],
+			tools: ["bash", "read", "write"],
+			context: [],
+		},
+		body: { content: `# ${name}`, extractCodeBlocks: () => [] },
+		location:
+			scope === "local" ? `/project/.taskp/skills/${name}/SKILL.md` : `/global/${name}/SKILL.md`,
+		scope,
+	};
+}
+
+function createInMemoryRepository(skills: readonly Skill[]): SkillRepository {
+	return {
+		findByName: async (name) => {
+			const found = skills.find((s) => s.metadata.name === name);
+			return found ? ok(found) : err(skillNotFoundError(name));
+		},
+		listAll: async () => [...skills],
+		listLocal: async () => skills.filter((s) => s.scope === "local"),
+		listGlobal: async () => skills.filter((s) => s.scope === "global"),
+	};
+}
+
+describe("ListSkillsUseCase", () => {
+	const localDeploy = createSkill("deploy", "local");
+	const globalDeploy = createSkill("deploy", "global");
+	const globalLint = createSkill("lint", "global");
+	const localTest = createSkill("test", "local");
+
+	it("ローカル + グローバルの統合一覧を返す", async () => {
+		const repo = createInMemoryRepository([localTest, globalLint]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({});
+
+		expect(result.skills).toHaveLength(2);
+		const names = result.skills.map((s) => s.metadata.name);
+		expect(names).toContain("test");
+		expect(names).toContain("lint");
+	});
+
+	it("同名スキルはローカルを優先する", async () => {
+		const repo = createInMemoryRepository([globalDeploy, localDeploy, globalLint]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({});
+
+		expect(result.skills).toHaveLength(2);
+		const deploy = result.skills.find((s) => s.metadata.name === "deploy");
+		expect(deploy?.scope).toBe("local");
+	});
+
+	it("--global フィルタでグローバルスキルのみ返す", async () => {
+		const repo = createInMemoryRepository([localTest, globalLint, globalDeploy]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({ scope: "global" });
+
+		expect(result.skills).toHaveLength(2);
+		for (const skill of result.skills) {
+			expect(skill.scope).toBe("global");
+		}
+	});
+
+	it("--local フィルタでローカルスキルのみ返す", async () => {
+		const repo = createInMemoryRepository([localTest, globalLint, localDeploy]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({ scope: "local" });
+
+		expect(result.skills).toHaveLength(2);
+		for (const skill of result.skills) {
+			expect(skill.scope).toBe("local");
+		}
+	});
+
+	it("スキルが0件の場合は空配列を返す", async () => {
+		const repo = createInMemoryRepository([]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({});
+
+		expect(result.skills).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
#### 概要

スキル一覧取得ユースケース (ListSkillsUseCase) を実装。

#### 変更内容

- `src/usecase/list-skills.ts`: スコープフィルタ (--global / --local) 対応、同名スキルのローカル優先重複排除
- `tests/usecase/list-skills.test.ts`: InMemorySkillRepository を使った5テストケース
- `src/usecase/index.ts`: 新しい型とファクトリ関数のエクスポート追加

Closes #23