### PR TITLE
fix: wrap streamText with try-catch in agent-executor

### DIFF
--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -77,7 +77,7 @@ describe("read tool", () => {
 	});
 
 	it("存在しないファイルでエラーを投げる", async () => {
-		const tools = buildTools(["read"]);
+		const tools = unwrapTools(["read"]);
 		await expect(
 			tools.read.execute?.(
 				{ path: "/nonexistent/path/file.txt" },
@@ -106,7 +106,7 @@ describe("write tool", () => {
 	});
 
 	it("存在しないディレクトリへの書き込みでエラーを投げる", async () => {
-		const tools = buildTools(["write"]);
+		const tools = unwrapTools(["write"]);
 		const invalidPath = "/nonexistent/dir/file.txt";
 		await expect(
 			tools.write.execute?.(


### PR DESCRIPTION
#### 概要

agent-executor.ts の streamText 呼び出しに try-catch を追加し、エラーハンドリングを改善。

#### 変更内容

- `executeAgentLoop` 内の `streamText` 呼び出しと async iteration を try-catch で囲む
- `buildTools` の戻り値を Result 型として適切にハンドリング
- テストの型エラー修正: `buildTools` → `unwrapTools` に変更（Result 型の適切なアンラップ）

Closes #127