### PR TITLE
refactor: buildTools を Result 型返却に変更

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -21,7 +21,11 @@ async function executeAgentLoop(
 	writer: StreamWriter,
 ): ReturnType<AgentExecutorPort["execute"]> {
 	const startTime = Date.now();
-	const tools = buildTools(input.toolNames) as ToolSet;
+	const toolsResult = buildTools(input.toolNames);
+	if (!toolsResult.ok) {
+		return toolsResult;
+	}
+	const tools = toolsResult.value as ToolSet;
 
 	const result = streamText({
 		model: input.model,

--- a/src/core/execution/agent-executor.ts
+++ b/src/core/execution/agent-executor.ts
@@ -30,7 +30,11 @@ export function createAgentExecutor() {
 async function executeAgentLoop(
 	input: AgentExecutorInput,
 ): Promise<Result<AgentResult, ExecutionError>> {
-	const tools = buildTools(input.toolNames);
+	const toolsResult = buildTools(input.toolNames);
+	if (!toolsResult.ok) {
+		return toolsResult;
+	}
+	const tools = toolsResult.value;
 
 	const result = streamText({
 		model: input.model,

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -4,6 +4,8 @@ import type { JSONSchema7, Tool } from "ai";
 import { jsonSchema } from "ai";
 import { execa } from "execa";
 import { toJSONSchema, z } from "zod";
+import { type ExecutionError, executionError } from "../types/errors";
+import { err, ok, type Result } from "../types/result";
 
 // Vercel AI SDK は JSONSchema7 形式のツール定義を要求するが、
 // zod スキーマから直接変換する公式 API がないため、
@@ -115,17 +117,17 @@ const allTools: Record<ToolName, Tool<any, any>> = {
 export function buildTools(
 	toolNames: readonly string[],
 	// biome-ignore lint/suspicious/noExplicitAny: Tool generic variance prevents strict typing
-): Record<string, Tool<any, any>> {
+): Result<Record<string, Tool<any, any>>, ExecutionError> {
 	// biome-ignore lint/suspicious/noExplicitAny: Tool generic variance prevents strict typing
 	const tools: Record<string, Tool<any, any>> = {};
 	for (const name of toolNames) {
 		const t = allTools[name as ToolName];
 		if (t === undefined) {
-			throw new Error(`Unknown tool: ${name}`);
+			return err(executionError(`Unknown tool: ${name}`));
 		}
 		tools[name] = t;
 	}
-	return tools;
+	return ok(tools);
 }
 
 export type { ToolName };

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -6,30 +6,48 @@ import { buildTools, TOOL_NAMES } from "../../../src/core/execution/agent-tools"
 
 describe("buildTools", () => {
 	it("指定したツール名に対応するツールを返す", () => {
-		const tools = buildTools(["bash", "read"]);
-		expect(Object.keys(tools)).toEqual(["bash", "read"]);
-		expect(tools.bash.execute).toBeTypeOf("function");
-		expect(tools.read.execute).toBeTypeOf("function");
+		const result = buildTools(["bash", "read"]);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(Object.keys(result.value)).toEqual(["bash", "read"]);
+		expect(result.value.bash.execute).toBeTypeOf("function");
+		expect(result.value.read.execute).toBeTypeOf("function");
 	});
 
 	it("すべてのツールを取得できる", () => {
-		const tools = buildTools([...TOOL_NAMES]);
-		expect(Object.keys(tools)).toHaveLength(5);
+		const result = buildTools([...TOOL_NAMES]);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(Object.keys(result.value)).toHaveLength(5);
 	});
 
 	it("空のツール名配列で空のオブジェクトを返す", () => {
-		const tools = buildTools([]);
-		expect(Object.keys(tools)).toHaveLength(0);
+		const result = buildTools([]);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(Object.keys(result.value)).toHaveLength(0);
 	});
 
-	it("不明なツール名でエラーを投げる", () => {
-		expect(() => buildTools(["unknown_tool"])).toThrow("Unknown tool: unknown_tool");
+	it("不明なツール名で ExecutionError を返す", () => {
+		const result = buildTools(["unknown_tool"]);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toEqual({
+			type: "EXECUTION_ERROR",
+			message: "Unknown tool: unknown_tool",
+		});
 	});
 });
 
+function unwrapTools(toolNames: readonly string[]) {
+	const result = buildTools(toolNames);
+	if (!result.ok) throw new Error("buildTools failed unexpectedly");
+	return result.value;
+}
+
 describe("bash tool", () => {
 	it("シェルコマンドを実行して stdout を返す", async () => {
-		const tools = buildTools(["bash"]);
+		const tools = unwrapTools(["bash"]);
 		const result = await tools.bash.execute?.(
 			{ command: "echo hello" },
 			{ toolCallId: "1", messages: [], abortSignal: AbortSignal.timeout(5000) },
@@ -38,7 +56,7 @@ describe("bash tool", () => {
 	});
 
 	it("失敗したコマンドの exitCode と stderr を返す", async () => {
-		const tools = buildTools(["bash"]);
+		const tools = unwrapTools(["bash"]);
 		const result = (await tools.bash.execute?.(
 			{ command: "echo err >&2 && exit 1" },
 			{ toolCallId: "2", messages: [], abortSignal: AbortSignal.timeout(5000) },
@@ -50,7 +68,7 @@ describe("bash tool", () => {
 
 describe("read tool", () => {
 	it("ファイルの内容を読み込む", async () => {
-		const tools = buildTools(["read"]);
+		const tools = unwrapTools(["read"]);
 		const result = await tools.read.execute?.(
 			{ path: join(__dirname, "agent-tools.test.ts") },
 			{ toolCallId: "3", messages: [], abortSignal: AbortSignal.timeout(5000) },
@@ -64,7 +82,7 @@ describe("write tool", () => {
 		const dir = await mkdtemp(join(tmpdir(), "agent-tools-test-"));
 		const filePath = join(dir, "test.txt");
 		try {
-			const tools = buildTools(["write"]);
+			const tools = unwrapTools(["write"]);
 			const result = await tools.write.execute?.(
 				{ path: filePath, content: "hello world" },
 				{ toolCallId: "4", messages: [], abortSignal: AbortSignal.timeout(5000) },
@@ -80,7 +98,7 @@ describe("write tool", () => {
 
 describe("glob tool", () => {
 	it("パターンにマッチするファイルを返す", async () => {
-		const tools = buildTools(["glob"]);
+		const tools = unwrapTools(["glob"]);
 		const result = (await tools.glob.execute?.(
 			{ pattern: "tests/core/execution/*.test.ts" },
 			{ toolCallId: "5", messages: [], abortSignal: AbortSignal.timeout(5000) },


### PR DESCRIPTION
#### 概要

buildTools が未知のツール名に対して例外を投げていたのを、Result 型を返すように変更し、プロジェクトのエラーハンドリング規約に準拠させた。

#### 変更内容

- `buildTools` の戻り値を `Result<Record<string, Tool>, ExecutionError>` に変更
- `src/core/execution/agent-executor.ts` の呼び出し元で Result を処理するよう更新
- `src/adapter/agent-executor.ts` の呼び出し元で Result を処理するよう更新
- テストを Result 型の検証に更新

Closes #153