### PR TITLE
fix: vi.mocked() を型キャストに置換し Bun テスト互換性を修正

### DIFF
--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SkillInput } from "../../src/core/skill/skill-input";
 
 vi.mock("@inquirer/prompts", () => ({
@@ -12,14 +12,18 @@ vi.mock("@inquirer/prompts", () => ({
 import { confirm, input, number, password, select } from "@inquirer/prompts";
 import { createPromptRunner } from "../../src/adapter/prompt-runner";
 
-const mockedInput = vi.mocked(input);
-const mockedSelect = vi.mocked(select);
-const mockedConfirm = vi.mocked(confirm);
-const mockedNumber = vi.mocked(number);
-const mockedPassword = vi.mocked(password);
+const mockedInput = input as ReturnType<typeof vi.fn>;
+const mockedSelect = select as ReturnType<typeof vi.fn>;
+const mockedConfirm = confirm as ReturnType<typeof vi.fn>;
+const mockedNumber = number as ReturnType<typeof vi.fn>;
+const mockedPassword = password as ReturnType<typeof vi.fn>;
 
 describe("PromptRunner", () => {
 	const runner = createPromptRunner();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
 	it("collects text input", async () => {
 		mockedInput.mockResolvedValueOnce("hello");

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -101,7 +101,7 @@ describe("runAgentSkill", () => {
 		);
 
 		// Context should include both system prompt and collected context
-		const executorCall = vi.mocked(deps.agentExecutor.execute).mock.calls[0][0];
+		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
 		expect(executorCall.context).toContain("You are a helpful assistant.");
 		expect(executorCall.context).toContain("collected context");
 	});
@@ -187,7 +187,7 @@ describe("runAgentSkill", () => {
 
 		await runAgentSkill({ name: "test-agent", presets: {}, model: mockModel }, deps);
 
-		const executorCall = vi.mocked(deps.agentExecutor.execute).mock.calls[0][0];
+		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
 		expect(executorCall.model).toBe(mockModel);
 	});
 });


### PR DESCRIPTION
## 問題

`vi.mocked()` は Vitest 固有の API で、Bun のネイティブテストランナーでは未定義。
また `prompt-runner.test.ts` でモック状態がテスト間でリークしていた。

## 修正内容

- `vi.mocked(fn)` → `fn as ReturnType<typeof vi.fn>` に置換（2ファイル、7箇所）
- `prompt-runner.test.ts` に `beforeEach(() => vi.clearAllMocks())` を追加

## 結果

- `bun test`: 252 pass, 0 fail ✅
- `vitest run`: 252 pass ✅