### PR TITLE
feat(tui): KeyHelp コンポーネントの実装

### DIFF
--- a/src/tui/components/key-help.ts
+++ b/src/tui/components/key-help.ts
@@ -1,0 +1,25 @@
+import { Box, Text, type VNode } from "@opentui/core";
+
+export type KeyBinding = {
+	readonly key: string;
+	readonly description: string;
+};
+
+export function KeyHelp(bindings: readonly KeyBinding[]): VNode {
+	const parts = bindings.map((b) =>
+		Box(
+			{ flexDirection: "row", gap: 1 },
+			Text({ content: b.key, fg: "#FFFF00" }),
+			Text({ content: b.description, fg: "#888888" }),
+		),
+	);
+
+	return Box(
+		{
+			flexDirection: "row",
+			gap: 2,
+			paddingTop: 1,
+		},
+		...parts,
+	);
+}

--- a/tests/tui/components/key-help-verify.ts
+++ b/tests/tui/components/key-help-verify.ts
@@ -1,0 +1,38 @@
+import { type KeyBinding, KeyHelp } from "../../../src/tui/components/key-help";
+
+const bindings: readonly KeyBinding[] = [
+	{ key: "↑↓", description: "移動" },
+	{ key: "Enter", description: "選択" },
+	{ key: "Esc", description: "終了" },
+];
+
+const result = KeyHelp(bindings);
+
+if (result === undefined || result === null) {
+	console.error("FAIL: KeyHelp returned null/undefined");
+	process.exit(1);
+}
+
+if (typeof result !== "object") {
+	console.error(`FAIL: KeyHelp returned ${typeof result}, expected object (VNode)`);
+	process.exit(1);
+}
+
+console.log("PASS: KeyHelp returned a VNode");
+console.log(`PASS: VNode type = ${JSON.stringify(typeof result)}`);
+
+const emptyResult = KeyHelp([]);
+if (emptyResult === undefined || emptyResult === null) {
+	console.error("FAIL: KeyHelp([]) returned null/undefined");
+	process.exit(1);
+}
+console.log("PASS: KeyHelp([]) returned a VNode for empty bindings");
+
+const singleResult = KeyHelp([{ key: "Enter", description: "確定" }]);
+if (singleResult === undefined || singleResult === null) {
+	console.error("FAIL: KeyHelp with single binding returned null/undefined");
+	process.exit(1);
+}
+console.log("PASS: KeyHelp with single binding returned a VNode");
+
+console.log("ALL CHECKS PASSED");

--- a/tests/tui/components/key-help.test.ts
+++ b/tests/tui/components/key-help.test.ts
@@ -1,0 +1,19 @@
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { describe, expect, it } from "vitest";
+
+const VERIFY_SCRIPT = join(import.meta.dirname, "key-help-verify.ts");
+
+describe("KeyHelp", () => {
+	it("returns VNode for various binding inputs", async () => {
+		const result = await execaCommand(`bun run ${VERIFY_SCRIPT}`, {
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("ALL CHECKS PASSED");
+		expect(result.stdout).toContain("PASS: KeyHelp returned a VNode");
+		expect(result.stdout).toContain("PASS: KeyHelp([]) returned a VNode for empty bindings");
+		expect(result.stdout).toContain("PASS: KeyHelp with single binding returned a VNode");
+	});
+});


### PR DESCRIPTION
#### 概要

画面下部に表示するキーバインドヘルプコンポーネントを実装。キー名を黄色、説明を灰色で横並び表示する。

#### 変更内容

- `src/tui/components/key-help.ts` — `KeyBinding` 型と `KeyHelp` 関数を作成
- `tests/tui/components/key-help.test.ts` — subprocess ベースの smoke テストを追加
- `tests/tui/components/key-help-verify.ts` — テスト用検証スクリプト

Closes #99