### PR TITLE
feat(tui): ToolStatusDisplay コンポーネント（スピナー付き）を追加

### DIFF
--- a/src/tui/components/tool-args-formatter.ts
+++ b/src/tui/components/tool-args-formatter.ts
@@ -1,0 +1,20 @@
+const TRUNCATE_LENGTH = 60;
+
+export function formatToolArgs(toolName: string, args: Record<string, unknown>): string {
+	switch (toolName) {
+		case "bash":
+			return truncate(String(args.command), TRUNCATE_LENGTH);
+		case "read":
+			return String(args.path);
+		case "write":
+			return String(args.path);
+		case "glob":
+			return String(args.pattern);
+		default:
+			return truncate(JSON.stringify(args), TRUNCATE_LENGTH);
+	}
+}
+
+function truncate(text: string, maxLength: number): string {
+	return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}

--- a/src/tui/components/tool-status.ts
+++ b/src/tui/components/tool-status.ts
@@ -1,0 +1,64 @@
+import { type CliRenderer, TextRenderable } from "@opentui/core";
+import { formatToolArgs } from "./tool-args-formatter";
+
+const SPINNER_FRAMES = ["⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"] as const;
+const SPINNER_INTERVAL_MS = 80;
+
+type ToolState = {
+	readonly tool: string;
+	readonly summary: string;
+};
+
+export class ToolStatusDisplay {
+	private readonly text: TextRenderable;
+	private spinnerIndex = 0;
+	private spinnerInterval: ReturnType<typeof setInterval> | null = null;
+	private current: ToolState | null = null;
+
+	constructor(renderer: CliRenderer, id: string) {
+		this.text = new TextRenderable(renderer, {
+			id,
+			content: "",
+			fg: "#888888",
+		});
+	}
+
+	get renderable(): TextRenderable {
+		return this.text;
+	}
+
+	show(toolName: string, args: Record<string, unknown>): void {
+		this.current = {
+			tool: toolName,
+			summary: formatToolArgs(toolName, args),
+		};
+		this.spinnerIndex = 0;
+		this.updateContent();
+
+		if (this.spinnerInterval) clearInterval(this.spinnerInterval);
+		this.spinnerInterval = setInterval(() => {
+			this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
+			this.updateContent();
+		}, SPINNER_INTERVAL_MS);
+	}
+
+	clear(): void {
+		if (this.spinnerInterval) {
+			clearInterval(this.spinnerInterval);
+			this.spinnerInterval = null;
+		}
+		this.current = null;
+		this.text.content = "";
+	}
+
+	destroy(): void {
+		this.clear();
+	}
+
+	private updateContent(): void {
+		if (!this.current) return;
+		const frame = SPINNER_FRAMES[this.spinnerIndex % SPINNER_FRAMES.length];
+		if (frame === undefined) return;
+		this.text.content = `${frame} [${this.current.tool}] ${this.current.summary}`;
+	}
+}

--- a/tests/tui/components/tool-args-formatter.test.ts
+++ b/tests/tui/components/tool-args-formatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatToolArgs } from "../../../src/tui/components/tool-args-formatter";
+
+describe("formatToolArgs", () => {
+	it("formats bash tool with command string", () => {
+		const result = formatToolArgs("bash", { command: "echo hello" });
+		expect(result).toBe("echo hello");
+	});
+
+	it("truncates long bash commands at 60 characters", () => {
+		const longCommand = "a".repeat(80);
+		const result = formatToolArgs("bash", { command: longCommand });
+		expect(result).toBe(`${"a".repeat(60)}...`);
+	});
+
+	it("does not truncate bash commands at exactly 60 characters", () => {
+		const exactCommand = "a".repeat(60);
+		const result = formatToolArgs("bash", { command: exactCommand });
+		expect(result).toBe(exactCommand);
+	});
+
+	it("formats read tool with file path", () => {
+		const result = formatToolArgs("read", { path: "/src/index.ts" });
+		expect(result).toBe("/src/index.ts");
+	});
+
+	it("formats write tool with file path", () => {
+		const result = formatToolArgs("write", { path: "/src/output.ts" });
+		expect(result).toBe("/src/output.ts");
+	});
+
+	it("formats glob tool with pattern", () => {
+		const result = formatToolArgs("glob", { pattern: "**/*.ts" });
+		expect(result).toBe("**/*.ts");
+	});
+
+	it("formats unknown tool as JSON", () => {
+		const result = formatToolArgs("unknown", { key: "value" });
+		expect(result).toBe('{"key":"value"}');
+	});
+
+	it("truncates long JSON for unknown tools", () => {
+		const args: Record<string, unknown> = { data: "x".repeat(80) };
+		const result = formatToolArgs("custom", args);
+		expect(result.length).toBe(63);
+		expect(result.endsWith("...")).toBe(true);
+	});
+
+	it("formats empty args for unknown tool", () => {
+		const result = formatToolArgs("custom", {});
+		expect(result).toBe("{}");
+	});
+});

--- a/tests/tui/components/tool-status.test.ts
+++ b/tests/tui/components/tool-status.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from "vitest";
+
+describe("ToolStatusDisplay", () => {
+	it.todo("show/clear/destroy lifecycle (requires TUI renderer — manual verification)");
+});


### PR DESCRIPTION
#### 概要

ツール呼び出し中にスピナーアニメーション + ツール名 + 引数サマリを表示する ToolStatusDisplay コンポーネントを実装。

#### 変更内容

- `src/tui/components/tool-status.ts` — ToolStatusDisplay クラス（show/clear/destroy ライフサイクル、80ms 間隔スピナー）
- `src/tui/components/tool-args-formatter.ts` — ツール引数のフォーマットロジック（bash/read/write/glob 対応、60文字 truncate）
- `tests/tui/components/tool-args-formatter.test.ts` — formatToolArgs のユニットテスト（9テスト）
- `tests/tui/components/tool-status.test.ts` — ToolStatusDisplay の todo テスト（OpenTUI/Vitest 制約による）

Closes #103