### PR TITLE
refactor: replace unsafe type assertions with proper type guards in isNetworkError

### DIFF
--- a/src/adapter/agent-error-handler.ts
+++ b/src/adapter/agent-error-handler.ts
@@ -99,17 +99,27 @@ function isNetworkError(error: unknown): boolean {
 		"ENOTFOUND",
 		"UND_ERR_CONNECT_TIMEOUT",
 	];
-	const cause = (error as { cause?: { code?: string } }).cause;
-	if (cause?.code !== undefined && networkCodes.includes(cause.code)) {
+	if (hasCauseWithCode(error, networkCodes)) {
 		return true;
 	}
 
-	const code = (error as { code?: string }).code;
-	if (code !== undefined && networkCodes.includes(code)) {
+	if (hasCode(error, networkCodes)) {
 		return true;
 	}
 
 	return false;
+}
+
+function hasCauseWithCode(error: Error, codes: readonly string[]): boolean {
+	const { cause } = error;
+	if (typeof cause !== "object" || cause === null) return false;
+	if (!("code" in cause) || typeof cause.code !== "string") return false;
+	return codes.includes(cause.code);
+}
+
+function hasCode(error: Error, codes: readonly string[]): boolean {
+	if (!("code" in error) || typeof error.code !== "string") return false;
+	return codes.includes(error.code);
 }
 
 const API_KEY_ENV_VARS: Record<string, string> = {


### PR DESCRIPTION
#### 概要

`isNetworkError` 関数の unsafe な `as` 型アサーションを、`in` 演算子と `typeof` による適切な型ガードに置き換え。

#### 変更内容

- `hasCauseWithCode` / `hasCode` ヘルパー関数を追加し、ランタイム型チェックを実装
- `isNetworkError` から `as` キャストを完全に除去
- 既存テスト18件すべてパス、型チェッククリーン

Closes #136