### PR TITLE
feat: GitHub Trending スキル追加 & __skill_dir__ バグ修正

### DIFF
--- a/.taskp/skills/github-trending/SKILL.md
+++ b/.taskp/skills/github-trending/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: github-trending
+description: GitHub Trending のリポジトリ情報を README 要約付きの日本語マークダウンファイルとして出力する
+mode: agent
+inputs:
+  - name: language
+    type: text
+    message: "言語でフィルタしますか？（例: typescript, python, rust）空欄で全言語"
+    default: ""
+    required: false
+  - name: since
+    type: select
+    message: "期間を選んでください"
+    choices: [daily, weekly, monthly]
+  - name: limit
+    type: number
+    message: "表示件数（最大25）"
+    default: 10
+  - name: output
+    type: text
+    message: "出力先ファイルパス"
+    default: "github-trending.md"
+context:
+  - type: command
+    run: "bash {{__skill_dir__}}/fetch-trending.sh \"{{language}}\" \"{{since}}\" \"{{limit}}\""
+tools:
+  - write
+---
+
+# GitHub Trending 日本語レポート生成
+
+あなたは GitHub Trending 情報を日本語で分かりやすく伝えるテックレポーターです。
+
+## 入力
+
+コンテキストとして、GitHub Trending の各リポジトリの基本情報（名前、説明、スター数、言語）と README 原文抜粋が渡されます。
+
+## タスク
+
+1. 各リポジトリの README を読み、プロジェクトの概要を **日本語で3〜5行に要約** してください
+2. 結果を以下のフォーマットでマークダウンファイルとして `{{output}}` に書き出してください
+
+## 出力フォーマット
+
+```markdown
+# 🔥 GitHub Trending レポート — [言語] ([期間])
+
+> 取得日時: YYYY-MM-DD HH:MM
+> 生成: taskp github-trending
+
+---
+
+## 1. [owner/repo](URL)
+
+📝 言語 | ⭐ 総スター数 | 📈 +増分
+
+**概要（原文）:** 元の英語の短い説明文
+
+### 📖 README 要約
+
+README の内容を読んで、以下の観点で日本語で要約する:
+- **何をするツール/ライブラリか**（1行）
+- **主な特徴・機能**（箇条書き2〜3点）
+- **想定ユースケース/対象ユーザー**（1行）
+
+---
+```
+
+## 注意事項
+
+- 技術用語（API、CLI、LLM、ORM 等）はそのまま英語表記で構いません
+- 元データの順位・数値・リンクは正確に保ってください
+- README が取得できなかったリポジトリは、説明文から推測して簡潔に紹介してください
+- 出力は `write` ツールで `{{output}}` にファイルとして書き出してください
+- ファイル書き出し後、出力先パスを表示してください

--- a/.taskp/skills/github-trending/fetch-trending.sh
+++ b/.taskp/skills/github-trending/fetch-trending.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LANGUAGE="${1:-}"
+SINCE="${2:-daily}"
+LIMIT="${3:-10}"
+README_MAX_CHARS="${4:-3000}"
+
+# URL 構築
+URL="https://github.com/trending"
+if [[ -n "$LANGUAGE" ]]; then
+  URL="${URL}/${LANGUAGE}"
+fi
+URL="${URL}?since=${SINCE}"
+
+# HTML 取得
+HTML=$(curl -s -L -H "Accept-Language: en-US,en;q=0.9" "$URL")
+
+# 期間ラベル
+case "$SINCE" in
+  daily)   PERIOD="今日" ;;
+  weekly)  PERIOD="今週" ;;
+  monthly) PERIOD="今月" ;;
+  *)       PERIOD="$SINCE" ;;
+esac
+
+# ヘッダー出力
+if [[ -n "$LANGUAGE" ]]; then
+  echo "# 🔥 GitHub Trending — ${LANGUAGE} (${PERIOD})"
+else
+  echo "# 🔥 GitHub Trending (${PERIOD})"
+fi
+echo ""
+echo "> 取得日時: $(date '+%Y-%m-%d %H:%M')"
+echo ""
+
+# パース → リポジトリ一覧 + README 取得
+echo "$HTML" | python3 -c "
+import sys
+import html
+import re
+import urllib.request
+import urllib.error
+
+content = sys.stdin.read()
+limit = int('${LIMIT}')
+readme_max = int('${README_MAX_CHARS}')
+
+articles = re.findall(r'<article[^>]*>.*?</article>', content, re.DOTALL)
+
+def fetch_readme(owner, repo, max_chars):
+    \"\"\"GitHub API で README を取得し、先頭 max_chars 文字を返す\"\"\"
+    # raw.githubusercontent.com から直接取得（API rate limit を避ける）
+    for branch in ['main', 'master']:
+        url = f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/README.md'
+        try:
+            req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                text = resp.read().decode('utf-8', errors='replace')
+                if len(text) > max_chars:
+                    text = text[:max_chars] + '\n\n... (truncated)'
+                return text
+        except urllib.error.HTTPError:
+            continue
+        except Exception:
+            continue
+    return '(README の取得に失敗しました)'
+
+count = 0
+for article in articles:
+    if count >= limit:
+        break
+
+    # リポジトリ名 (owner/repo)
+    repo_match = re.search(r'href=\"/([^\"]+)\"[^>]*>\s*(?:<svg[^>]*>.*?</svg>)?\s*<span[^>]*>([^<]+)</span>\s*/\s*<span[^>]*>([^<]+)</span>', article, re.DOTALL)
+    if not repo_match:
+        repo_match = re.search(r'<h2[^>]*>.*?href=\"/([^\"]+)\"', article, re.DOTALL)
+        if not repo_match:
+            continue
+        repo_path = repo_match.group(1).strip()
+        parts = repo_path.split('/')
+        if len(parts) >= 2:
+            owner = parts[0].strip()
+            repo = parts[1].strip()
+        else:
+            continue
+    else:
+        owner = repo_match.group(2).strip()
+        repo = repo_match.group(3).strip()
+
+    count += 1
+
+    # 説明
+    desc_match = re.search(r'<p[^>]*class=\"[^\"]*col-9[^\"]*\"[^>]*>(.*?)</p>', article, re.DOTALL)
+    desc = ''
+    if desc_match:
+        desc = re.sub(r'<[^>]+>', '', desc_match.group(1)).strip()
+        desc = html.unescape(desc)
+
+    # 言語
+    lang_match = re.search(r'<span[^>]*itemprop=\"programmingLanguage\"[^>]*>([^<]+)</span>', article)
+    lang = lang_match.group(1).strip() if lang_match else ''
+
+    # スター数
+    star_match = re.search(r'href=\"/[^\"]+/stargazers\"[^>]*>\s*(?:<svg[^>]*>.*?</svg>)?\s*([\d,]+)', article, re.DOTALL)
+    if not star_match:
+        star_match = re.search(r'([\d,]+)\s*stars', article, re.IGNORECASE)
+    stars = star_match.group(1).strip().replace(',', '') if star_match else ''
+
+    # 今期のスター増分
+    trend_match = re.search(r'([\d,]+)\s*stars\s*(today|this\s*week|this\s*month)', article, re.IGNORECASE)
+    trend = trend_match.group(1).strip() if trend_match else ''
+
+    # README 取得
+    sys.stderr.write(f'  📖 README 取得中: {owner}/{repo} ...\n')
+    readme = fetch_readme(owner, repo, readme_max)
+
+    # 出力
+    print(f'## {count}. [{owner}/{repo}](https://github.com/{owner}/{repo})')
+    print()
+    if desc:
+        print(f'> {desc}')
+        print()
+    meta = []
+    if lang:
+        meta.append(f'📝 {lang}')
+    if stars:
+        meta.append(f'⭐ {int(stars):,}')
+    if trend:
+        meta.append(f'📈 +{trend}')
+    if meta:
+        print(' | '.join(meta))
+        print()
+    print('### README (原文抜粋)')
+    print()
+    print(readme)
+    print()
+    print('---')
+    print()
+
+if count == 0:
+    print('トレンドリポジトリが見つかりませんでした。')
+"

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,4 +1,6 @@
+import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { ContextSource } from "../core/skill/context-source";
 import type { DomainError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
@@ -43,7 +45,7 @@ export async function runAgentSkill(
 
 	const reserved: ReservedVars = {
 		cwd: process.cwd(),
-		skillDir: skill.location,
+		skillDir: dirname(skill.location),
 		date: new Date().toISOString().split("T")[0],
 		timestamp: new Date().toISOString(),
 	};
@@ -60,10 +62,13 @@ export async function runAgentSkill(
 	const contextParts: string[] = [systemPrompt];
 
 	if (skill.metadata.context.length > 0) {
-		const contextResult = await deps.contextCollector.collect(
-			skill.metadata.context,
-			process.cwd(),
-		);
+		// context ソース内の変数（{{__skill_dir__}} 等）を展開してからコレクタに渡す
+		// （SKILL-SPEC.md「展開タイミング」ステップ3: context のパス内の変数を展開）
+		const resolvedSources = resolveContextSources(skill.metadata.context, variables, reserved);
+		if (!resolvedSources.ok) {
+			return resolvedSources;
+		}
+		const contextResult = await deps.contextCollector.collect(resolvedSources.value, process.cwd());
 		if (!contextResult.ok) {
 			return contextResult;
 		}
@@ -87,4 +92,53 @@ export async function runAgentSkill(
 		skillName: skill.metadata.name,
 		result: executeResult.value,
 	});
+}
+
+/**
+ * context ソース内の変数（パス・コマンド等）を展開する。
+ * 例: `{{__skill_dir__}}/fetch.sh` → `/abs/path/to/skill/fetch.sh`
+ */
+function resolveContextSources(
+	sources: readonly ContextSource[],
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+): Result<readonly ContextSource[], DomainError> {
+	const resolved: ContextSource[] = [];
+
+	for (const source of sources) {
+		const raw = getContextSourceValue(source);
+		const renderResult = renderTemplate(raw, variables, reserved);
+		if (!renderResult.ok) {
+			return renderResult;
+		}
+		resolved.push(withResolvedValue(source, renderResult.value));
+	}
+
+	return ok(resolved);
+}
+
+function getContextSourceValue(source: ContextSource): string {
+	switch (source.type) {
+		case "file":
+			return source.path;
+		case "glob":
+			return source.pattern;
+		case "command":
+			return source.run;
+		case "url":
+			return source.url;
+	}
+}
+
+function withResolvedValue(source: ContextSource, value: string): ContextSource {
+	switch (source.type) {
+		case "file":
+			return { ...source, path: value };
+		case "glob":
+			return { ...source, pattern: value };
+		case "command":
+			return { ...source, run: value };
+		case "url":
+			return { ...source, url: value };
+	}
 }

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import type { CodeBlock } from "../core/skill/skill-body";
 import type { DomainError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
@@ -48,7 +49,7 @@ export async function runSkill(
 
 	const reserved: ReservedVars = {
 		cwd: process.cwd(),
-		skillDir: skill.location,
+		skillDir: dirname(skill.location),
 		date: new Date().toISOString().split("T")[0],
 		timestamp: new Date().toISOString(),
 	};


### PR DESCRIPTION
## 概要

GitHub Trending のリポジトリ情報を README 要約付きの日本語マークダウンファイルとして出力するスキルを追加。
また、実装中に発見したバグ2件を修正。

## 新機能

### github-trending スキル (`.taskp/skills/github-trending/`)

- GitHub Trending ページをスクレイピングし、各リポジトリの基本情報を取得
- 各リポジトリの README.md を取得（先頭3000文字）
- LLM が README を要約して日本語に翻訳
- 結果をマークダウンファイルとして出力

**入力:**
| パラメータ | 説明 |
|-----------|------|
| language | 言語フィルタ（空欄で全言語） |
| since | 期間（daily / weekly / monthly） |
| limit | 表示件数（最大25） |
| output | 出力先ファイルパス |

## バグ修正

### 1. `__skill_dir__` がファイルパスになるバグ
- `run-skill.ts`, `run-agent-skill.ts` で `skill.location`（SKILL.md のフルパス）をそのまま `skillDir` に渡していた
- `dirname()` でディレクトリパスに変換するよう修正

### 2. agent モードで context ソース内の変数が未展開
- SKILL-SPEC.md の「展開タイミング」ステップ3（context のパス内の変数を展開）が未実装だった
- `resolveContextSources()` を追加し、context collector に渡す前に変数展開を実行するよう修正

## テスト

- 全 275 テスト通過
- lint / typecheck / build すべて通過