### PR TITLE
fix: extract shared context-collector deps with proper error wrapping

### DIFF
--- a/src/adapter/context-collector-deps.ts
+++ b/src/adapter/context-collector-deps.ts
@@ -1,0 +1,58 @@
+import { executionError } from "../core/types/errors";
+import { err, ok } from "../core/types/result";
+import type { ContextCollectorDeps } from "./context-collector";
+
+export async function createDefaultContextCollectorDeps(): Promise<ContextCollectorDeps> {
+	const { execa } = await import("execa");
+	const { glob } = await import("node:fs/promises");
+
+	return {
+		executeCommand: async (command, cwd) => {
+			try {
+				const result = await execa(command, {
+					shell: true,
+					cwd,
+					reject: false,
+				});
+				if (result.failed) {
+					return err(
+						executionError(
+							`Command failed (exit ${result.exitCode}): ${command}${result.stderr ? `\n${result.stderr}` : ""}`,
+						),
+					);
+				}
+				return ok(result.stdout);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return err(executionError(`Failed to execute command: ${command} (${message})`));
+			}
+		},
+		fetchUrl: async (url) => {
+			try {
+				const response = await fetch(url);
+				if (!response.ok) {
+					return err(executionError(`Failed to fetch URL (HTTP ${response.status}): ${url}`));
+				}
+				return ok(await response.text());
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return err(executionError(`Network error fetching ${url}: ${message}`));
+			}
+		},
+		scanGlob: async (pattern, cwd) => {
+			try {
+				const matches: string[] = [];
+				for await (const entry of glob(pattern, { cwd })) {
+					matches.push(entry);
+				}
+				return ok(matches);
+			} catch (e) {
+				return err(
+					executionError(
+						`Failed to scan glob: ${pattern} (${e instanceof Error ? e.message : String(e)})`,
+					),
+				);
+			}
+		},
+	};
+}

--- a/src/adapter/context-collector.ts
+++ b/src/adapter/context-collector.ts
@@ -11,7 +11,7 @@ type CollectedContext = {
 	readonly content: string;
 };
 
-type ContextCollectorDeps = {
+export type ContextCollectorDeps = {
 	readonly executeCommand: (
 		command: string,
 		cwd: string,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,14 +5,14 @@ import { createLanguageModel, resolveModelSpec } from "./adapter/ai-provider";
 import { createCommandRunner } from "./adapter/command-runner";
 import { createDefaultConfigLoader } from "./adapter/config-loader";
 import { createContextCollector } from "./adapter/context-collector";
+import { createDefaultContextCollectorDeps } from "./adapter/context-collector-deps";
 import { createPromptRunner } from "./adapter/prompt-runner";
 import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
 import { createStreamWriter } from "./adapter/stream-writer";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
-import { type DomainError, EXIT_CODE, executionError } from "./core/types/errors";
-import { err, ok } from "./core/types/result";
+import { type DomainError, EXIT_CODE } from "./core/types/errors";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
@@ -276,41 +276,8 @@ async function runAgentMode(
 		output: process.stdout,
 	});
 
-	const contextCollector = createContextCollector({
-		executeCommand: async (command, cwd) => {
-			const { execa } = await import("execa");
-			const result = await execa(command, { shell: true, cwd, reject: false });
-			return ok(result.stdout);
-		},
-		fetchUrl: async (url) => {
-			try {
-				const response = await fetch(url);
-				if (!response.ok) {
-					return err(executionError(`Failed to fetch URL (HTTP ${response.status}): ${url}`));
-				}
-				return ok(await response.text());
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return err(executionError(`Network error fetching ${url}: ${message}`));
-			}
-		},
-		scanGlob: async (pattern, cwd) => {
-			try {
-				const { glob } = await import("node:fs/promises");
-				const matches: string[] = [];
-				for await (const entry of glob(pattern, { cwd })) {
-					matches.push(entry);
-				}
-				return ok(matches);
-			} catch (e) {
-				return err(
-					executionError(
-						`Failed to scan glob: ${pattern} (${e instanceof Error ? e.message : String(e)})`,
-					),
-				);
-			}
-		},
-	});
+	const contextCollectorDeps = await createDefaultContextCollectorDeps();
+	const contextCollector = createContextCollector(contextCollectorDeps);
 
 	const agentExecutor = createAgentExecutor(writer);
 

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -11,9 +11,10 @@ import {
 import { createAgentExecutor } from "../../adapter/agent-executor";
 import { createCommandRunner } from "../../adapter/command-runner";
 import { createContextCollector } from "../../adapter/context-collector";
+import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
 import type { Skill } from "../../core/skill/skill";
-import { type DomainError, executionError } from "../../core/types/errors";
-import { err, ok } from "../../core/types/result";
+import type { DomainError } from "../../core/types/errors";
+import { ok } from "../../core/types/result";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { runAgentSkill } from "../../usecase/run-agent-skill";
@@ -182,41 +183,8 @@ async function executeAgentMode(
 	const writer = createTuiStreamWriter(viewPort);
 	const agentExecutor = createAgentExecutor(writer);
 
-	const contextCollector = createContextCollector({
-		executeCommand: async (command, cwd) => {
-			const { execaCommand } = await import("execa");
-			const result = await execaCommand(command, { shell: true, cwd, reject: false });
-			return ok(result.stdout);
-		},
-		fetchUrl: async (url) => {
-			try {
-				const response = await fetch(url);
-				if (!response.ok) {
-					return err(executionError(`Failed to fetch URL (HTTP ${response.status}): ${url}`));
-				}
-				return ok(await response.text());
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return err(executionError(`Network error fetching ${url}: ${message}`));
-			}
-		},
-		scanGlob: async (pattern, cwd) => {
-			try {
-				const { glob } = await import("node:fs/promises");
-				const matches: string[] = [];
-				for await (const entry of glob(pattern, { cwd })) {
-					matches.push(entry);
-				}
-				return ok(matches);
-			} catch (e) {
-				return err(
-					executionError(
-						`Failed to scan glob: ${pattern} (${e instanceof Error ? e.message : String(e)})`,
-					),
-				);
-			}
-		},
-	});
+	const contextCollectorDeps = await createDefaultContextCollectorDeps();
+	const contextCollector = createContextCollector(contextCollectorDeps);
 
 	const result = await runAgentSkill(
 		{ name: skill.metadata.name, presets: variables, model },

--- a/tests/adapter/context-collector-deps.test.ts
+++ b/tests/adapter/context-collector-deps.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createDefaultContextCollectorDeps } from "../../src/adapter/context-collector-deps";
+
+describe("createDefaultContextCollectorDeps", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "context-deps-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	describe("executeCommand", () => {
+		it("returns stdout on success", async () => {
+			const deps = await createDefaultContextCollectorDeps();
+
+			const result = await deps.executeCommand("echo hello", tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toBe("hello");
+		});
+
+		it("returns error on command failure", async () => {
+			const deps = await createDefaultContextCollectorDeps();
+
+			const result = await deps.executeCommand("exit 1", tempDir);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			expect(result.error.message).toContain("Command failed (exit 1)");
+		});
+	});
+
+	describe("fetchUrl", () => {
+		it("returns error for non-existent host", async () => {
+			const deps = await createDefaultContextCollectorDeps();
+
+			const result = await deps.fetchUrl("http://this-domain-does-not-exist.invalid");
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			expect(result.error.message).toContain("Network error fetching");
+		});
+	});
+
+	describe("scanGlob", () => {
+		it("returns matching files", async () => {
+			await writeFile(join(tempDir, "a.txt"), "");
+			await writeFile(join(tempDir, "b.txt"), "");
+			await writeFile(join(tempDir, "c.md"), "");
+
+			const deps = await createDefaultContextCollectorDeps();
+
+			const result = await deps.scanGlob("*.txt", tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toHaveLength(2);
+			expect([...result.value].sort()).toEqual(["a.txt", "b.txt"]);
+		});
+
+		it("returns empty array for no matches", async () => {
+			const deps = await createDefaultContextCollectorDeps();
+
+			const result = await deps.scanGlob("*.xyz", tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toHaveLength(0);
+		});
+	});
+});


### PR DESCRIPTION
#### 概要

context-collector の依存関数を共有モジュールに抽出し、エラーハンドリングを統一・修正。

#### 変更内容

- `context-collector-deps.ts` に共有の deps ファクトリを抽出（cli.ts と execution-view.ts の重複解消）
- `executeCommand` がコマンド失敗時に `err()` を返すように修正（以前は `ok("")` を返していた）
- execa API 使用を統一（`execaCommand` → `execa`）
- `ContextCollectorDeps` 型を export
- 新規テスト追加

Closes #149