### PR TITLE
fix: add error handling for scanGlob in collectGlob

### DIFF
--- a/src/adapter/context-collector.ts
+++ b/src/adapter/context-collector.ts
@@ -84,7 +84,13 @@ async function collectGlob(
 	cwd: string,
 	deps: ContextCollectorDeps,
 ): Promise<Result<readonly CollectedContext[], ExecutionError>> {
-	const paths = await deps.scanGlob(pattern, cwd);
+	let paths: readonly string[];
+	try {
+		paths = await deps.scanGlob(pattern, cwd);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return err(executionError(`Failed to scan glob pattern "${pattern}": ${message}`));
+	}
 	const matches: CollectedContext[] = [];
 
 	for (const path of paths) {


### PR DESCRIPTION
#### 概要

collectGlob 内の deps.scanGlob() 呼び出しに try-catch を追加し、glob パターンの不正やファイルシステムエラー時に Result エラーを返すようにした。

#### 変更内容

- `src/adapter/context-collector.ts`: collectGlob 内で deps.scanGlob() を try-catch でラップし、エラー時に `err(executionError(...))` を返すように変更
- scanGlob 実装自体は変更せず、エラーハンドリングの責務を上位層（collectGlob）に集約

Closes #132