### PR TITLE
fix: wrap streamText in try-catch for error handling

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -23,41 +23,49 @@ async function executeAgentLoop(
 	const startTime = Date.now();
 	const tools = buildTools(input.toolNames) as ToolSet;
 
-	const result = streamText({
-		model: input.model,
-		system: input.systemPrompt,
-		prompt: input.context,
-		tools,
-		stopWhen: stepCountIs(input.maxSteps),
-	});
+	try {
+		const result = streamText({
+			model: input.model,
+			system: input.systemPrompt,
+			prompt: input.context,
+			tools,
+			stopWhen: stepCountIs(input.maxSteps),
+		});
 
-	for await (const part of result.fullStream) {
-		switch (part.type) {
-			case "text-delta":
-				writer.writeText(part.text);
-				break;
-			case "tool-call":
-				writer.writeToolCall(part.toolName, part.input as Record<string, unknown>);
-				break;
-			case "tool-result":
-				writer.writeToolResult(part.toolName, part.output);
-				break;
-			case "error":
-				return err(executionError(String(part.error)));
+		for await (const part of result.fullStream) {
+			switch (part.type) {
+				case "text-delta":
+					writer.writeText(part.text);
+					break;
+				case "tool-call":
+					writer.writeToolCall(part.toolName, part.input as Record<string, unknown>);
+					break;
+				case "tool-result":
+					writer.writeToolResult(part.toolName, part.output);
+					break;
+				case "error":
+					return err(executionError(String(part.error)));
+			}
 		}
+
+		const steps = await result.steps;
+		const text = await result.text;
+		const elapsedMs = Date.now() - startTime;
+
+		writer.writeSummary(elapsedMs, steps.length);
+
+		const agentResult: AgentExecutorResult = {
+			output: text,
+			steps: steps.length,
+			elapsedMs,
+		};
+
+		return ok(agentResult);
+	} catch (error) {
+		return err(
+			executionError(
+				`Agent execution failed: ${error instanceof Error ? error.message : String(error)}`,
+			),
+		);
 	}
-
-	const steps = await result.steps;
-	const text = await result.text;
-	const elapsedMs = Date.now() - startTime;
-
-	writer.writeSummary(elapsedMs, steps.length);
-
-	const agentResult: AgentExecutorResult = {
-		output: text,
-		steps: steps.length,
-		elapsedMs,
-	};
-
-	return ok(agentResult);
 }

--- a/src/core/execution/agent-executor.ts
+++ b/src/core/execution/agent-executor.ts
@@ -32,29 +32,37 @@ async function executeAgentLoop(
 ): Promise<Result<AgentResult, ExecutionError>> {
 	const tools = buildTools(input.toolNames);
 
-	const result = streamText({
-		model: input.model,
-		system: input.systemPrompt,
-		prompt: input.context,
-		tools,
-		stopWhen: stepCountIs(MAX_STEPS),
-	});
+	try {
+		const result = streamText({
+			model: input.model,
+			system: input.systemPrompt,
+			prompt: input.context,
+			tools,
+			stopWhen: stepCountIs(MAX_STEPS),
+		});
 
-	const chunks: string[] = [];
-	for await (const chunk of result.textStream) {
-		chunks.push(chunk);
-		process.stdout.write(chunk);
+		const chunks: string[] = [];
+		for await (const chunk of result.textStream) {
+			chunks.push(chunk);
+			process.stdout.write(chunk);
+		}
+
+		const finalResult = await result;
+		const steps = await finalResult.steps;
+		const stepCount = steps.length;
+
+		if (isMaxStepsExceeded(steps)) {
+			return err(executionError(`Agent loop exceeded maximum steps (${MAX_STEPS}). Aborting.`));
+		}
+
+		return ok({ output: chunks.join(""), steps: stepCount });
+	} catch (error) {
+		return err(
+			executionError(
+				`Agent execution failed: ${error instanceof Error ? error.message : String(error)}`,
+			),
+		);
 	}
-
-	const finalResult = await result;
-	const steps = await finalResult.steps;
-	const stepCount = steps.length;
-
-	if (isMaxStepsExceeded(steps)) {
-		return err(executionError(`Agent loop exceeded maximum steps (${MAX_STEPS}). Aborting.`));
-	}
-
-	return ok({ output: chunks.join(""), steps: stepCount });
 }
 
 function isMaxStepsExceeded(steps: readonly { readonly finishReason: string }[]): boolean {


### PR DESCRIPTION
#### 概要

executeAgentLoop の streamText 呼び出しとストリーム反復処理を try-catch で囲み、API エラーやネットワークタイムアウトがプログラムをクラッシュさせる代わりに Result エラーとして返されるようにした。

#### 変更内容

- `src/adapter/agent-executor.ts`: streamText + fullStream 反復 + result 取得を try-catch でラップ
- `src/core/execution/agent-executor.ts`: streamText + textStream 反復 + result 取得を try-catch でラップ

Closes #135