### PR TITLE
feat(tui): add clipboard copy on text selection

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -3,6 +3,7 @@ import { createCliRenderer } from "@opentui/core";
 import { createLanguageModel, resolveModelSpec } from "../adapter/ai-provider";
 import { createDefaultConfigLoader } from "../adapter/config-loader";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
+import { copyToClipboard } from "./clipboard";
 import { showExecution } from "./screens/execution-view";
 import { showInputForm } from "./screens/input-form";
 import { showSkillSelector } from "./screens/skill-selector";
@@ -11,6 +12,13 @@ export async function startTui(): Promise<void> {
 	const renderer = await createCliRenderer({
 		exitOnCtrlC: true,
 		targetFps: 30,
+	});
+
+	renderer.on("selection", (selection) => {
+		const text = selection.getSelectedText();
+		if (text) {
+			copyToClipboard(text);
+		}
 	});
 
 	const skillRepository = createDefaultSkillLoader(process.cwd());

--- a/src/tui/clipboard.ts
+++ b/src/tui/clipboard.ts
@@ -1,0 +1,28 @@
+import { execFile } from "node:child_process";
+
+// OpenTUI の selection イベントハンドラから呼ばれるため、
+// レンダリングをブロックしないよう非同期で実行する
+export function copyToClipboard(text: string): void {
+	const command = resolveClipboardCommand();
+	if (!command) return;
+
+	const child = execFile(command.bin, command.args, { timeout: 3000 });
+	child.stdin?.end(text);
+}
+
+/** @internal テスト用に export */
+export function resolveClipboardCommand(): {
+	readonly bin: string;
+	readonly args: readonly string[];
+} | null {
+	switch (process.platform) {
+		case "darwin":
+			return { bin: "pbcopy", args: [] };
+		case "linux":
+			return { bin: "xclip", args: ["-selection", "clipboard"] };
+		case "win32":
+			return { bin: "clip.exe", args: [] };
+		default:
+			return null;
+	}
+}

--- a/tests/tui/clipboard.test.ts
+++ b/tests/tui/clipboard.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveClipboardCommand } from "../../src/tui/clipboard";
+
+describe("resolveClipboardCommand", () => {
+	it("returns a command object for the current platform", () => {
+		const result = resolveClipboardCommand();
+
+		// CI やローカル環境に依存しないよう、プラットフォームごとに期待値を分岐
+		switch (process.platform) {
+			case "darwin":
+				expect(result).toEqual({ bin: "pbcopy", args: [] });
+				break;
+			case "linux":
+				expect(result).toEqual({
+					bin: "xclip",
+					args: ["-selection", "clipboard"],
+				});
+				break;
+			case "win32":
+				expect(result).toEqual({ bin: "clip.exe", args: [] });
+				break;
+			default:
+				expect(result).toBeNull();
+		}
+	});
+
+	it("returns an object with bin and args properties", () => {
+		const result = resolveClipboardCommand();
+		if (result === null) return; // unsupported platform
+
+		expect(typeof result.bin).toBe("string");
+		expect(Array.isArray(result.args)).toBe(true);
+	});
+});


### PR DESCRIPTION
## 概要

OpenTUI の `selection` イベントを利用して、TUI 上でマウス選択したテキストを自動的にクリップボードにコピーする機能を追加。

## 変更内容

- **`src/tui/clipboard.ts`** — クリップボードコピーユーティリティ
  - 非同期 `execFile` でTUIレンダリングをブロックしない
  - macOS (pbcopy), Linux (xclip), Windows (clip.exe) 対応
- **`src/tui/app.ts`** — renderer の `selection` イベントで `copyToClipboard` を呼び出し
- **`tests/tui/clipboard.test.ts`** — `resolveClipboardCommand` のユニットテスト

## テスト

- `bun run check` ✅ (warnings は既存、今回の変更に無関係)
- `bun test` ✅ 281 pass, 0 fail