### PR TITLE
fix: add error handling to read/write/glob tool execute methods

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -62,7 +62,11 @@ const readTool: Tool<ReadInput, string> = {
 	description: "Read the contents of a file",
 	inputSchema: zodToJsonSchema(readParams),
 	execute: async ({ path }) => {
-		return await readFile(path, "utf-8");
+		try {
+			return await readFile(path, "utf-8");
+		} catch (error) {
+			throw new Error(`Failed to read file: ${path}`, { cause: error });
+		}
 	},
 };
 
@@ -72,8 +76,12 @@ const writeTool: Tool<WriteInput, string> = {
 	description: "Write content to a file",
 	inputSchema: zodToJsonSchema(writeParams),
 	execute: async ({ path, content }) => {
-		await writeFile(path, content, "utf-8");
-		return `Written to ${path}`;
+		try {
+			await writeFile(path, content, "utf-8");
+			return `Written to ${path}`;
+		} catch (error) {
+			throw new Error(`Failed to write file: ${path}`, { cause: error });
+		}
 	},
 };
 
@@ -83,11 +91,15 @@ const globTool: Tool<GlobInput, readonly string[]> = {
 	description: "Search for files matching a glob pattern",
 	inputSchema: zodToJsonSchema(globParams),
 	execute: async ({ pattern }) => {
-		const matches: string[] = [];
-		for await (const entry of fsGlob(pattern)) {
-			matches.push(entry);
+		try {
+			const matches: string[] = [];
+			for await (const entry of fsGlob(pattern)) {
+				matches.push(entry);
+			}
+			return matches;
+		} catch (error) {
+			throw new Error(`Failed to glob pattern: ${pattern}`, { cause: error });
 		}
-		return matches;
 	},
 };
 

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -57,6 +57,16 @@ describe("read tool", () => {
 		);
 		expect(result).toContain("describe");
 	});
+
+	it("存在しないファイルでエラーを投げる", async () => {
+		const tools = buildTools(["read"]);
+		await expect(
+			tools.read.execute?.(
+				{ path: "/nonexistent/path/file.txt" },
+				{ toolCallId: "3", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			),
+		).rejects.toThrow("Failed to read file: /nonexistent/path/file.txt");
+	});
 });
 
 describe("write tool", () => {
@@ -75,6 +85,17 @@ describe("write tool", () => {
 		} finally {
 			await rm(dir, { recursive: true });
 		}
+	});
+
+	it("存在しないディレクトリへの書き込みでエラーを投げる", async () => {
+		const tools = buildTools(["write"]);
+		const invalidPath = "/nonexistent/dir/file.txt";
+		await expect(
+			tools.write.execute?.(
+				{ path: invalidPath, content: "test" },
+				{ toolCallId: "4", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			),
+		).rejects.toThrow(`Failed to write file: ${invalidPath}`);
 	});
 });
 


### PR DESCRIPTION
#### 概要

read/write/glob ツールの execute メソッドにエラーハンドリングを追加し、ファイルシステム操作の例外が未処理のまま伝播する問題を修正。

#### 変更内容

- `readTool`, `writeTool`, `globTool` の execute メソッドを try-catch でラップ
- エラーメッセージにファイルパス/glob パターンのコンテキストを含め、元のエラーを cause として保持
- エラーケースのテストを追加（存在しないファイルの読み込み、無効なディレクトリへの書き込み）

Closes #155