### PR TITLE
feat: スキル入力に textarea タイプを追加

### DIFF
--- a/docs/SKILL-SPEC.md
+++ b/docs/SKILL-SPEC.md
@@ -66,7 +66,7 @@ npm run deploy:{{environment}}
 ### Input 型
 
 ```typescript
-type InputType = "text" | "select" | "confirm" | "number" | "password";
+type InputType = "text" | "textarea" | "select" | "confirm" | "number" | "password";
 
 interface Input {
   name: string;                     // 変数名（{{name}} で参照）
@@ -83,7 +83,8 @@ interface Input {
 
 | type | UI | 戻り値型 |
 |------|-----|---------|
-| `text` | 自由入力 | `string` |
+| `text` | 自由入力（1行） | `string` |
+| `textarea` | 複数行入力（Meta+Enter で確定） | `string` |
 | `select` | 選択肢から選ぶ | `string` |
 | `confirm` | Yes/No | `boolean` |
 | `number` | 数値入力 | `number` |

--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -1,4 +1,4 @@
-import { confirm, input, number, password, select } from "@inquirer/prompts";
+import { confirm, editor, input, number, password, select } from "@inquirer/prompts";
 import type { SkillInput } from "../core/skill/skill-input";
 import type { PromptCollector } from "../usecase/port/prompt-collector";
 
@@ -6,6 +6,7 @@ type PromptFn = (skillInput: SkillInput) => Promise<string>;
 
 const promptByType: Record<string, PromptFn> = {
 	text: askText,
+	textarea: askTextarea,
 	select: askSelect,
 	confirm: askConfirm,
 	number: askNumber,
@@ -42,6 +43,14 @@ async function askText(skillInput: SkillInput): Promise<string> {
 		message: skillInput.message,
 		default: skillInput.default as string | undefined,
 		required: skillInput.required ?? false,
+		validate: buildValidator(skillInput),
+	});
+}
+
+async function askTextarea(skillInput: SkillInput): Promise<string> {
+	return editor({
+		message: skillInput.message,
+		default: skillInput.default as string | undefined,
 		validate: buildValidator(skillInput),
 	});
 }

--- a/src/core/skill/skill-input.ts
+++ b/src/core/skill/skill-input.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const inputTypeSchema = z.enum(["text", "select", "confirm", "number", "password"]);
+const inputTypeSchema = z.enum(["text", "textarea", "select", "confirm", "number", "password"]);
 
 const skillInputSchema = z
 	.object({

--- a/src/tui/screens/input-form.ts
+++ b/src/tui/screens/input-form.ts
@@ -8,6 +8,7 @@ import {
 	type SelectOption,
 	SelectRenderable,
 	SelectRenderableEvents,
+	TextareaRenderable,
 	TextRenderable,
 	t,
 } from "@opentui/core";
@@ -17,10 +18,11 @@ import { KeyHelp } from "../components/key-help";
 import { flatSelectStyle } from "../components/styles";
 
 const CONTAINER_ID = "form-container";
+const TEXTAREA_DEFAULT_HEIGHT = 5;
 
 type FormElement = {
 	readonly input: SkillInput;
-	readonly element: InputRenderable | SelectRenderable;
+	readonly element: InputRenderable | SelectRenderable | TextareaRenderable;
 };
 
 export async function showInputForm(
@@ -153,12 +155,14 @@ function createInputElement(
 	renderer: CliRenderer,
 	input: SkillInput,
 	onConfirm: (value: string) => void,
-): InputRenderable | SelectRenderable {
+): InputRenderable | SelectRenderable | TextareaRenderable {
 	switch (input.type) {
 		case "select":
 			return createSelectElement(renderer, input, onConfirm);
 		case "confirm":
 			return createConfirmElement(renderer, input, onConfirm);
+		case "textarea":
+			return createTextareaElement(renderer, input, onConfirm);
 		case "text":
 		case "number":
 		case "password":
@@ -220,6 +224,33 @@ function createConfirmElement(
 	});
 
 	return select;
+}
+
+function createTextareaElement(
+	renderer: CliRenderer,
+	input: SkillInput,
+	onConfirm: (value: string) => void,
+): TextareaRenderable {
+	const textarea = new TextareaRenderable(renderer, {
+		id: `input-${input.name}`,
+		width: "100%",
+		height: TEXTAREA_DEFAULT_HEIGHT,
+		marginLeft: 2,
+		wrapMode: "word",
+	});
+
+	if (input.default !== undefined) {
+		textarea.initialValue = String(input.default);
+	}
+
+	// Meta+Enter（macOS: Cmd+Enter, Linux/Windows: Alt+Enter）で確定
+	textarea.onSubmit = () => {
+		// getTextRange で全テキストを取得（endOffset に十分大きい値を渡す）
+		const text = textarea.getTextRange(0, Number.MAX_SAFE_INTEGER);
+		onConfirm(text);
+	};
+
+	return textarea;
 }
 
 function createTextInputElement(

--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -3,16 +3,18 @@ import type { SkillInput } from "../../src/core/skill/skill-input";
 
 vi.mock("@inquirer/prompts", () => ({
 	input: vi.fn(),
+	editor: vi.fn(),
 	select: vi.fn(),
 	confirm: vi.fn(),
 	number: vi.fn(),
 	password: vi.fn(),
 }));
 
-import { confirm, input, number, password, select } from "@inquirer/prompts";
+import { confirm, editor, input, number, password, select } from "@inquirer/prompts";
 import { createPromptRunner } from "../../src/adapter/prompt-runner";
 
 const mockedInput = input as ReturnType<typeof vi.fn>;
+const mockedEditor = editor as ReturnType<typeof vi.fn>;
 const mockedSelect = select as ReturnType<typeof vi.fn>;
 const mockedConfirm = confirm as ReturnType<typeof vi.fn>;
 const mockedNumber = number as ReturnType<typeof vi.fn>;
@@ -78,6 +80,16 @@ describe("PromptRunner", () => {
 
 		const result = await runner.collect(inputs, {});
 		expect(result).toEqual({ count: "42" });
+	});
+
+	it("collects textarea input", async () => {
+		mockedEditor.mockResolvedValueOnce("line1\nline2\nline3");
+
+		const inputs: SkillInput[] = [{ name: "body", type: "textarea", message: "Enter body" }];
+
+		const result = await runner.collect(inputs, {});
+		expect(result).toEqual({ body: "line1\nline2\nline3" });
+		expect(mockedEditor).toHaveBeenCalledWith(expect.objectContaining({ message: "Enter body" }));
 	});
 
 	it("collects password input", async () => {

--- a/tests/core/skill/skill-input.test.ts
+++ b/tests/core/skill/skill-input.test.ts
@@ -50,6 +50,29 @@ describe("parseSkillInput", () => {
 		expect(result.default).toBe(5);
 	});
 
+	it("textarea タイプが正しくパースされる", () => {
+		const result = parseSkillInput({
+			name: "body",
+			type: "textarea",
+			message: "本文を入力してください",
+		});
+
+		expect(result.type).toBe("textarea");
+		expect(result.message).toBe("本文を入力してください");
+	});
+
+	it("textarea タイプがデフォルト値付きでパースされる", () => {
+		const result = parseSkillInput({
+			name: "body",
+			type: "textarea",
+			message: "本文を入力",
+			default: "デフォルトテキスト",
+		});
+
+		expect(result.type).toBe("textarea");
+		expect(result.default).toBe("デフォルトテキスト");
+	});
+
 	it("password タイプが正しくパースされる", () => {
 		const result = parseSkillInput({
 			name: "secret",


### PR DESCRIPTION
## 概要

スキルの入力定義に `type: textarea` を追加し、複数行テキスト入力に対応。

## 使い方

```yaml
inputs:
  - name: body
    type: textarea
    message: "本文を入力してください"
```

## 変更内容

### コア
- `skill-input.ts`: `InputType` に `textarea` を追加

### CLI (`taskp run`)
- `prompt-runner.ts`: `@inquirer/prompts` の `editor` を使用（外部エディタで複数行入力）

### TUI (`taskp tui`)
- `input-form.ts`: OpenTUI の `TextareaRenderable` を使用
  - Meta+Enter（macOS: Cmd+Enter, Linux/Windows: Alt+Enter）で確定
  - 高さは `TEXTAREA_DEFAULT_HEIGHT` (5行) で定数管理

### ドキュメント
- `SKILL-SPEC.md`: InputType 定義と挙動表に `textarea` を追記

### テスト
- `skill-input.test.ts`: textarea パーステスト 2件追加
- `prompt-runner.test.ts`: editor モック追加 + textarea テスト 1件追加