### PR TITLE
fix: add error handling for fetchUrl

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,8 @@ import { createDefaultSkillLoader } from "./adapter/skill-loader";
 import { createStreamWriter } from "./adapter/stream-writer";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
-import { type DomainError, EXIT_CODE } from "./core/types/errors";
-import { ok } from "./core/types/result";
+import { type DomainError, EXIT_CODE, executionError } from "./core/types/errors";
+import { err, ok } from "./core/types/result";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
@@ -283,8 +283,16 @@ async function runAgentMode(
 			return ok(result.stdout);
 		},
 		fetchUrl: async (url) => {
-			const response = await fetch(url);
-			return ok(await response.text());
+			try {
+				const response = await fetch(url);
+				if (!response.ok) {
+					return err(executionError(`Failed to fetch URL (HTTP ${response.status}): ${url}`));
+				}
+				return ok(await response.text());
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return err(executionError(`Network error fetching ${url}: ${message}`));
+			}
 		},
 		scanGlob: async (pattern, cwd) => {
 			const { glob } = await import("node:fs/promises");

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -12,8 +12,8 @@ import { createAgentExecutor } from "../../adapter/agent-executor";
 import { createCommandRunner } from "../../adapter/command-runner";
 import { createContextCollector } from "../../adapter/context-collector";
 import type { Skill } from "../../core/skill/skill";
-import type { DomainError } from "../../core/types/errors";
-import { ok } from "../../core/types/result";
+import { type DomainError, executionError } from "../../core/types/errors";
+import { err, ok } from "../../core/types/result";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { runAgentSkill } from "../../usecase/run-agent-skill";
@@ -189,8 +189,16 @@ async function executeAgentMode(
 			return ok(result.stdout);
 		},
 		fetchUrl: async (url) => {
-			const response = await fetch(url);
-			return ok(await response.text());
+			try {
+				const response = await fetch(url);
+				if (!response.ok) {
+					return err(executionError(`Failed to fetch URL (HTTP ${response.status}): ${url}`));
+				}
+				return ok(await response.text());
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return err(executionError(`Network error fetching ${url}: ${message}`));
+			}
 		},
 		scanGlob: async (pattern, cwd) => {
 			const { glob } = await import("node:fs/promises");


### PR DESCRIPTION
#### 概要

fetchUrl の fetch 呼び出しにエラーハンドリングを追加し、ネットワークエラーや HTTP エラーステータスが Result 型で返されるようにした。

#### 変更内容

- `src/cli.ts`: fetchUrl に try-catch と response.ok チェックを追加
- `src/tui/screens/execution-view.ts`: 同様のエラーハンドリングを追加

Closes #131