### PR TITLE
fix: include underlying error message in collectGlob error

### DIFF
--- a/src/adapter/context-collector.ts
+++ b/src/adapter/context-collector.ts
@@ -101,8 +101,11 @@ async function collectGlob(
 		try {
 			const content = await readFile(fullPath, "utf-8");
 			matches.push({ source: { type: "glob", pattern }, content });
-		} catch {
-			return err(executionError(`Failed to read glob match (${i + 1}/${total}): ${fullPath}`));
+		} catch (e) {
+			const message = e instanceof Error ? e.message : String(e);
+			return err(
+				executionError(`Failed to read glob match (${i + 1}/${total}): ${fullPath}: ${message}`),
+			);
 		}
 	}
 


### PR DESCRIPTION
#### 概要

collectGlob のエラーメッセージに根本原因のエラーメッセージを含めるように修正。

#### 変更内容

- catch ブロックでエラーオブジェクトを捕捉し、`e.message` をエラーメッセージに追加
- デバッグ時にファイル読み取り失敗の原因（権限エラー、パスが無効等）が即座にわかるように改善

Closes #152