### PR TITLE
feat: GitHub経由のインストールをサポート

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 ## インストール
 
 ```bash
-bun install -g taskp
+bun add -g github:takemo101/taskp
 ```
 
 > **必要環境:** Bun >= 1.2.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A CLI tool that runs skills (task procedures) defined in Markdown — collecting
 ## Installation
 
 ```bash
-bun install -g taskp
+bun add -g github:takemo101/taskp
 ```
 
 > **Requirements:** Bun >= 1.2.0

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	],
 	"scripts": {
 		"prepare": "lefthook install",
+    "postinstall": "bun build src/cli.ts --outdir dist --target bun",
 		"dev": "bun run src/cli.ts",
 		"build": "bun build src/cli.ts --outdir dist --target bun",
 		"check": "biome check .",


### PR DESCRIPTION
## 変更内容

- `postinstall` スクリプトを追加（`bun build` を自動実行）
- READMEのインストール手順を `bun add -g github:takemo101/taskp` に更新

これにより `bun add github:takemo101/taskp` でインストール時に自動的にビルドが実行され、CLIが利用可能になります。