### PR TITLE
feat: add hooks section schema to config.toml

### DIFF
--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -27,12 +27,19 @@ export const aiConfigSchema = z.object({
 		.describe("Per-provider settings"),
 });
 
+export const hooksConfigSchema = z.object({
+	on_success: z.array(z.string().min(1)).optional().describe("Commands to run on skill success"),
+	on_failure: z.array(z.string().min(1)).optional().describe("Commands to run on skill failure"),
+});
+
 export const configSchema = z.object({
 	ai: aiConfigSchema.optional().describe("AI/LLM settings"),
+	hooks: hooksConfigSchema.optional().describe("Lifecycle hooks"),
 });
 
 export type ProviderConfig = z.infer<typeof providerConfigSchema>;
 export type AiConfig = z.infer<typeof aiConfigSchema>;
+export type HooksConfig = z.infer<typeof hooksConfigSchema>;
 export type Config = z.infer<typeof configSchema>;
 
 type ConfigLoaderDeps = {
@@ -104,25 +111,50 @@ function parseConfig(raw: string, path: string): Result<Config, ConfigError> {
 }
 
 function mergeConfigs(global: Config, project: Config): Config {
-	const globalAi = global.ai;
-	const projectAi = project.ai;
+	return {
+		ai: mergeAi(global.ai, project.ai),
+		hooks: mergeHooks(global.hooks, project.hooks),
+	};
+}
 
-	if (globalAi === undefined && projectAi === undefined) {
-		return {};
+function mergeAi(
+	global: AiConfig | undefined,
+	project: AiConfig | undefined,
+): AiConfig | undefined {
+	if (global === undefined && project === undefined) {
+		return undefined;
 	}
-	if (globalAi === undefined) {
-		return { ai: projectAi };
+	if (global === undefined) {
+		return project;
 	}
-	if (projectAi === undefined) {
-		return { ai: globalAi };
+	if (project === undefined) {
+		return global;
 	}
 
 	return {
-		ai: {
-			default_provider: projectAi.default_provider ?? globalAi.default_provider,
-			default_model: projectAi.default_model ?? globalAi.default_model,
-			providers: mergeProviders(globalAi.providers, projectAi.providers),
-		},
+		default_provider: project.default_provider ?? global.default_provider,
+		default_model: project.default_model ?? global.default_model,
+		providers: mergeProviders(global.providers, project.providers),
+	};
+}
+
+function mergeHooks(
+	global: HooksConfig | undefined,
+	project: HooksConfig | undefined,
+): HooksConfig | undefined {
+	if (global === undefined && project === undefined) {
+		return undefined;
+	}
+	if (global === undefined) {
+		return project;
+	}
+	if (project === undefined) {
+		return global;
+	}
+
+	return {
+		on_success: project.on_success ?? global.on_success,
+		on_failure: project.on_failure ?? global.on_failure,
 	};
 }
 

--- a/tests/adapter/config-loader.test.ts
+++ b/tests/adapter/config-loader.test.ts
@@ -100,6 +100,187 @@ default_model = "qwen2.5-coder:14b"
 		expect(result.error.message).toContain("Failed to parse TOML");
 	});
 
+	describe("hooks", () => {
+		it("parses config without hooks section", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[ai]
+default_provider = "anthropic"
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks).toBeUndefined();
+		});
+
+		it("parses on_success only", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = ["echo done"]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toEqual(["echo done"]);
+			expect(result.value.hooks?.on_failure).toBeUndefined();
+		});
+
+		it("parses on_failure only", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_failure = ["notify-failure"]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toBeUndefined();
+			expect(result.value.hooks?.on_failure).toEqual(["notify-failure"]);
+		});
+
+		it("parses both on_success and on_failure", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = ["echo ok", "notify-success"]
+on_failure = ["echo fail"]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toEqual(["echo ok", "notify-success"]);
+			expect(result.value.hooks?.on_failure).toEqual(["echo fail"]);
+		});
+
+		it("returns error for empty string in on_success", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = [""]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("CONFIG_ERROR");
+		});
+
+		it("returns error for non-array on_success", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = "not-an-array"
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("CONFIG_ERROR");
+		});
+
+		it("merges hooks: project on_success overrides global, global on_failure preserved", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = ["global-success"]
+on_failure = ["global-failure"]
+`,
+			);
+
+			writeConfig(
+				projectRoot,
+				`
+[hooks]
+on_success = ["project-success"]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toEqual(["project-success"]);
+			expect(result.value.hooks?.on_failure).toEqual(["global-failure"]);
+		});
+
+		it("merges hooks: project overrides both", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = ["global-success"]
+on_failure = ["global-failure"]
+`,
+			);
+
+			writeConfig(
+				projectRoot,
+				`
+[hooks]
+on_success = ["project-success"]
+on_failure = ["project-failure"]
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toEqual(["project-success"]);
+			expect(result.value.hooks?.on_failure).toEqual(["project-failure"]);
+		});
+
+		it("merges hooks: global only when project has no hooks", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[hooks]
+on_success = ["global-success"]
+on_failure = ["global-failure"]
+`,
+			);
+
+			writeConfig(
+				projectRoot,
+				`
+[ai]
+default_provider = "ollama"
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.hooks?.on_success).toEqual(["global-success"]);
+			expect(result.value.hooks?.on_failure).toEqual(["global-failure"]);
+		});
+	});
+
 	it("merges providers from both configs", async () => {
 		writeConfig(
 			globalRoot,


### PR DESCRIPTION
#### 概要

`config.toml` に `[hooks]` セクションのスキーマを追加し、`on_success` / `on_failure` コマンド配列を定義できるようにした。

#### 変更内容

- `hooksConfigSchema` Zod スキーマを追加（`on_success` / `on_failure` コマンド配列）
- `configSchema` に `hooks` フィールドを追加
- `mergeConfigs` にフィールド単位上書きのマージロジックを追加
- テスト 9 件追加（パース・バリデーション・マージ）

Closes #181