### PR TITLE
feat: taskp show コマンドの実装

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { createPromptRunner } from "./adapter/prompt-runner";
 import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
 import { createStreamWriter } from "./adapter/stream-writer";
+import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
 import { type DomainError, EXIT_CODE } from "./core/types/errors";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
@@ -15,6 +16,8 @@ import { createListSkillsUseCase } from "./usecase/list-skills";
 import { prepareAgentSkill } from "./usecase/run-agent-skill";
 import type { RunOutput } from "./usecase/run-skill";
 import { runSkill } from "./usecase/run-skill";
+import type { ShowOutput } from "./usecase/show-skill";
+import { showSkill } from "./usecase/show-skill";
 
 function parsePresets(pairs: readonly string[]): Readonly<Record<string, string>> {
 	const result: Record<string, string> = {};
@@ -193,6 +196,23 @@ const cli = Cli.create("taskp", {
 
 			console.log(formatInitOutput(result.value));
 		},
+	})
+	.command("show", {
+		description: "Show skill details",
+		args: z.object({
+			skill: z.string().describe("Skill name to show"),
+		}),
+		async run(c) {
+			const repository = createDefaultSkillLoader(process.cwd());
+			const result = await showSkill(c.args.skill, repository);
+
+			if (!result.ok) {
+				console.error(formatError(result.error));
+				process.exit(EXIT_CODE[result.error.type]);
+			}
+
+			console.log(formatShowOutput(result.value));
+		},
 	});
 
 type RunCommandContext = {
@@ -291,6 +311,53 @@ function printSkillTable(
 	console.log(formatRow(header.name, header.description, header.location));
 	for (const row of rows) {
 		console.log(formatRow(row.name, row.description, row.location));
+	}
+}
+
+function formatShowOutput(output: ShowOutput): string {
+	const lines: string[] = [
+		`Skill: ${output.name}`,
+		`Description: ${output.description}`,
+		`Mode: ${output.mode}`,
+		`Location: ${output.location}`,
+	];
+
+	if (output.inputs.length > 0) {
+		lines.push("");
+		lines.push("Inputs:");
+		for (const input of output.inputs) {
+			const parts = [`  ${input.name}`, input.type, input.message];
+			if (input.choices && input.choices.length > 0) {
+				parts.push(`[${input.choices.join(", ")}]`);
+			} else if (input.default !== undefined) {
+				parts.push(`(default: ${String(input.default)})`);
+			}
+			lines.push(parts.join("  "));
+		}
+	}
+
+	if (output.context.length > 0) {
+		lines.push("");
+		lines.push("Context:");
+		for (const ctx of output.context) {
+			const source = contextSourceValue(ctx);
+			lines.push(`  ${ctx.type}  ${source}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function contextSourceValue(ctx: ContextSource): string {
+	switch (ctx.type) {
+		case "file":
+			return ctx.path;
+		case "glob":
+			return ctx.pattern;
+		case "command":
+			return ctx.run;
+		case "url":
+			return ctx.url;
 	}
 }
 

--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -23,3 +23,5 @@ export type {
 export { prepareAgentSkill } from "./run-agent-skill";
 export type { CommandResult, RunOutput, RunSkillDeps, RunSkillInput } from "./run-skill";
 export { runSkill } from "./run-skill";
+export type { ShowOutput } from "./show-skill";
+export { showSkill } from "./show-skill";

--- a/src/usecase/show-skill.ts
+++ b/src/usecase/show-skill.ts
@@ -1,0 +1,36 @@
+import type { ContextSource } from "../core/skill/context-source";
+import type { SkillInput } from "../core/skill/skill-input";
+import type { SkillMode } from "../core/skill/skill-metadata";
+import type { SkillNotFoundError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { ok } from "../core/types/result";
+import type { SkillRepository } from "./port/skill-repository";
+
+export type ShowOutput = {
+	readonly name: string;
+	readonly description: string;
+	readonly mode: SkillMode;
+	readonly location: string;
+	readonly inputs: readonly SkillInput[];
+	readonly context: readonly ContextSource[];
+};
+
+export async function showSkill(
+	name: string,
+	repository: SkillRepository,
+): Promise<Result<ShowOutput, SkillNotFoundError>> {
+	const result = await repository.findByName(name);
+	if (!result.ok) {
+		return result;
+	}
+
+	const skill = result.value;
+	return ok({
+		name: skill.metadata.name,
+		description: skill.metadata.description,
+		mode: skill.metadata.mode,
+		location: skill.location,
+		inputs: skill.metadata.inputs,
+		context: skill.metadata.context,
+	});
+}

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../../src/core/skill/skill";
+import { skillNotFoundError } from "../../src/core/types/errors";
+import { err, ok } from "../../src/core/types/result";
+import type { SkillRepository } from "../../src/usecase/port/skill-repository";
+import { showSkill } from "../../src/usecase/show-skill";
+
+function createSkill(overrides: Partial<Skill["metadata"]> = {}): Skill {
+	return {
+		metadata: {
+			name: "deploy",
+			description: "アプリケーションをデプロイする",
+			mode: "template",
+			inputs: [
+				{
+					name: "environment",
+					type: "select",
+					message: "デプロイ先を選んでください",
+					choices: ["staging", "production"],
+				},
+				{
+					name: "branch",
+					type: "text",
+					message: "ブランチ名は？",
+					default: "main",
+				},
+				{
+					name: "confirm",
+					type: "confirm",
+					message: "本当にデプロイしますか？",
+				},
+			],
+			tools: ["bash", "read", "write"],
+			context: [
+				{ type: "file", path: "./config.yaml" },
+				{ type: "command", run: "git branch --show-current" },
+			],
+			...overrides,
+		},
+		body: { content: "# deploy", extractCodeBlocks: () => [] },
+		location: "/project/.taskp/skills/deploy/SKILL.md",
+		scope: "local",
+	};
+}
+
+function createRepository(skills: readonly Skill[]): SkillRepository {
+	return {
+		findByName: async (name) => {
+			const found = skills.find((s) => s.metadata.name === name);
+			return found ? ok(found) : err(skillNotFoundError(name));
+		},
+		listAll: async () => [...skills],
+		listLocal: async () => skills.filter((s) => s.scope === "local"),
+		listGlobal: async () => skills.filter((s) => s.scope === "global"),
+	};
+}
+
+describe("showSkill", () => {
+	it("スキルの詳細情報を返す", async () => {
+		const skill = createSkill();
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		expect(result.value.name).toBe("deploy");
+		expect(result.value.description).toBe("アプリケーションをデプロイする");
+		expect(result.value.mode).toBe("template");
+		expect(result.value.location).toBe("/project/.taskp/skills/deploy/SKILL.md");
+		expect(result.value.inputs).toHaveLength(3);
+		expect(result.value.context).toHaveLength(2);
+	});
+
+	it("入力定義の詳細が含まれる", async () => {
+		const skill = createSkill();
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		const selectInput = result.value.inputs[0];
+		expect(selectInput.name).toBe("environment");
+		expect(selectInput.type).toBe("select");
+		expect(selectInput.choices).toEqual(["staging", "production"]);
+
+		const textInput = result.value.inputs[1];
+		expect(textInput.name).toBe("branch");
+		expect(textInput.default).toBe("main");
+	});
+
+	it("コンテキストソースが含まれる", async () => {
+		const skill = createSkill();
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		expect(result.value.context[0]).toEqual({ type: "file", path: "./config.yaml" });
+		expect(result.value.context[1]).toEqual({ type: "command", run: "git branch --show-current" });
+	});
+
+	it("存在しないスキルはエラーを返す", async () => {
+		const repo = createRepository([]);
+
+		const result = await showSkill("nonexistent", repo);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("SKILL_NOT_FOUND");
+	});
+
+	it("入力・コンテキストが空のスキルも正常に返す", async () => {
+		const skill = createSkill({ inputs: [], context: [] });
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.inputs).toHaveLength(0);
+		expect(result.value.context).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
#### 概要

スキルの詳細表示コマンド `taskp show <skill>` を実装。

#### 変更内容

- `src/usecase/show-skill.ts`: showSkill ユースケースを追加（スキル名・説明・モード・ロケーション・入力定義・コンテキストソースの取得）
- `src/cli.ts`: show コマンドを追加し、出力フォーマットを実装
- `tests/usecase/show-skill.test.ts`: ユースケースのテストを追加（5ケース）
- `src/usecase/index.ts`: エクスポートを追加

Closes #43