### PR TITLE
fix: validate regex compilation in prompt-runner validators

### DIFF
--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -98,7 +98,7 @@ async function askPassword(skillInput: SkillInput): Promise<string> {
 function buildValidator(skillInput: SkillInput): ((value: string) => string | true) | undefined {
 	if (!skillInput.validate) return undefined;
 
-	const regex = new RegExp(skillInput.validate);
+	const regex = compileRegex(skillInput.validate);
 	return (value: string) => {
 		if (!regex.test(value)) {
 			return `Input must match pattern: ${skillInput.validate}`;
@@ -112,7 +112,7 @@ function buildNumberValidator(
 ): ((value: number | undefined) => string | true) | undefined {
 	if (!skillInput.validate) return undefined;
 
-	const regex = new RegExp(skillInput.validate);
+	const regex = compileRegex(skillInput.validate);
 	return (value: number | undefined) => {
 		if (value === undefined) return true;
 		if (!regex.test(String(value))) {
@@ -120,4 +120,12 @@ function buildNumberValidator(
 		}
 		return true;
 	};
+}
+
+function compileRegex(pattern: string): RegExp {
+	try {
+		return new RegExp(pattern);
+	} catch (cause) {
+		throw new Error(`Invalid regex pattern: ${pattern}`, { cause });
+	}
 }

--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -145,6 +145,19 @@ describe("PromptRunner", () => {
 		expect(callArgs.validate!("INVALID")).toEqual(expect.stringContaining("must match"));
 	});
 
+	it("throws on invalid validate regex pattern", async () => {
+		const inputs: SkillInput[] = [
+			{
+				name: "code",
+				type: "text",
+				message: "Code?",
+				validate: "[invalid(",
+			},
+		];
+
+		await expect(runner.collect(inputs, {})).rejects.toThrow("Invalid regex pattern: [invalid(");
+	});
+
 	it("collects multiple inputs in order", async () => {
 		mockedInput.mockResolvedValueOnce("Alice");
 		mockedNumber.mockResolvedValueOnce(30);


### PR DESCRIPTION
#### 概要

`buildValidator` と `buildNumberValidator` で `new RegExp()` の無効パターンによる SyntaxError を防止する。

#### 変更内容

- `compileRegex` ヘルパー関数を追加し、無効な正規表現パターンに対して明確なエラーメッセージを投げるように変更
- `buildValidator` と `buildNumberValidator` の両方で `compileRegex` を使用
- 無効な正規表現パターンに対するテストケースを追加

Closes #158