### PR TITLE
feat: taskp tui コマンドの骨格を追加

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -220,6 +220,13 @@ const cli = Cli.create("taskp", {
 			console.log(formatShowOutput(result.value));
 		},
 	})
+	.command("tui", {
+		description: "Launch interactive TUI",
+		async run() {
+			const { startTui } = await import("./tui/app");
+			await startTui();
+		},
+	})
 	.command("serve", {
 		description: "Start as MCP stdio server",
 		async run() {

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1,0 +1,28 @@
+import { Box, createCliRenderer, Text } from "@opentui/core";
+
+export async function startTui(): Promise<void> {
+	const renderer = await createCliRenderer({
+		exitOnCtrlC: true,
+		targetFps: 30,
+	});
+
+	renderer.root.add(
+		Box(
+			{
+				width: "100%",
+				height: "100%",
+				borderStyle: "rounded",
+				title: "taskp",
+				padding: 1,
+				flexDirection: "column",
+				justifyContent: "center",
+				alignItems: "center",
+			},
+			Text({ content: "taskp TUI - Press Ctrl+C to exit", fg: "#888888" }),
+		),
+	);
+
+	// renderer は exitOnCtrlC: true で Ctrl+C 時に自動 destroy するため、
+	// プロセス終了まで待機する
+	await new Promise(() => {});
+}

--- a/tests/tui/app.test.ts
+++ b/tests/tui/app.test.ts
@@ -1,0 +1,17 @@
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { describe, expect, it } from "vitest";
+
+const CLI_PATH = join(import.meta.dirname, "../../src/cli.ts");
+
+describe("taskp tui command", () => {
+	it("is registered and shown in help output", async () => {
+		const result = await execaCommand(`bun run ${CLI_PATH} --help`, {
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("tui");
+		expect(result.stdout).toContain("Launch interactive TUI");
+	});
+});


### PR DESCRIPTION
#### 概要

`taskp tui` コマンドの骨格を作成。最小限の OpenTUI 画面を表示し、Ctrl+C で終了できることを確認する。

#### 変更内容

- `src/tui/app.ts` を新規作成 — OpenTUI の `createCliRenderer` で最小限の TUI 画面を表示
- `src/cli.ts` に `tui` コマンドを追加（動的 import で他コマンドへの影響なし）
- `tests/tui/app.test.ts` を追加 — CLI ヘルプに tui コマンドが登録されていることを検証

Closes #97