### PR TITLE
feat: ファジー検索ロジック filterSkills を実装

### DIFF
--- a/src/tui/components/fuzzy-select.ts
+++ b/src/tui/components/fuzzy-select.ts
@@ -1,0 +1,18 @@
+import fuzzysort from "fuzzysort";
+
+export type SkillOption = {
+	readonly name: string;
+	readonly description: string;
+};
+
+export function filterSkills(query: string, skills: readonly SkillOption[]): SkillOption[] {
+	if (query === "") {
+		return [...skills];
+	}
+
+	const results = fuzzysort.go(query, skills as SkillOption[], {
+		keys: ["name", "description"],
+	});
+
+	return results.map((r) => r.obj);
+}

--- a/tests/tui/components/fuzzy-select.test.ts
+++ b/tests/tui/components/fuzzy-select.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { filterSkills, type SkillOption } from "../../../src/tui/components/fuzzy-select";
+
+const skills: SkillOption[] = [
+	{ name: "code-review", description: "コードレビューを実行する" },
+	{ name: "deploy", description: "アプリケーションをデプロイする" },
+	{
+		name: "find-refactoring",
+		description: "リファクタリング箇所を検出する",
+	},
+];
+
+describe("filterSkills", () => {
+	it("returns all skills when query is empty", () => {
+		expect(filterSkills("", skills)).toHaveLength(3);
+	});
+
+	it("filters by name match", () => {
+		const result = filterSkills("deploy", skills);
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("deploy");
+	});
+
+	it("supports fuzzy matching", () => {
+		const result = filterSkills("cdr", skills);
+		expect(result.length).toBeGreaterThanOrEqual(1);
+		expect(result[0].name).toBe("code-review");
+	});
+
+	it("filters by description match", () => {
+		const result = filterSkills("リファクタリング", skills);
+		expect(result.length).toBeGreaterThanOrEqual(1);
+		expect(result[0].name).toBe("find-refactoring");
+	});
+
+	it("returns empty array when no match", () => {
+		expect(filterSkills("zzzzzzz", skills)).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
#### 概要

fuzzysort を使って、スキル名と説明文をファジー検索する `filterSkills` 関数を実装。

#### 変更内容

- `src/tui/components/fuzzy-select.ts` — `SkillOption` 型と `filterSkills` 関数を新規作成
- `tests/tui/components/fuzzy-select.test.ts` — 空クエリ・名前マッチ・ファジーマッチ・説明文マッチ・マッチなしの 5 テストを追加

Closes #98