### PR TITLE
feat: 公開 API の整備（src/index.ts）

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,15 @@
 	"bin": {
 		"taskp": "./dist/cli.js"
 	},
+	"exports": {
+		".": {
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
+		}
+	},
 	"files": [
-		"dist/"
+		"dist/",
+		"src/"
 	],
 	"scripts": {
 		"prepare": "lefthook install",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,61 @@
 // taskp public API
+
+// Core domain types
+export type { Skill, SkillScope } from "./core/skill/skill";
+export { parseSkill } from "./core/skill/skill";
+export type { SkillBody } from "./core/skill/skill-body";
+export type { InputType } from "./core/skill/skill-input";
+export { parseSkillInput } from "./core/skill/skill-input";
+export type {
+	ContextSource,
+	SkillInput,
+	SkillMetadata,
+	SkillMode,
+} from "./core/skill/skill-metadata";
+export { parseSkillMetadata } from "./core/skill/skill-metadata";
+// Error types
+export type {
+	ConfigError,
+	DomainError,
+	ExecutionError,
+	ParseError,
+	RenderError,
+	SkillNotFoundError,
+} from "./core/types/errors";
+export {
+	configError,
+	ErrorType,
+	executionError,
+	parseError,
+	renderError,
+	skillNotFoundError,
+} from "./core/types/errors";
+// Result type
+export type { Result } from "./core/types/result";
+export { err, flatMap, isErr, isOk, map, ok } from "./core/types/result";
+export type { InitOutput, InitSkillInput } from "./usecase/init-skill";
+// Use cases
+export { initSkill } from "./usecase/init-skill";
+export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./usecase/list-skills";
+export { createListSkillsUseCase } from "./usecase/list-skills";
+export type {
+	AgentExecutorInput,
+	AgentExecutorPort,
+	AgentExecutorResult,
+} from "./usecase/port/agent-executor";
+export type { CommandExecutor, ExecOptions, ExecResult } from "./usecase/port/command-executor";
+export type { ContextCollectorPort } from "./usecase/port/context-collector";
+export type { PromptCollector } from "./usecase/port/prompt-collector";
+export type { InitOptions, SkillInitializer } from "./usecase/port/skill-initializer";
+// Port interfaces
+export type { SkillRepository } from "./usecase/port/skill-repository";
+export type {
+	RunAgentSkillDeps,
+	RunAgentSkillInput,
+	RunAgentSkillOutput,
+} from "./usecase/run-agent-skill";
+export { runAgentSkill } from "./usecase/run-agent-skill";
+export type { CommandResult, RunOutput, RunSkillDeps, RunSkillInput } from "./usecase/run-skill";
+export { runSkill } from "./usecase/run-skill";
+export type { ShowOutput } from "./usecase/show-skill";
+export { showSkill } from "./usecase/show-skill";

--- a/tests/smoke/public-api.test.ts
+++ b/tests/smoke/public-api.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+describe("public API (src/index.ts)", () => {
+	it("exports core domain types and functions", async () => {
+		const api = await import("../../src/index");
+
+		// Result utilities
+		expect(api.ok).toBeTypeOf("function");
+		expect(api.err).toBeTypeOf("function");
+		expect(api.isOk).toBeTypeOf("function");
+		expect(api.isErr).toBeTypeOf("function");
+		expect(api.map).toBeTypeOf("function");
+		expect(api.flatMap).toBeTypeOf("function");
+
+		// Skill parsers
+		expect(api.parseSkill).toBeTypeOf("function");
+		expect(api.parseSkillMetadata).toBeTypeOf("function");
+		expect(api.parseSkillInput).toBeTypeOf("function");
+
+		// Error constructors
+		expect(api.ErrorType).toBeDefined();
+		expect(api.skillNotFoundError).toBeTypeOf("function");
+		expect(api.parseError).toBeTypeOf("function");
+		expect(api.renderError).toBeTypeOf("function");
+		expect(api.executionError).toBeTypeOf("function");
+		expect(api.configError).toBeTypeOf("function");
+
+		// Use case functions
+		expect(api.initSkill).toBeTypeOf("function");
+		expect(api.createListSkillsUseCase).toBeTypeOf("function");
+		expect(api.runSkill).toBeTypeOf("function");
+		expect(api.runAgentSkill).toBeTypeOf("function");
+		expect(api.showSkill).toBeTypeOf("function");
+	});
+
+	it("Result utilities work correctly", async () => {
+		const { ok, err, isOk, isErr } = await import("../../src/index");
+
+		const success = ok(42);
+		expect(isOk(success)).toBe(true);
+		expect(isErr(success)).toBe(false);
+
+		const failure = err("error");
+		expect(isOk(failure)).toBe(false);
+		expect(isErr(failure)).toBe(true);
+	});
+});


### PR DESCRIPTION
#### 概要

ライブラリとして使用するための公開 API を `src/index.ts` に整備。

#### 変更内容

- `src/index.ts` から主要な型・関数を re-export（Skill, SkillMetadata, SkillInput, Result 型、UseCase 関数、Port インターフェース）
- `package.json` に `exports` フィールドを設定
- import テスト追加（`tests/smoke/public-api.test.ts`）

Closes #46