### PR TITLE
feat: InitSkillUseCase の実装

### DIFF
--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,5 +1,8 @@
 // Use cases
 
+export type { InitOutput, InitSkillInput } from "./init-skill";
+export { initSkill } from "./init-skill";
+
 // Ports (interfaces for adapters)
 export type {
 	CommandExecutor,

--- a/src/usecase/init-skill.ts
+++ b/src/usecase/init-skill.ts
@@ -1,0 +1,61 @@
+import type { ExecutionMode } from "../core/execution/execution-mode";
+import type { DomainError } from "../core/types/errors";
+import { configError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { err, ok } from "../core/types/result";
+import type { SkillInitializer } from "./port/skill-initializer";
+import type { SkillRepository } from "./port/skill-repository";
+
+export type InitOutput = {
+	readonly name: string;
+	readonly path: string;
+	readonly mode: ExecutionMode;
+};
+
+export type InitSkillInput = {
+	readonly name: string;
+	readonly global: boolean;
+	readonly mode: ExecutionMode;
+};
+
+type Deps = {
+	readonly skillRepository: SkillRepository;
+	readonly skillInitializer: SkillInitializer;
+};
+
+export async function initSkill(
+	deps: Deps,
+	input: InitSkillInput,
+): Promise<Result<InitOutput, DomainError>> {
+	const conflictResult = await checkNameConflict(deps.skillRepository, input.name);
+	if (!conflictResult.ok) {
+		return conflictResult;
+	}
+
+	const createResult = await deps.skillInitializer.create(input.name, {
+		mode: input.mode,
+		description: `${input.name} skill`,
+	});
+
+	if (!createResult.ok) {
+		return err(configError(createResult.error.message));
+	}
+
+	return ok({
+		name: input.name,
+		path: createResult.value,
+		mode: input.mode,
+	});
+}
+
+async function checkNameConflict(
+	repository: SkillRepository,
+	name: string,
+): Promise<Result<void, DomainError>> {
+	const skills = await repository.listAll();
+	const exists = skills.some((s) => s.metadata.name === name);
+	if (exists) {
+		return err(configError(`Skill "${name}" already exists`));
+	}
+	return ok(undefined);
+}

--- a/tests/usecase/init-skill.test.ts
+++ b/tests/usecase/init-skill.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../../src/core/skill/skill";
+import { ErrorType } from "../../src/core/types/errors";
+import { err, ok } from "../../src/core/types/result";
+import { initSkill } from "../../src/usecase/init-skill";
+import type { SkillInitializer } from "../../src/usecase/port/skill-initializer";
+import type { SkillRepository } from "../../src/usecase/port/skill-repository";
+
+function stubRepository(skills: Skill[] = []): SkillRepository {
+	return {
+		findByName: () => Promise.resolve(err({ type: ErrorType.SkillNotFound, name: "" })),
+		listAll: () => Promise.resolve(skills),
+		listLocal: () => Promise.resolve([]),
+		listGlobal: () => Promise.resolve([]),
+	};
+}
+
+function stubInitializer(path: string): SkillInitializer {
+	return {
+		create: () => Promise.resolve(ok(path)),
+	};
+}
+
+function makeSkill(name: string): Skill {
+	return {
+		metadata: {
+			name,
+			description: "test",
+			mode: "template",
+			inputs: [],
+			tools: [],
+			context: [],
+		},
+		body: { content: "", extractCodeBlocks: () => [] },
+		location: `.taskp/skills/${name}/SKILL.md`,
+		scope: "local",
+	};
+}
+
+describe("initSkill", () => {
+	it("generates template mode scaffold", async () => {
+		const deps = {
+			skillRepository: stubRepository(),
+			skillInitializer: stubInitializer(".taskp/skills/my-task/SKILL.md"),
+		};
+
+		const result = await initSkill(deps, {
+			name: "my-task",
+			global: false,
+			mode: "template",
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toEqual({
+				name: "my-task",
+				path: ".taskp/skills/my-task/SKILL.md",
+				mode: "template",
+			});
+		}
+	});
+
+	it("generates agent mode scaffold", async () => {
+		const deps = {
+			skillRepository: stubRepository(),
+			skillInitializer: stubInitializer(".taskp/skills/review/SKILL.md"),
+		};
+
+		const result = await initSkill(deps, {
+			name: "review",
+			global: false,
+			mode: "agent",
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toEqual({
+				name: "review",
+				path: ".taskp/skills/review/SKILL.md",
+				mode: "agent",
+			});
+		}
+	});
+
+	it("uses global path when --global is specified", async () => {
+		const globalPath = "~/.taskp/skills/my-task/SKILL.md";
+		const deps = {
+			skillRepository: stubRepository(),
+			skillInitializer: stubInitializer(globalPath),
+		};
+
+		const result = await initSkill(deps, {
+			name: "my-task",
+			global: true,
+			mode: "template",
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.path).toBe(globalPath);
+		}
+	});
+
+	it("returns error when skill name already exists", async () => {
+		const deps = {
+			skillRepository: stubRepository([makeSkill("existing-skill")]),
+			skillInitializer: stubInitializer("unused"),
+		};
+
+		const result = await initSkill(deps, {
+			name: "existing-skill",
+			global: false,
+			mode: "template",
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Config);
+			expect(result.error).toHaveProperty("message");
+			expect((result.error as { message: string }).message).toContain("already exists");
+		}
+	});
+
+	it("passes mode and description to initializer", async () => {
+		let capturedOptions: { mode: string; description: string } | undefined;
+		const deps = {
+			skillRepository: stubRepository(),
+			skillInitializer: {
+				create: (_name: string, options: { mode: string; description: string }) => {
+					capturedOptions = options;
+					return Promise.resolve(ok(".taskp/skills/test/SKILL.md"));
+				},
+			},
+		};
+
+		await initSkill(deps, {
+			name: "test",
+			global: false,
+			mode: "agent",
+		});
+
+		expect(capturedOptions).toEqual({
+			mode: "agent",
+			description: "test skill",
+		});
+	});
+});


### PR DESCRIPTION
#### 概要

スキル雛形生成ユースケース `initSkill` を実装。

#### 変更内容

- `src/usecase/init-skill.ts`: initSkill ユースケース関数（名前衝突チェック + SkillInitializer.create() 呼び出し）
- `tests/usecase/init-skill.test.ts`: テスト5ケース（template/agent モード、global パス、名前衝突エラー、オプション検証）
- `src/usecase/index.ts`: エクスポート追加

Closes #24