### PR TITLE
feat: SkillLoader の実装（ファイルシステムからスキル読み込み）

### DIFF
--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,1 +1,2 @@
 // Interface adapters
+export { createDefaultSkillLoader, createSkillLoader } from "./skill-loader";

--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -1,0 +1,102 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Skill, SkillScope } from "../core/skill/skill";
+import { parseSkill } from "../core/skill/skill";
+import { type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { err } from "../core/types/result";
+import type { SkillRepository } from "../usecase/port/skill-repository";
+
+const SKILL_DIR_NAME = ".taskp/skills";
+const SKILL_FILE_NAME = "SKILL.md";
+
+type SkillLoaderDeps = {
+	readonly localRoot: string;
+	readonly globalRoot: string;
+};
+
+export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
+	const localSkillsDir = resolve(deps.localRoot, SKILL_DIR_NAME);
+	const globalSkillsDir = resolve(deps.globalRoot, SKILL_DIR_NAME);
+
+	return {
+		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir),
+		listAll: () => listAll(localSkillsDir, globalSkillsDir),
+		listLocal: () => scanDirectory(localSkillsDir, "local"),
+		listGlobal: () => scanDirectory(globalSkillsDir, "global"),
+	};
+}
+
+export function createDefaultSkillLoader(projectRoot: string): SkillRepository {
+	return createSkillLoader({
+		localRoot: projectRoot,
+		globalRoot: homedir(),
+	});
+}
+
+async function findByName(
+	name: string,
+	localSkillsDir: string,
+	globalSkillsDir: string,
+): Promise<Result<Skill, SkillNotFoundError>> {
+	const localPath = join(localSkillsDir, name, SKILL_FILE_NAME);
+	const localResult = await tryLoadSkill(localPath, "local");
+	if (localResult !== undefined) {
+		return localResult;
+	}
+
+	const globalPath = join(globalSkillsDir, name, SKILL_FILE_NAME);
+	const globalResult = await tryLoadSkill(globalPath, "global");
+	if (globalResult !== undefined) {
+		return globalResult;
+	}
+
+	return err(skillNotFoundError(name));
+}
+
+async function listAll(localSkillsDir: string, globalSkillsDir: string): Promise<Skill[]> {
+	const [localSkills, globalSkills] = await Promise.all([
+		scanDirectory(localSkillsDir, "local"),
+		scanDirectory(globalSkillsDir, "global"),
+	]);
+
+	const localNames = new Set(localSkills.map((s) => s.metadata.name));
+	const uniqueGlobalSkills = globalSkills.filter((s) => !localNames.has(s.metadata.name));
+
+	return [...localSkills, ...uniqueGlobalSkills];
+}
+
+async function scanDirectory(skillsDir: string, scope: SkillScope): Promise<Skill[]> {
+	const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+
+	const results = await Promise.all(
+		entries
+			.filter((entry) => entry.isDirectory())
+			.map(async (entry) => {
+				const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
+				return tryLoadSkill(skillPath, scope);
+			}),
+	);
+
+	return results
+		.filter((r): r is Result<Skill, never> & { ok: true } => r !== undefined && r.ok === true)
+		.map((r) => r.value);
+}
+
+async function tryLoadSkill(
+	path: string,
+	scope: SkillScope,
+): Promise<Result<Skill, never> | undefined> {
+	const raw = await readFile(path, "utf-8").catch(() => undefined);
+	if (raw === undefined) {
+		return undefined;
+	}
+
+	const result = parseSkill(raw, path, scope);
+	if (!result.ok) {
+		return undefined;
+	}
+
+	return result as Result<Skill, never> & { ok: true };
+}

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -17,7 +17,11 @@ export type Skill = {
 	readonly scope: SkillScope;
 };
 
-export function parseSkill(raw: string, location: string): Result<Skill, ParseError> {
+export function parseSkill(
+	raw: string,
+	location: string,
+	scope?: SkillScope,
+): Result<Skill, ParseError> {
 	let parsed: matter.GrayMatterFile<string>;
 	try {
 		parsed = matter(raw);
@@ -38,10 +42,10 @@ export function parseSkill(raw: string, location: string): Result<Skill, ParseEr
 		metadata,
 		body: createSkillBody(raw),
 		location,
-		scope: resolveScope(location),
+		scope: scope ?? inferScope(location),
 	});
 }
 
-function resolveScope(location: string): SkillScope {
+function inferScope(location: string): SkillScope {
 	return location.includes("/.taskp/skills/") ? "local" : "global";
 }

--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,9 +1,10 @@
 // Use cases
-export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./list-skills";
-export { createListSkillsUseCase } from "./list-skills";
 
 export type { InitOutput, InitSkillInput } from "./init-skill";
 export { initSkill } from "./init-skill";
+
+export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./list-skills";
+export { createListSkillsUseCase } from "./list-skills";
 
 // Ports (interfaces for adapters)
 export type {

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -1,0 +1,148 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createSkillLoader } from "../../src/adapter/skill-loader";
+
+function createSkillFile(baseDir: string, name: string, content: string): void {
+	const dir = join(baseDir, ".taskp", "skills", name);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, "SKILL.md"), content);
+}
+
+function makeSkillMd(name: string, description: string): string {
+	return [
+		"---",
+		`name: ${name}`,
+		`description: "${description}"`,
+		"mode: template",
+		"---",
+		"",
+		`# ${name}`,
+	].join("\n");
+}
+
+describe("SkillLoader", () => {
+	let localRoot: string;
+	let globalRoot: string;
+
+	beforeEach(() => {
+		localRoot = mkdtempSync(join(tmpdir(), "taskp-local-"));
+		globalRoot = mkdtempSync(join(tmpdir(), "taskp-global-"));
+	});
+
+	afterEach(() => {
+		rmSync(localRoot, { recursive: true, force: true });
+		rmSync(globalRoot, { recursive: true, force: true });
+	});
+
+	describe("findByName", () => {
+		it("ローカルスキルを読み込める", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "デプロイする"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const result = await loader.findByName("deploy");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("deploy");
+			expect(result.value.scope).toBe("local");
+		});
+
+		it("グローバルスキルを読み込める", async () => {
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "リントする"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const result = await loader.findByName("lint");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("lint");
+			expect(result.value.scope).toBe("global");
+		});
+
+		it("ローカルがグローバルより優先される", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "ローカル版"));
+			createSkillFile(globalRoot, "deploy", makeSkillMd("deploy", "グローバル版"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const result = await loader.findByName("deploy");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.description).toBe("ローカル版");
+			expect(result.value.scope).toBe("local");
+		});
+
+		it("存在しないスキルでエラーを返す", async () => {
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const result = await loader.findByName("nonexistent");
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("SKILL_NOT_FOUND");
+			expect(result.error.name).toBe("nonexistent");
+		});
+	});
+
+	describe("listAll", () => {
+		it("ローカルとグローバルの両方をリストする", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "デプロイ"));
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "リント"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const skills = await loader.listAll();
+
+			expect(skills).toHaveLength(2);
+			const names = skills.map((s) => s.metadata.name);
+			expect(names).toContain("deploy");
+			expect(names).toContain("lint");
+		});
+
+		it("同名スキルはローカルが優先される", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "ローカル版"));
+			createSkillFile(globalRoot, "deploy", makeSkillMd("deploy", "グローバル版"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const skills = await loader.listAll();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.description).toBe("ローカル版");
+		});
+
+		it("スキルディレクトリが存在しない場合は空配列を返す", async () => {
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const skills = await loader.listAll();
+
+			expect(skills).toEqual([]);
+		});
+	});
+
+	describe("listLocal", () => {
+		it("ローカルスキルのみリストする", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "デプロイ"));
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "リント"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const skills = await loader.listLocal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("deploy");
+		});
+	});
+
+	describe("listGlobal", () => {
+		it("グローバルスキルのみリストする", async () => {
+			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "デプロイ"));
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "リント"));
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const skills = await loader.listGlobal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("lint");
+		});
+	});
+});


### PR DESCRIPTION
#### 概要

SkillRepository Port を実装する SkillLoader アダプタを作成。ローカル・グローバルのスキルディレクトリからSKILL.mdを読み込む。

#### 変更内容

- `src/adapter/skill-loader.ts`: SkillRepository Port の実装（findByName, listAll, listLocal, listGlobal）
- `src/core/skill/skill.ts`: parseSkill に scope パラメータを追加（既存コードとの後方互換あり）
- `src/adapter/index.ts`: SkillLoader のエクスポート追加
- `src/usecase/index.ts`: import 順序修正（既存のlint警告対応）
- `tests/adapter/skill-loader.test.ts`: 9テスト追加（ローカル読み込み、グローバル読み込み、ローカル優先、エラーケース等）

Closes #26