### PR TITLE
feat: AI SDK 導入と AiProvider アダプタの実装

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,11 @@
     "": {
       "name": "taskp",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.58",
+        "@ai-sdk/google": "^3.0.43",
+        "@ai-sdk/openai": "^3.0.41",
         "@inquirer/prompts": "^8.3.2",
+        "ai": "^6.0.116",
         "execa": "^9.6.1",
         "gray-matter": "^4.0.3",
         "incur": "^0.3.4",
@@ -25,6 +29,18 @@
     },
   },
   "packages": {
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.66", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.43", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.41", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
+
     "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.2.1", "", { "dependencies": { "js-yaml": "^4.1.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -99,6 +115,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@oxc-project/runtime": ["@oxc-project/runtime@0.115.0", "", {}, "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
@@ -171,6 +189,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "chai": "^6.2.2", "tinyrainbow": "^3.0.3" } }, "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.0", "", { "dependencies": { "@vitest/spy": "4.1.0", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw=="],
@@ -186,6 +206,8 @@
     "@vitest/utils": ["@vitest/utils@4.1.0", "", { "dependencies": { "@vitest/pretty-format": "4.1.0", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.0.3" } }, "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ai": ["ai@6.0.116", "", { "dependencies": { "@ai-sdk/gateway": "3.0.66", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -352,6 +374,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
 		"test:watch": "bun x vitest"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.58",
+		"@ai-sdk/google": "^3.0.43",
+		"@ai-sdk/openai": "^3.0.41",
 		"@inquirer/prompts": "^8.3.2",
+		"ai": "^6.0.116",
 		"execa": "^9.6.1",
 		"gray-matter": "^4.0.3",
 		"incur": "^0.3.4",

--- a/src/adapter/ai-provider.ts
+++ b/src/adapter/ai-provider.ts
@@ -1,0 +1,178 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { type ConfigError, configError } from "../core/types/errors";
+import { err, ok, type Result } from "../core/types/result";
+import type { AiConfig, ProviderConfig } from "./config-loader";
+
+const KNOWN_PROVIDERS = ["anthropic", "openai", "google", "ollama"] as const;
+
+export type ModelSpec = {
+	readonly provider: string;
+	readonly model: string;
+};
+
+export type ModelSource = {
+	readonly cliModel?: string;
+	readonly skillModel?: string;
+	readonly config: AiConfig;
+};
+
+export function parseModelSpec(spec: string): Result<ModelSpec, ConfigError> {
+	const slashIndex = spec.indexOf("/");
+	if (slashIndex === -1) {
+		return ok({ provider: "", model: spec });
+	}
+
+	const provider = spec.slice(0, slashIndex);
+	const model = spec.slice(slashIndex + 1);
+
+	if (provider === "" || model === "") {
+		return err(configError(`Invalid model spec: "${spec}". Expected "provider/model" format.`));
+	}
+
+	return ok({ provider, model });
+}
+
+export function resolveModelSpec(source: ModelSource): Result<ModelSpec, ConfigError> {
+	const rawSpec = source.cliModel ?? source.skillModel ?? source.config.default_model;
+
+	if (rawSpec === undefined) {
+		return err(
+			configError("No model specified. Set --model, skill model field, or config default_model."),
+		);
+	}
+
+	const parseResult = parseModelSpec(rawSpec);
+	if (!parseResult.ok) {
+		return parseResult;
+	}
+
+	const { provider, model } = parseResult.value;
+
+	if (provider !== "") {
+		return ok({ provider, model });
+	}
+
+	const defaultProvider = source.config.default_provider;
+	if (defaultProvider === undefined) {
+		return err(
+			configError(
+				`Model "${rawSpec}" has no provider prefix. Set default_provider in config or use "provider/model" format.`,
+			),
+		);
+	}
+
+	return ok({ provider: defaultProvider, model });
+}
+
+export function createLanguageModel(
+	spec: ModelSpec,
+	config: AiConfig,
+): Result<LanguageModelV3, ConfigError> {
+	const providerConfig = config.providers?.[spec.provider];
+	return createModelForProvider(spec.provider, spec.model, providerConfig);
+}
+
+function createModelForProvider(
+	providerName: string,
+	model: string,
+	providerConfig: ProviderConfig | undefined,
+): Result<LanguageModelV3, ConfigError> {
+	switch (providerName) {
+		case "anthropic":
+			return createAnthropicModel(model, providerConfig);
+		case "openai":
+			return createOpenAIModel(model, providerConfig);
+		case "google":
+			return createGoogleModel(model, providerConfig);
+		case "ollama":
+			return createOllamaModel(model, providerConfig);
+		default:
+			return err(
+				configError(
+					`Unknown provider: "${providerName}". Supported: ${KNOWN_PROVIDERS.join(", ")}.`,
+				),
+			);
+	}
+}
+
+function createAnthropicModel(
+	model: string,
+	config: ProviderConfig | undefined,
+): Result<LanguageModelV3, ConfigError> {
+	const apiKey = resolveApiKey(config?.api_key_env, "ANTHROPIC_API_KEY");
+	if (!apiKey.ok) {
+		return apiKey;
+	}
+
+	const provider = createAnthropic({
+		apiKey: apiKey.value,
+		...(config?.base_url !== undefined && { baseURL: config.base_url }),
+	});
+
+	return ok(provider(model));
+}
+
+function createOpenAIModel(
+	model: string,
+	config: ProviderConfig | undefined,
+): Result<LanguageModelV3, ConfigError> {
+	const apiKey = resolveApiKey(config?.api_key_env, "OPENAI_API_KEY");
+	if (!apiKey.ok) {
+		return apiKey;
+	}
+
+	const provider = createOpenAI({
+		apiKey: apiKey.value,
+		...(config?.base_url !== undefined && { baseURL: config.base_url }),
+	});
+
+	return ok(provider(model));
+}
+
+function createGoogleModel(
+	model: string,
+	config: ProviderConfig | undefined,
+): Result<LanguageModelV3, ConfigError> {
+	const apiKey = resolveApiKey(config?.api_key_env, "GOOGLE_GENERATIVE_AI_KEY");
+	if (!apiKey.ok) {
+		return apiKey;
+	}
+
+	const provider = createGoogleGenerativeAI({
+		apiKey: apiKey.value,
+		...(config?.base_url !== undefined && { baseURL: config.base_url }),
+	});
+
+	return ok(provider(model));
+}
+
+function createOllamaModel(
+	model: string,
+	config: ProviderConfig | undefined,
+): Result<LanguageModelV3, ConfigError> {
+	const baseUrl = config?.base_url ?? "http://localhost:11434/v1";
+
+	const provider = createOpenAI({
+		apiKey: "ollama",
+		baseURL: baseUrl,
+	});
+
+	return ok(provider(model));
+}
+
+function resolveApiKey(
+	envVarName: string | undefined,
+	defaultEnvVar: string,
+): Result<string, ConfigError> {
+	const envName = envVarName ?? defaultEnvVar;
+	const value = process.env[envName];
+
+	if (value === undefined || value === "") {
+		return err(configError(`API key not found. Set the ${envName} environment variable.`));
+	}
+
+	return ok(value);
+}

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,4 +1,6 @@
 // Interface adapters
+export type { ModelSource, ModelSpec } from "./ai-provider";
+export { createLanguageModel, parseModelSpec, resolveModelSpec } from "./ai-provider";
 export { createCommandRunner } from "./command-runner";
 
 export type { AiConfig, Config, ProviderConfig } from "./config-loader";

--- a/tests/adapter/ai-provider.test.ts
+++ b/tests/adapter/ai-provider.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	createLanguageModel,
+	parseModelSpec,
+	resolveModelSpec,
+} from "../../src/adapter/ai-provider";
+import type { AiConfig } from "../../src/adapter/config-loader";
+
+describe("parseModelSpec", () => {
+	it("parses provider/model format", () => {
+		const result = parseModelSpec("anthropic/claude-sonnet-4-20250514");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+	});
+
+	it("returns empty provider for model-only format", () => {
+		const result = parseModelSpec("claude-sonnet-4-20250514");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "", model: "claude-sonnet-4-20250514" });
+	});
+
+	it("handles ollama model with tag", () => {
+		const result = parseModelSpec("ollama/qwen2.5-coder:32b");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "ollama", model: "qwen2.5-coder:32b" });
+	});
+
+	it("returns error for empty provider", () => {
+		const result = parseModelSpec("/model");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("Invalid model spec");
+	});
+
+	it("returns error for empty model", () => {
+		const result = parseModelSpec("provider/");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+	});
+});
+
+describe("resolveModelSpec", () => {
+	it("prioritizes CLI model over skill and config", () => {
+		const result = resolveModelSpec({
+			cliModel: "anthropic/claude-sonnet-4-20250514",
+			skillModel: "openai/gpt-4o",
+			config: { default_model: "google/gemini-pro" },
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+	});
+
+	it("falls back to skill model when CLI not provided", () => {
+		const result = resolveModelSpec({
+			skillModel: "openai/gpt-4o",
+			config: { default_model: "google/gemini-pro" },
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "openai", model: "gpt-4o" });
+	});
+
+	it("falls back to config default_model when CLI and skill not provided", () => {
+		const result = resolveModelSpec({
+			config: { default_model: "google/gemini-pro" },
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "google", model: "gemini-pro" });
+	});
+
+	it("uses config default_provider for model without provider prefix", () => {
+		const result = resolveModelSpec({
+			cliModel: "claude-sonnet-4-20250514",
+			config: { default_provider: "anthropic" },
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ provider: "anthropic", model: "claude-sonnet-4-20250514" });
+	});
+
+	it("returns error when no model specified anywhere", () => {
+		const result = resolveModelSpec({ config: {} });
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("No model specified");
+	});
+
+	it("returns error when model has no provider and no default_provider", () => {
+		const result = resolveModelSpec({
+			cliModel: "claude-sonnet-4-20250514",
+			config: {},
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("no provider prefix");
+	});
+});
+
+describe("createLanguageModel", () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach(() => {
+		process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+		process.env.OPENAI_API_KEY = "test-openai-key";
+		process.env.GOOGLE_GENERATIVE_AI_KEY = "test-google-key";
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
+	});
+
+	it("creates anthropic model", () => {
+		const config: AiConfig = {
+			providers: {
+				anthropic: { api_key_env: "ANTHROPIC_API_KEY" },
+			},
+		};
+
+		const result = createLanguageModel(
+			{ provider: "anthropic", model: "claude-sonnet-4-20250514" },
+			config,
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("claude-sonnet-4-20250514");
+	});
+
+	it("creates openai model", () => {
+		const config: AiConfig = {
+			providers: {
+				openai: { api_key_env: "OPENAI_API_KEY" },
+			},
+		};
+
+		const result = createLanguageModel({ provider: "openai", model: "gpt-4o" }, config);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("gpt-4o");
+	});
+
+	it("creates google model", () => {
+		const config: AiConfig = {
+			providers: {
+				google: { api_key_env: "GOOGLE_GENERATIVE_AI_KEY" },
+			},
+		};
+
+		const result = createLanguageModel({ provider: "google", model: "gemini-pro" }, config);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("gemini-pro");
+	});
+
+	it("creates ollama model with default base URL", () => {
+		const config: AiConfig = {};
+
+		const result = createLanguageModel({ provider: "ollama", model: "qwen2.5-coder:32b" }, config);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("qwen2.5-coder:32b");
+	});
+
+	it("creates ollama model with custom base URL", () => {
+		const config: AiConfig = {
+			providers: {
+				ollama: { base_url: "http://custom:11434/v1" },
+			},
+		};
+
+		const result = createLanguageModel({ provider: "ollama", model: "llama3" }, config);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("llama3");
+	});
+
+	it("returns error for unknown provider", () => {
+		const result = createLanguageModel({ provider: "unknown", model: "some-model" }, {});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("Unknown provider");
+		expect(result.error.message).toContain("unknown");
+	});
+
+	it("returns error when API key is missing", () => {
+		delete process.env.ANTHROPIC_API_KEY;
+
+		const result = createLanguageModel(
+			{ provider: "anthropic", model: "claude-sonnet-4-20250514" },
+			{},
+		);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("ANTHROPIC_API_KEY");
+	});
+
+	it("uses custom api_key_env from provider config", () => {
+		process.env.MY_CUSTOM_KEY = "custom-key";
+		const config: AiConfig = {
+			providers: {
+				anthropic: { api_key_env: "MY_CUSTOM_KEY" },
+			},
+		};
+
+		const result = createLanguageModel(
+			{ provider: "anthropic", model: "claude-sonnet-4-20250514" },
+			config,
+		);
+
+		expect(result.ok).toBe(true);
+		delete process.env.MY_CUSTOM_KEY;
+	});
+});


### PR DESCRIPTION
#### 概要

Vercel AI SDK を導入し、マルチプロバイダ対応の AiProvider アダプタを実装。

#### 変更内容

- `ai`, `@ai-sdk/anthropic`, `@ai-sdk/openai`, `@ai-sdk/google` を依存追加
- `src/adapter/ai-provider.ts`: プロバイダ解決・モデル生成
  - `parseModelSpec`: `provider/model` 形式のパース
  - `resolveModelSpec`: CLI → スキル → 設定の優先順位でモデル解決
  - `createLanguageModel`: プロバイダ別 LanguageModel 生成
  - Ollama: OpenAI 互換モードで対応（デフォルト `http://localhost:11434/v1`）
- `tests/adapter/ai-provider.test.ts`: テスト19件追加

Closes #37