### PR TITLE
test: テスト用スタブアダプタとヘルパーの実装

### DIFF
--- a/tests/helpers/make-skill.ts
+++ b/tests/helpers/make-skill.ts
@@ -1,0 +1,50 @@
+import type { Skill, SkillScope } from "../../src/core/skill/skill";
+import { createSkillBody } from "../../src/core/skill/skill-body";
+import type { SkillMetadata } from "../../src/core/skill/skill-metadata";
+
+type SkillOverrides = {
+	readonly name?: string;
+	readonly description?: string;
+	readonly mode?: "template" | "agent";
+	readonly location?: string;
+	readonly scope?: SkillScope;
+	readonly inputs?: SkillMetadata["inputs"];
+	readonly tools?: string[];
+	readonly context?: SkillMetadata["context"];
+	readonly model?: string;
+	readonly bodyContent?: string;
+};
+
+export function makeSkill(overrides: SkillOverrides = {}): Skill {
+	const name = overrides.name ?? "test-skill";
+	const rawMarkdown = buildRawMarkdown(overrides);
+
+	return {
+		metadata: {
+			name,
+			description: overrides.description ?? `Description of ${name}`,
+			mode: overrides.mode ?? "template",
+			inputs: overrides.inputs ?? [],
+			tools: overrides.tools ?? ["bash", "read", "write"],
+			context: overrides.context ?? [],
+			model: overrides.model,
+		},
+		body: createSkillBody(rawMarkdown),
+		location: overrides.location ?? `/skills/${name}/SKILL.md`,
+		scope: overrides.scope ?? "local",
+	};
+}
+
+function buildRawMarkdown(overrides: SkillOverrides): string {
+	const name = overrides.name ?? "test-skill";
+	const frontmatter = [
+		"---",
+		`name: ${name}`,
+		`description: ${overrides.description ?? `Description of ${name}`}`,
+		`mode: ${overrides.mode ?? "template"}`,
+		"---",
+	].join("\n");
+
+	const body = overrides.bodyContent ?? `# ${name}\n\nSkill body content.`;
+	return `${frontmatter}\n${body}`;
+}

--- a/tests/stubs/in-memory-skill-repository.ts
+++ b/tests/stubs/in-memory-skill-repository.ts
@@ -1,0 +1,20 @@
+import type { Skill } from "../../src/core/skill/skill";
+import type { SkillNotFoundError } from "../../src/core/types/errors";
+import { skillNotFoundError } from "../../src/core/types/errors";
+import type { Result } from "../../src/core/types/result";
+import { err, ok } from "../../src/core/types/result";
+import type { SkillRepository } from "../../src/usecase/port/skill-repository";
+
+export function createInMemorySkillRepository(skills: readonly Skill[]): SkillRepository {
+	const store = [...skills];
+
+	return {
+		findByName: async (name: string): Promise<Result<Skill, SkillNotFoundError>> => {
+			const found = store.find((s) => s.metadata.name === name);
+			return found ? ok(found) : err(skillNotFoundError(name));
+		},
+		listAll: async (): Promise<Skill[]> => [...store],
+		listLocal: async (): Promise<Skill[]> => store.filter((s) => s.scope === "local"),
+		listGlobal: async (): Promise<Skill[]> => store.filter((s) => s.scope === "global"),
+	};
+}

--- a/tests/stubs/stub-command-executor.ts
+++ b/tests/stubs/stub-command-executor.ts
@@ -1,0 +1,36 @@
+import type { ExecutionError } from "../../src/core/types/errors";
+import type { Result } from "../../src/core/types/result";
+import { ok } from "../../src/core/types/result";
+import type {
+	CommandExecutor,
+	ExecOptions,
+	ExecResult,
+} from "../../src/usecase/port/command-executor";
+
+type ExecutedCommand = {
+	readonly command: string;
+	readonly options: ExecOptions | undefined;
+};
+
+export type StubCommandExecutor = CommandExecutor & {
+	readonly executedCommands: readonly ExecutedCommand[];
+};
+
+export function createStubCommandExecutor(
+	preset: Result<ExecResult, ExecutionError> = ok({ stdout: "", stderr: "", exitCode: 0 }),
+): StubCommandExecutor {
+	const executed: ExecutedCommand[] = [];
+
+	return {
+		execute: async (
+			command: string,
+			options?: ExecOptions,
+		): Promise<Result<ExecResult, ExecutionError>> => {
+			executed.push({ command, options });
+			return preset;
+		},
+		get executedCommands(): readonly ExecutedCommand[] {
+			return [...executed];
+		},
+	};
+}

--- a/tests/stubs/stub-prompt-collector.ts
+++ b/tests/stubs/stub-prompt-collector.ts
@@ -1,0 +1,25 @@
+import type { SkillInput } from "../../src/core/skill/skill-metadata";
+import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
+
+export type StubPromptCollector = PromptCollector & {
+	readonly collectedInputs: readonly (readonly SkillInput[])[];
+};
+
+export function createStubPromptCollector(
+	answers: Readonly<Record<string, string>>,
+): StubPromptCollector {
+	const collected: (readonly SkillInput[])[] = [];
+
+	return {
+		collect: async (
+			inputs: readonly SkillInput[],
+			presets: Readonly<Record<string, string>>,
+		): Promise<Readonly<Record<string, string>>> => {
+			collected.push(inputs);
+			return { ...presets, ...answers };
+		},
+		get collectedInputs(): readonly (readonly SkillInput[])[] {
+			return [...collected];
+		},
+	};
+}

--- a/tests/stubs/stub-skill-initializer.ts
+++ b/tests/stubs/stub-skill-initializer.ts
@@ -1,0 +1,28 @@
+import type { Result } from "../../src/core/types/result";
+import { ok } from "../../src/core/types/result";
+import type { InitOptions, SkillInitializer } from "../../src/usecase/port/skill-initializer";
+
+type CreatedSkill = {
+	readonly name: string;
+	readonly options: InitOptions;
+	readonly path: string;
+};
+
+export type StubSkillInitializer = SkillInitializer & {
+	readonly createdSkills: readonly CreatedSkill[];
+};
+
+export function createStubSkillInitializer(basePath = "/skills"): StubSkillInitializer {
+	const created: CreatedSkill[] = [];
+
+	return {
+		create: async (name: string, options: InitOptions): Promise<Result<string, Error>> => {
+			const path = `${basePath}/${name}/SKILL.md`;
+			created.push({ name, options, path });
+			return ok(path);
+		},
+		get createdSkills(): readonly CreatedSkill[] {
+			return [...created];
+		},
+	};
+}

--- a/tests/stubs/stubs.test.ts
+++ b/tests/stubs/stubs.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { ok } from "../../src/core/types/result";
+import { makeSkill } from "../helpers/make-skill";
+import { createInMemorySkillRepository } from "./in-memory-skill-repository";
+import { createStubCommandExecutor } from "./stub-command-executor";
+import { createStubPromptCollector } from "./stub-prompt-collector";
+import { createStubSkillInitializer } from "./stub-skill-initializer";
+
+describe("makeSkill", () => {
+	it("creates a skill with defaults", () => {
+		const skill = makeSkill();
+		expect(skill.metadata.name).toBe("test-skill");
+		expect(skill.scope).toBe("local");
+	});
+
+	it("applies overrides", () => {
+		const skill = makeSkill({ name: "custom", scope: "global", mode: "agent" });
+		expect(skill.metadata.name).toBe("custom");
+		expect(skill.metadata.mode).toBe("agent");
+		expect(skill.scope).toBe("global");
+	});
+});
+
+describe("InMemorySkillRepository", () => {
+	it("findByName returns ok for existing skill", async () => {
+		const skill = makeSkill({ name: "hello" });
+		const repo = createInMemorySkillRepository([skill]);
+
+		const result = await repo.findByName("hello");
+		expect(result).toEqual(ok(skill));
+	});
+
+	it("findByName returns err for missing skill", async () => {
+		const repo = createInMemorySkillRepository([]);
+
+		const result = await repo.findByName("missing");
+		expect(result.ok).toBe(false);
+	});
+
+	it("listAll returns all skills", async () => {
+		const skills = [makeSkill({ name: "a" }), makeSkill({ name: "b" })];
+		const repo = createInMemorySkillRepository(skills);
+
+		expect(await repo.listAll()).toHaveLength(2);
+	});
+
+	it("listLocal/listGlobal filters by scope", async () => {
+		const skills = [
+			makeSkill({ name: "local-one", scope: "local" }),
+			makeSkill({ name: "global-one", scope: "global" }),
+		];
+		const repo = createInMemorySkillRepository(skills);
+
+		expect(await repo.listLocal()).toHaveLength(1);
+		expect(await repo.listGlobal()).toHaveLength(1);
+	});
+});
+
+describe("StubCommandExecutor", () => {
+	it("records executed commands", async () => {
+		const executor = createStubCommandExecutor();
+		await executor.execute("echo hello", { cwd: "/tmp" });
+
+		expect(executor.executedCommands).toEqual([
+			{ command: "echo hello", options: { cwd: "/tmp" } },
+		]);
+	});
+
+	it("returns preset result", async () => {
+		const preset = ok({ stdout: "output", stderr: "", exitCode: 0 } as const);
+		const executor = createStubCommandExecutor(preset);
+
+		const result = await executor.execute("any");
+		expect(result).toEqual(preset);
+	});
+});
+
+describe("StubPromptCollector", () => {
+	it("returns preset answers merged with presets", async () => {
+		const collector = createStubPromptCollector({ name: "Alice" });
+
+		const result = await collector.collect([], { existing: "value" });
+		expect(result).toEqual({ existing: "value", name: "Alice" });
+	});
+
+	it("records collected inputs", async () => {
+		const collector = createStubPromptCollector({});
+		const inputs = [{ name: "q", type: "text" as const, message: "Question?" }];
+
+		await collector.collect(inputs, {});
+		expect(collector.collectedInputs).toHaveLength(1);
+	});
+});
+
+describe("StubSkillInitializer", () => {
+	it("records created skills with path", async () => {
+		const initializer = createStubSkillInitializer("/custom");
+
+		const result = await initializer.create("my-skill", {
+			mode: "template",
+			description: "A skill",
+		});
+
+		expect(result).toEqual(ok("/custom/my-skill/SKILL.md"));
+		expect(initializer.createdSkills).toEqual([
+			{
+				name: "my-skill",
+				options: { mode: "template", description: "A skill" },
+				path: "/custom/my-skill/SKILL.md",
+			},
+		]);
+	});
+});


### PR DESCRIPTION
#### 概要

ユースケーステスト用のインメモリスタブアダプタ4つとテスト用Skillファクトリヘルパーを実装。

#### 変更内容

- `tests/stubs/in-memory-skill-repository.ts`: SkillRepository のインメモリ実装
- `tests/stubs/stub-command-executor.ts`: コマンド実行記録・プリセット結果返却
- `tests/stubs/stub-prompt-collector.ts`: プリセット回答返却・入力記録
- `tests/stubs/stub-skill-initializer.ts`: スキル生成パス記録
- `tests/helpers/make-skill.ts`: テスト用 Skill オブジェクトファクトリ
- `tests/stubs/stubs.test.ts`: 全スタブ・ヘルパーの動作確認テスト (11テスト)

Closes #25