### PR TITLE
fix: wrap inquirer prompts in try-catch with Result type error handling

### DIFF
--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -1,5 +1,9 @@
 import { confirm, editor, input, number, password, select } from "@inquirer/prompts";
 import type { SkillInput } from "../core/skill/skill-input";
+import type { ExecutionError } from "../core/types/errors";
+import { executionError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { err, ok } from "../core/types/result";
 import type { PromptCollector } from "../usecase/port/prompt-collector";
 
 type PromptFn = (skillInput: SkillInput) => Promise<string>;
@@ -18,24 +22,35 @@ export function createPromptRunner(): PromptCollector {
 		collect: async (
 			inputs: readonly SkillInput[],
 			presets: Readonly<Record<string, string>>,
-		): Promise<Readonly<Record<string, string>>> => {
-			const results: Record<string, string> = {};
+		): Promise<Result<Readonly<Record<string, string>>, ExecutionError>> => {
+			try {
+				const results: Record<string, string> = {};
 
-			for (const skillInput of inputs) {
-				// --set key=value で事前指定された値はプロンプトをスキップする
-				// （CI/スクリプトからの非対話実行を可能にするため）
-				if (skillInput.name in presets) {
-					results[skillInput.name] = presets[skillInput.name];
-					continue;
+				for (const skillInput of inputs) {
+					// --set key=value で事前指定された値はプロンプトをスキップする
+					// （CI/スクリプトからの非対話実行を可能にするため）
+					if (skillInput.name in presets) {
+						results[skillInput.name] = presets[skillInput.name];
+						continue;
+					}
+
+					const promptFn = promptByType[skillInput.type];
+					results[skillInput.name] = await promptFn(skillInput);
 				}
 
-				const promptFn = promptByType[skillInput.type];
-				results[skillInput.name] = await promptFn(skillInput);
+				return ok(results);
+			} catch (error: unknown) {
+				return err(executionError(toErrorMessage(error)));
 			}
-
-			return results;
 		},
 	};
+}
+
+function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
 }
 
 async function askText(skillInput: SkillInput): Promise<string> {

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -169,7 +169,7 @@ function buildSkillRepository(skill: Skill): SkillRepository {
 
 function buildPromptCollector(variables: Readonly<Record<string, string>>): PromptCollector {
 	return {
-		collect: async () => variables as Record<string, string>,
+		collect: async () => ok(variables as Record<string, string>),
 	};
 }
 

--- a/src/usecase/port/prompt-collector.ts
+++ b/src/usecase/port/prompt-collector.ts
@@ -1,8 +1,10 @@
 import type { SkillInput } from "../../core/skill/skill-metadata";
+import type { ExecutionError } from "../../core/types/errors";
+import type { Result } from "../../core/types/result";
 
 export type PromptCollector = {
 	readonly collect: (
 		inputs: readonly SkillInput[],
 		presets: Readonly<Record<string, string>>,
-	) => Promise<Readonly<Record<string, string>>>;
+	) => Promise<Result<Readonly<Record<string, string>>, ExecutionError>>;
 };

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -41,7 +41,11 @@ export async function runAgentSkill(
 	}
 
 	const skill = findResult.value;
-	const variables = await deps.promptCollector.collect(skill.metadata.inputs, input.presets);
+	const collectResult = await deps.promptCollector.collect(skill.metadata.inputs, input.presets);
+	if (!collectResult.ok) {
+		return collectResult;
+	}
+	const variables = collectResult.value;
 
 	const reserved: ReservedVars = {
 		cwd: process.cwd(),

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -45,7 +45,11 @@ export async function runSkill(
 
 	const skill = findResult.value;
 
-	const variables = await deps.promptCollector.collect(skill.metadata.inputs, input.presets);
+	const collectResult = await deps.promptCollector.collect(skill.metadata.inputs, input.presets);
+	if (!collectResult.ok) {
+		return collectResult;
+	}
+	const variables = collectResult.value;
 
 	const reserved: ReservedVars = {
 		cwd: process.cwd(),

--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -33,7 +33,9 @@ describe("PromptRunner", () => {
 		const inputs: SkillInput[] = [{ name: "greeting", type: "text", message: "Enter greeting" }];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ greeting: "hello" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ greeting: "hello" });
 		expect(mockedInput).toHaveBeenCalledWith(
 			expect.objectContaining({ message: "Enter greeting" }),
 		);
@@ -52,7 +54,9 @@ describe("PromptRunner", () => {
 		];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ lang: "opt-b" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ lang: "opt-b" });
 		expect(mockedSelect).toHaveBeenCalledWith(
 			expect.objectContaining({
 				message: "Pick language",
@@ -70,7 +74,9 @@ describe("PromptRunner", () => {
 		const inputs: SkillInput[] = [{ name: "proceed", type: "confirm", message: "Continue?" }];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ proceed: "true" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ proceed: "true" });
 	});
 
 	it("collects number input", async () => {
@@ -79,7 +85,9 @@ describe("PromptRunner", () => {
 		const inputs: SkillInput[] = [{ name: "count", type: "number", message: "How many?" }];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ count: "42" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ count: "42" });
 	});
 
 	it("collects textarea input", async () => {
@@ -88,7 +96,9 @@ describe("PromptRunner", () => {
 		const inputs: SkillInput[] = [{ name: "body", type: "textarea", message: "Enter body" }];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ body: "line1\nline2\nline3" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ body: "line1\nline2\nline3" });
 		expect(mockedEditor).toHaveBeenCalledWith(expect.objectContaining({ message: "Enter body" }));
 	});
 
@@ -98,7 +108,9 @@ describe("PromptRunner", () => {
 		const inputs: SkillInput[] = [{ name: "token", type: "password", message: "Enter token" }];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ token: "secret123" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ token: "secret123" });
 	});
 
 	it("skips questions for preset values", async () => {
@@ -110,7 +122,9 @@ describe("PromptRunner", () => {
 		mockedNumber.mockResolvedValueOnce(25);
 
 		const result = await runner.collect(inputs, { name: "Alice" });
-		expect(result).toEqual({ name: "Alice", age: "25" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ name: "Alice", age: "25" });
 		expect(mockedInput).not.toHaveBeenCalled();
 	});
 
@@ -157,6 +171,20 @@ describe("PromptRunner", () => {
 		];
 
 		const result = await runner.collect(inputs, {});
-		expect(result).toEqual({ name: "Alice", age: "30", ok: "false" });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toEqual({ name: "Alice", age: "30", ok: "false" });
+	});
+
+	it("returns error when prompt throws", async () => {
+		mockedInput.mockRejectedValueOnce(new Error("User force closed the prompt"));
+
+		const inputs: SkillInput[] = [{ name: "name", type: "text", message: "Name?" }];
+
+		const result = await runner.collect(inputs, {});
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("EXECUTION_ERROR");
+		expect(result.error.message).toContain("User force closed the prompt");
 	});
 });

--- a/tests/stubs/stub-prompt-collector.ts
+++ b/tests/stubs/stub-prompt-collector.ts
@@ -1,4 +1,5 @@
 import type { SkillInput } from "../../src/core/skill/skill-metadata";
+import { ok } from "../../src/core/types/result";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 
 export type StubPromptCollector = PromptCollector & {
@@ -11,12 +12,9 @@ export function createStubPromptCollector(
 	const collected: (readonly SkillInput[])[] = [];
 
 	return {
-		collect: async (
-			inputs: readonly SkillInput[],
-			presets: Readonly<Record<string, string>>,
-		): Promise<Readonly<Record<string, string>>> => {
+		collect: async (inputs, presets) => {
 			collected.push(inputs);
-			return { ...presets, ...answers };
+			return ok({ ...presets, ...answers });
 		},
 		get collectedInputs(): readonly (readonly SkillInput[])[] {
 			return [...collected];

--- a/tests/stubs/stubs.test.ts
+++ b/tests/stubs/stubs.test.ts
@@ -80,7 +80,7 @@ describe("StubPromptCollector", () => {
 		const collector = createStubPromptCollector({ name: "Alice" });
 
 		const result = await collector.collect([], { existing: "value" });
-		expect(result).toEqual({ existing: "value", name: "Alice" });
+		expect(result).toEqual(ok({ existing: "value", name: "Alice" }));
 	});
 
 	it("records collected inputs", async () => {

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -40,7 +40,7 @@ function createMockDeps(skill: Skill) {
 	};
 
 	const promptCollector: PromptCollector = {
-		collect: vi.fn().mockResolvedValue({}),
+		collect: vi.fn().mockResolvedValue(ok({})),
 	};
 
 	const contextCollector: ContextCollectorPort = {

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -64,7 +64,7 @@ function stubRepository(skill?: Skill): SkillRepository {
 
 function stubCollector(values: Record<string, string>): PromptCollector {
 	return {
-		collect: async () => values,
+		collect: async () => ok(values),
 	};
 }
 
@@ -209,7 +209,7 @@ echo "step 2 {{env}}"
 				collect: async (_inputs, presets) => {
 					const merged = { env: "production", ...presets };
 					collectedValues.push(merged);
-					return merged;
+					return ok(merged);
 				},
 			},
 		});


### PR DESCRIPTION
#### 概要

PromptCollector の collect メソッドに Result 型のエラーハンドリングを追加し、ユーザーキャンセル（Ctrl+C）や予期しないエラーによるクラッシュを防止。

#### 変更内容

- `PromptCollector.collect` の戻り値を `Promise<Result<Readonly<Record<string, string>>, ExecutionError>>` に変更
- `prompt-runner.ts` の collect メソッドに try-catch を追加し、エラーを `ExecutionError` として返却
- `run-skill.ts` / `run-agent-skill.ts` のコール元で Result 型をアンラップ
- TUI モック・テストスタブ・テストケースを Result 型に対応
- エラーパスの新規テストを追加

Closes #133