### PR TITLE
feat: スキルメタデータに timeout オプションを追加

### DIFF
--- a/docs/SKILL-SPEC.md
+++ b/docs/SKILL-SPEC.md
@@ -60,6 +60,7 @@ npm run deploy:{{environment}}
 | `mode` | `"template" \| "agent"` | `"template"` | 実行モード |
 | `inputs` | `Input[]` | `[]` | 入力定義（質問リスト） |
 | `model` | `string` | 設定ファイルのデフォルト | 使用する LLM モデル |
+| `timeout` | `number` | `30000` | template モードのコマンド実行タイムアウト（ミリ秒、最大: 3,600,000）。agent モードでは無視される |
 | `tools` | `string[]` | `["bash", "read", "write"]` | agent モードで使用するツール |
 | `context` | `ContextSource[]` | `[]` | 自動的にコンテキストに含めるソース |
 

--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -20,6 +20,13 @@ const skillMetadataSchema = z.object({
 	mode: skillModeSchema.default("template"),
 	inputs: z.array(skillInputSchema).default([]),
 	model: z.string().min(1).optional(),
+	timeout: z
+		.number()
+		.int()
+		.positive()
+		.max(3_600_000)
+		.optional()
+		.describe("Timeout in milliseconds (max: 3,600,000 = 1 hour)"),
 	tools: z.array(z.string().min(1)).default([...DEFAULT_TOOLS]),
 	context: z.array(contextSourceSchema).default([]),
 });

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -84,8 +84,8 @@ export async function runSkill(
 		codeBlocks,
 		variables,
 		reserved,
-		input.force,
 		deps.commandExecutor,
+		{ force: input.force, timeout: skill.metadata.timeout },
 	);
 	if (!commandResults.ok) {
 		return commandResults;
@@ -99,12 +99,17 @@ export async function runSkill(
 	});
 }
 
+type ExecuteCommandsOptions = {
+	readonly force: boolean;
+	readonly timeout?: number;
+};
+
 async function executeCommands(
 	codeBlocks: readonly CodeBlock[],
 	variables: Record<string, string>,
 	reserved: ReservedVars,
-	force: boolean,
 	executor: CommandExecutor,
+	options: ExecuteCommandsOptions,
 ): Promise<Result<readonly CommandResult[], DomainError>> {
 	const results: CommandResult[] = [];
 
@@ -114,9 +119,12 @@ async function executeCommands(
 			return renderResult;
 		}
 
-		const execResult = await executor.execute(renderResult.value);
+		const execResult = await executor.execute(
+			renderResult.value,
+			options.timeout !== undefined ? { timeout: options.timeout } : undefined,
+		);
 		if (!execResult.ok) {
-			if (!force) {
+			if (!options.force) {
 				return execResult;
 			}
 			results.push({

--- a/tests/core/skill/skill-metadata.test.ts
+++ b/tests/core/skill/skill-metadata.test.ts
@@ -18,6 +18,7 @@ describe("parseSkillMetadata", () => {
 			tools: ["bash", "read", "write"],
 			context: [],
 		});
+		expect(result.value.timeout).toBeUndefined();
 	});
 
 	it("全フィールド指定で正しくパースされる", () => {
@@ -140,6 +141,78 @@ describe("parseSkillMetadata", () => {
 		expect(result.value.inputs[0].default).toBe(true);
 		expect(result.value.inputs[0].required).toBe(false);
 		expect(result.value.inputs[1].validate).toBe("^[1-9][0-9]*$");
+	});
+
+	it("timeout が正の整数で正しくパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: 300000,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.timeout).toBe(300000);
+	});
+
+	it("timeout が 0 でエラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: 0,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+	});
+
+	it("timeout が負の数でエラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: -1000,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+	});
+
+	it("timeout が小数でエラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: 1.5,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+	});
+
+	it("timeout が上限値（3,600,000ms）でパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: 3_600_000,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.timeout).toBe(3_600_000);
+	});
+
+	it("timeout が上限値を超えるとエラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "crawl",
+			description: "クロールする",
+			timeout: 3_600_001,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
 	});
 
 	it("name が未指定でエラーになる", () => {

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -29,7 +29,14 @@ echo "deploying to {{env}}"
 \`\`\`
 `;
 
-function createTestSkill(rawMarkdown: string = TEMPLATE_SKILL_MD): Skill {
+type MetadataOverrides = {
+	readonly timeout?: number;
+};
+
+function createTestSkill(
+	rawMarkdown: string = TEMPLATE_SKILL_MD,
+	overrides?: MetadataOverrides,
+): Skill {
 	return {
 		metadata: {
 			name: "deploy",
@@ -46,6 +53,7 @@ function createTestSkill(rawMarkdown: string = TEMPLATE_SKILL_MD): Skill {
 			model: undefined,
 			tools: ["bash", "read", "write"],
 			context: [],
+			...overrides,
 		},
 		body: createSkillBody(rawMarkdown),
 		location: "/skills/deploy",
@@ -219,6 +227,44 @@ echo "step 2 {{env}}"
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.commands[0].command).toContain("deploying to production");
+	});
+
+	it("metadata の timeout が executor に渡される", async () => {
+		let receivedOptions: Record<string, unknown> | undefined;
+
+		const deps = createDeps({
+			skillRepository: stubRepository(createTestSkill(TEMPLATE_SKILL_MD, { timeout: 300000 })),
+			commandExecutor: {
+				execute: async (_command, options) => {
+					receivedOptions = options as Record<string, unknown>;
+					return ok({ stdout: "ok", stderr: "", exitCode: 0 });
+				},
+			},
+		});
+
+		const result = await runSkill(createInput(), deps);
+
+		expect(result.ok).toBe(true);
+		expect(receivedOptions).toBeDefined();
+		expect(receivedOptions?.timeout).toBe(300000);
+	});
+
+	it("timeout 未設定のとき executor に options が渡されない", async () => {
+		let receivedOptions: unknown = "NOT_CALLED";
+
+		const deps = createDeps({
+			commandExecutor: {
+				execute: async (_command, options) => {
+					receivedOptions = options;
+					return ok({ stdout: "ok", stderr: "", exitCode: 0 });
+				},
+			},
+		});
+
+		const result = await runSkill(createInput(), deps);
+
+		expect(result.ok).toBe(true);
+		expect(receivedOptions).toBeUndefined();
 	});
 
 	it("passes noInput option to prompt collector", async () => {


### PR DESCRIPTION
## 概要

template モードのスキルで、bash コードブロックごとの実行タイムアウトをフロントマターで設定できるようにする。

## 変更内容

- **`skill-metadata.ts`**: `timeout` フィールドを追加（正の整数、最大 3,600,000ms = 1時間）
- **`run-skill.ts`**: `executeCommands` の引数を `ExecuteCommandsOptions` オブジェクトに整理し、`timeout` を `CommandExecutor` に伝搬
- **`SKILL-SPEC.md`**: オプションフィールドに `timeout` を追記（template モード限定・単位明示）
- **テスト**: バリデーション境界値テスト（0, 負数, 小数, 上限超過）および usecase の結合テストを追加

## 動作仕様

- 各 bash コードブロックの実行に対して個別に適用される（タスク全体ではない）
- 未指定時は既存のデフォルト（30秒）がそのまま適用される
- agent モードでは無視される（agent-tools 側に独自の timeout 制御がある）

## 使用例

```yaml
---
name: crawl
description: サイトをクロールする
timeout: 300000  # 5分
---
```
