### PR TITLE
refactor: type-safe error message extraction in executeCommands

### DIFF
--- a/src/core/types/errors.ts
+++ b/src/core/types/errors.ts
@@ -71,3 +71,15 @@ export function executionError(message: string): ExecutionError {
 export function configError(message: string): ConfigError {
 	return { type: ErrorType.Config, message };
 }
+
+export function domainErrorMessage(error: DomainError): string {
+	switch (error.type) {
+		case ErrorType.SkillNotFound:
+			return `Skill not found: ${error.name}`;
+		case ErrorType.Parse:
+		case ErrorType.Render:
+		case ErrorType.Execution:
+		case ErrorType.Config:
+			return error.message;
+	}
+}

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,6 +1,6 @@
 import { dirname } from "node:path";
 import type { CodeBlock } from "../core/skill/skill-body";
-import type { DomainError } from "../core/types/errors";
+import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
@@ -114,7 +114,7 @@ async function executeCommands(
 			}
 			results.push({
 				command: renderResult.value,
-				result: { stdout: "", stderr: execResult.error.message, exitCode: 1 },
+				result: { stdout: "", stderr: domainErrorMessage(execResult.error), exitCode: 1 },
 			});
 			continue;
 		}

--- a/tests/core/types/errors.test.ts
+++ b/tests/core/types/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+	configError,
+	domainErrorMessage,
+	executionError,
+	parseError,
+	renderError,
+	skillNotFoundError,
+} from "../../../src/core/types/errors";
+
+describe("domainErrorMessage", () => {
+	it("returns message for ExecutionError", () => {
+		expect(domainErrorMessage(executionError("cmd failed"))).toBe("cmd failed");
+	});
+
+	it("returns message for ParseError", () => {
+		expect(domainErrorMessage(parseError("bad syntax"))).toBe("bad syntax");
+	});
+
+	it("returns message for RenderError", () => {
+		expect(domainErrorMessage(renderError("missing var"))).toBe("missing var");
+	});
+
+	it("returns message for ConfigError", () => {
+		expect(domainErrorMessage(configError("invalid"))).toBe("invalid");
+	});
+
+	it("returns formatted message for SkillNotFoundError", () => {
+		expect(domainErrorMessage(skillNotFoundError("my-skill"))).toBe(
+			"Skill not found: my-skill",
+		);
+	});
+});


### PR DESCRIPTION
#### 概要

`run-skill.ts` の `executeCommands` で `execResult.error.message` に直接アクセスしていた箇所を、型安全なヘルパー関数に置き換え。

#### 変更内容

- `domainErrorMessage` ヘルパー関数を `src/core/types/errors.ts` に追加（全 `DomainError` バリアントを exhaustive switch で処理）
- `run-skill.ts` の直接 `.message` アクセスを `domainErrorMessage()` 呼び出しに置換
- `domainErrorMessage` の全バリアントをカバーするユニットテストを追加

Closes #134