### PR TITLE
refactor: buildTools returns Result instead of throwing exception

### DIFF
--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -156,8 +156,8 @@ describe("PromptRunner", () => {
 
 		const callArgs = mockedInput.mock.calls[0][0] as { validate?: (v: string) => string | true };
 		expect(callArgs.validate).toBeDefined();
-		expect(callArgs.validate!("abc123")).toBe(true);
-		expect(callArgs.validate!("INVALID")).toEqual(expect.stringContaining("must match"));
+		expect(callArgs.validate?.("abc123")).toBe(true);
+		expect(callArgs.validate?.("INVALID")).toEqual(expect.stringContaining("must match"));
 	});
 
 	it("returns error on invalid validate regex pattern", async () => {

--- a/tests/core/types/errors.test.ts
+++ b/tests/core/types/errors.test.ts
@@ -26,8 +26,6 @@ describe("domainErrorMessage", () => {
 	});
 
 	it("returns formatted message for SkillNotFoundError", () => {
-		expect(domainErrorMessage(skillNotFoundError("my-skill"))).toBe(
-			"Skill not found: my-skill",
-		);
+		expect(domainErrorMessage(skillNotFoundError("my-skill"))).toBe("Skill not found: my-skill");
 	});
 });


### PR DESCRIPTION
#### 概要

buildTools 関数が例外をスローする代わりに Result 型を返すようにリファクタリングし、エラーハンドリングの一貫性を向上。

#### 変更内容

- buildTools が Result<Record<string, Tool>, ExecutionError> を返すように変更
- 全呼び出し元（core/execution/agent-executor.ts, adapter/agent-executor.ts）で Result ハンドリングを追加
- テストを Result 型に対応するよう更新
- lint 修正（非null アサーション → オプショナルチェーン）

Closes #146