### PR TITLE
fix: --no-input を --skip-prompt にリネームし、list コマンドの表示を改善

### DIFF
--- a/docs/CLI-SPEC.md
+++ b/docs/CLI-SPEC.md
@@ -34,7 +34,7 @@ taskp run deploy --env production --branch main   # 質問をスキップ
 | `--dry-run` | | `boolean` | `false` | 実行計画を表示するが実行しない |
 | `--force` | `-f` | `boolean` | `false` | エラー時も続行する（template モード） |
 | `--verbose` | `-v` | `boolean` | `false` | 詳細ログを表示 |
-| `--no-input` | | `boolean` | `false` | 対話的質問を無効化（デフォルト値を使用） |
+| `--skip-prompt` | | `boolean` | `false` | 対話的質問を無効化（デフォルト値を使用） |
 | `--set` | `-s` | `string[]` | `[]` | 変数を直接指定（`--set key=value`） |
 
 #### 変数の直接指定
@@ -45,8 +45,8 @@ taskp run deploy --env production --branch main   # 質問をスキップ
 # --set で個別指定
 taskp run deploy --set environment=production --set branch=main
 
-# --no-input でデフォルト値を使用
-taskp run deploy --no-input
+# --skip-prompt でデフォルト値を使用
+taskp run deploy --skip-prompt
 ```
 
 #### 出力

--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -62,7 +62,7 @@ function resolveNonInteractive(skillInput: SkillInput): Result<string, Execution
 	if (skillInput.required !== false) {
 		return err(
 			executionError(
-				`Input "${skillInput.name}" is required but has no default value (--no-input mode)`,
+				`Input "${skillInput.name}" is required but has no default value (--skip-prompt mode)`,
 			),
 		);
 	}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ const cli = Cli.create("taskp", {
 			dryRun: z.boolean().optional().describe("Show execution plan without running"),
 			force: z.boolean().optional().describe("Continue on error (template mode)"),
 			verbose: z.boolean().optional().describe("Show detailed logs"),
-			noInput: z.boolean().optional().describe("Disable interactive prompts (use defaults)"),
+			skipPrompt: z.boolean().optional().describe("Disable interactive prompts (use defaults)"),
 			set: z.array(z.string()).optional().describe("Set variables directly (key=value)"),
 		}),
 		alias: {
@@ -138,7 +138,7 @@ const cli = Cli.create("taskp", {
 					presets,
 					dryRun: c.options.dryRun ?? false,
 					force: c.options.force ?? false,
-					noInput: c.options.noInput,
+					noInput: c.options.skipPrompt,
 				},
 				{ skillRepository, promptCollector, commandExecutor },
 			);
@@ -241,7 +241,7 @@ type RunCommandContext = {
 	readonly options: {
 		readonly model?: string;
 		readonly verbose?: boolean;
-		readonly noInput?: boolean;
+		readonly skipPrompt?: boolean;
 	};
 };
 
@@ -289,7 +289,7 @@ async function runAgentMode(
 			name: c.args.skill,
 			presets,
 			model: languageModelResult.value,
-			noInput: c.options.noInput,
+			noInput: c.options.skipPrompt,
 		},
 		{
 			skillRepository,
@@ -314,11 +314,13 @@ function resolveScope(
 	return undefined;
 }
 
-// ANSI カラーコード
+// ANSI カラーコード（NO_COLOR / 非 TTY 環境ではエスケープを無効化）
+// 注意: bold と dim は同じリセットコード（\x1b[22m）のため、ネスト不可
+const useColor = process.stdout.isTTY === true && !process.env.NO_COLOR;
 const ansi = {
-	bold: (s: string) => `\x1b[1m${s}\x1b[22m`,
-	cyan: (s: string) => `\x1b[36m${s}\x1b[39m`,
-	dim: (s: string) => `\x1b[2m${s}\x1b[22m`,
+	bold: (s: string) => (useColor ? `\x1b[1m${s}\x1b[22m` : s),
+	cyan: (s: string) => (useColor ? `\x1b[36m${s}\x1b[39m` : s),
+	dim: (s: string) => (useColor ? `\x1b[2m${s}\x1b[22m` : s),
 } as const;
 
 function printSkillTable(

--- a/tests/adapter/prompt-runner.test.ts
+++ b/tests/adapter/prompt-runner.test.ts
@@ -264,7 +264,7 @@ describe("PromptRunner", () => {
 			if (result.ok) return;
 			expect(result.error.type).toBe("EXECUTION_ERROR");
 			expect(result.error.message).toBe(
-				'Input "branch" is required but has no default value (--no-input mode)',
+				'Input "branch" is required but has no default value (--skip-prompt mode)',
 			);
 		});
 


### PR DESCRIPTION
## 概要

CLI の使い勝手に関する3つの改善を行いました。

## 変更内容

### 1. `--no-input` → `--skip-prompt` にリネーム

`--no-input` が incur の `--no-` プレフィックス否定パースと競合し、`Unknown flag: --no-input` エラーが発生していました。

- incur は `--no-xxx` を `xxx` オプションの否定として解釈するため、`noInput` のケバブ変換 `--no-input` が `--no-` + `input` と解析されていた
- `skipPrompt`（`--skip-prompt`）にリネームして競合を回避

### 2. `list` コマンドの出力を改善

**Before:**
```
Name             Description                                                 Location
auto-commit      gitのステージング済み差分から...                              /Users/.../SKILL.md
```

**After:**
```
auto-commit (local)
  gitのステージング済み差分からコミットメッセージを自動生成してコミットする
```

- Location のフルパスを `local` / `global` のスコープ表示に変更
- 2行表示で Description が長くても崩れない
- スキル名にシアン太字、スコープに dim のカラーリングを追加

### 3. ANSI カラーの `NO_COLOR` / 非 TTY 対応

- `NO_COLOR` 環境変数が設定されている場合、エスケープコードを出力しない
- パイプ・リダイレクト時（非 TTY）もカラーを無効化

## 変更ファイル

- `src/cli.ts` — skipPrompt リネーム、printSkillTable 改善、ANSI カラー対応
- `src/adapter/prompt-runner.ts` — エラーメッセージ更新
- `docs/CLI-SPEC.md` — ドキュメント更新
- `tests/adapter/prompt-runner.test.ts` — テストのアサーション更新