### PR TITLE
feat: TUI 用 StreamWriter を実装

### DIFF
--- a/src/tui/tui-stream-writer.ts
+++ b/src/tui/tui-stream-writer.ts
@@ -1,0 +1,25 @@
+import type { StreamWriter } from "../adapter/stream-writer";
+
+export type ExecutionViewPort = {
+	readonly appendOutput: (text: string) => void;
+	readonly showToolStatus: (toolName: string, args: Record<string, unknown>) => void;
+	readonly clearToolStatus: () => void;
+	readonly showSummary: (elapsedMs: number, steps: number) => void;
+};
+
+export function createTuiStreamWriter(view: ExecutionViewPort): StreamWriter {
+	return {
+		writeText(text: string): void {
+			view.appendOutput(text);
+		},
+		writeToolCall(toolName: string, args: Record<string, unknown>): void {
+			view.showToolStatus(toolName, args);
+		},
+		writeToolResult(_toolName: string, _result: unknown): void {
+			view.clearToolStatus();
+		},
+		writeSummary(elapsedMs: number, steps: number): void {
+			view.showSummary(elapsedMs, steps);
+		},
+	};
+}

--- a/tests/tui/tui-stream-writer.test.ts
+++ b/tests/tui/tui-stream-writer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { createTuiStreamWriter, type ExecutionViewPort } from "../../src/tui/tui-stream-writer";
+
+function createMockView(): ExecutionViewPort & { calls: string[] } {
+	const calls: string[] = [];
+	return {
+		calls,
+		appendOutput(text: string) {
+			calls.push(`appendOutput:${text}`);
+		},
+		showToolStatus(toolName: string, _args: Record<string, unknown>) {
+			calls.push(`showToolStatus:${toolName}`);
+		},
+		clearToolStatus() {
+			calls.push("clearToolStatus");
+		},
+		showSummary(elapsedMs: number, steps: number) {
+			calls.push(`showSummary:${elapsedMs}:${steps}`);
+		},
+	};
+}
+
+describe("createTuiStreamWriter", () => {
+	it("writeText calls appendOutput", () => {
+		const view = createMockView();
+		const writer = createTuiStreamWriter(view);
+		writer.writeText("hello");
+		expect(view.calls).toContain("appendOutput:hello");
+	});
+
+	it("writeToolCall calls showToolStatus", () => {
+		const view = createMockView();
+		const writer = createTuiStreamWriter(view);
+		writer.writeToolCall("bash", { command: "ls" });
+		expect(view.calls).toContain("showToolStatus:bash");
+	});
+
+	it("writeToolResult calls clearToolStatus", () => {
+		const view = createMockView();
+		const writer = createTuiStreamWriter(view);
+		writer.writeToolResult("bash", "output");
+		expect(view.calls).toContain("clearToolStatus");
+	});
+
+	it("writeSummary calls showSummary", () => {
+		const view = createMockView();
+		const writer = createTuiStreamWriter(view);
+		writer.writeSummary(1234, 5);
+		expect(view.calls).toContain("showSummary:1234:5");
+	});
+});


### PR DESCRIPTION
#### 概要

ExecutionViewPort インターフェースを定義し、TUI 用の StreamWriter 実装（createTuiStreamWriter）を追加。既存の StreamWriter インターフェースに準拠し、OpenTUI コンポーネント更新用のビューポートに委譲する。

#### 変更内容

- `src/tui/tui-stream-writer.ts`: ExecutionViewPort 型と createTuiStreamWriter ファクトリ関数を追加
- `tests/tui/tui-stream-writer.test.ts`: 4つの委譲テスト（writeText→appendOutput, writeToolCall→showToolStatus, writeToolResult→clearToolStatus, writeSummary→showSummary）

Closes #102