### PR TITLE
feat: define HookExecutorPort interface and related types

### DIFF
--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -1,0 +1,17 @@
+export type HookContext = {
+	readonly skillName: string;
+	readonly mode: "template" | "agent";
+	readonly status: "success" | "failed";
+	readonly durationMs: number;
+	readonly error?: string;
+};
+
+export type HookResult = {
+	readonly command: string;
+	readonly success: boolean;
+	readonly error?: string;
+};
+
+export interface HookExecutorPort {
+	execute(commands: readonly string[], context: HookContext): Promise<readonly HookResult[]>;
+}

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -1,6 +1,7 @@
 export type { AgentExecutorInput, AgentExecutorPort, AgentExecutorResult } from "./agent-executor";
 export type { CommandExecutor, ExecOptions, ExecResult } from "./command-executor";
 export type { ContextCollectorPort } from "./context-collector";
+export type { HookContext, HookExecutorPort, HookResult } from "./hook-executor";
 export type { PromptCollector } from "./prompt-collector";
 export type { InitOptions, SkillInitializer } from "./skill-initializer";
 export type { SkillRepository } from "./skill-repository";


### PR DESCRIPTION
#### 概要

フック実行のポートインターフェース（`HookExecutorPort`）と関連する型（`HookContext`, `HookResult`）を定義。

#### 変更内容

- `src/usecase/port/hook-executor.ts` を新規作成（`HookContext`, `HookResult`, `HookExecutorPort`）
- `src/usecase/port/index.ts` に re-export を追加

Closes #182