### PR TITLE
fix: wrap filesystem operations in skill-initializer with error handling

### DIFF
--- a/src/adapter/skill-initializer.ts
+++ b/src/adapter/skill-initializer.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Result } from "../core/types/result";
-import { ok } from "../core/types/result";
+import { err, ok } from "../core/types/result";
 import type { InitOptions, SkillInitializer } from "../usecase/port/skill-initializer";
 
 const SKILL_DIR_NAME = ".taskp/skills";
@@ -57,8 +57,13 @@ export function createSkillInitializer(deps: SkillInitializerDeps): SkillInitial
 			const skillDir = join(deps.baseDir, SKILL_DIR_NAME, name);
 			const skillPath = join(skillDir, SKILL_FILE_NAME);
 
-			await mkdir(skillDir, { recursive: true });
-			await writeFile(skillPath, generateSkillContent(name, options), "utf-8");
+			try {
+				await mkdir(skillDir, { recursive: true });
+				await writeFile(skillPath, generateSkillContent(name, options), "utf-8");
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return err(new Error(`Failed to create skill "${name}": ${message}`));
+			}
 
 			return ok(skillPath);
 		},

--- a/tests/adapter/skill-initializer.test.ts
+++ b/tests/adapter/skill-initializer.test.ts
@@ -47,6 +47,20 @@ describe("createSkillInitializer", () => {
 		expect(content).toContain("```bash");
 	});
 
+	it("returns error when directory creation fails", async () => {
+		const initializer = createSkillInitializer({ baseDir: "/nonexistent/readonly/path" });
+
+		const result = await initializer.create("my-task", {
+			mode: "template",
+			description: "my-task skill",
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toContain('Failed to create skill "my-task"');
+		}
+	});
+
 	it("generates agent mode content", async () => {
 		const initializer = createSkillInitializer({ baseDir });
 


### PR DESCRIPTION
#### 概要

skill-initializer.ts の mkdir/writeFile を try-catch で囲み、ファイルシステムエラーを Result 型で返すように修正。

#### 変更内容

- `createSkillInitializer` の `create` メソッドで mkdir/writeFile を try-catch でラップ
- エラー時は `err(new Error(...))` を返却（既存の config-loader パターンに準拠）
- エラーケースのテストを追加

Closes #154