### PR TITLE
feat: integrate hook execution into run-skill and run-agent-skill

### DIFF
--- a/src/usecase/hook-runner.ts
+++ b/src/usecase/hook-runner.ts
@@ -1,0 +1,25 @@
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
+
+export type HooksConfig = {
+	readonly on_success?: readonly string[];
+	readonly on_failure?: readonly string[];
+};
+
+type RunHooksParams = {
+	readonly hookExecutor: HookExecutorPort;
+	readonly hooksConfig: HooksConfig;
+	readonly context: HookContext;
+};
+
+export async function runHooks(params: RunHooksParams): Promise<void> {
+	const commands =
+		params.context.status === "success"
+			? params.hooksConfig.on_success
+			: params.hooksConfig.on_failure;
+
+	if (commands === undefined || commands.length === 0) {
+		return;
+	}
+
+	await params.hookExecutor.execute(commands, params.context);
+}

--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -1,0 +1,17 @@
+export type HookContext = {
+	readonly skillName: string;
+	readonly mode: "template" | "agent";
+	readonly status: "success" | "failed";
+	readonly durationMs: number;
+	readonly error?: string;
+};
+
+export type HookResult = {
+	readonly command: string;
+	readonly success: boolean;
+	readonly error?: string;
+};
+
+export interface HookExecutorPort {
+	execute(commands: readonly string[], context: HookContext): Promise<readonly HookResult[]>;
+}

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -1,6 +1,7 @@
 export type { AgentExecutorInput, AgentExecutorPort, AgentExecutorResult } from "./agent-executor";
 export type { CommandExecutor, ExecOptions, ExecResult } from "./command-executor";
 export type { ContextCollectorPort } from "./context-collector";
+export type { HookContext, HookExecutorPort, HookResult } from "./hook-executor";
 export type { PromptCollector } from "./prompt-collector";
 export type { InitOptions, SkillInitializer } from "./skill-initializer";
 export type { SkillRepository } from "./skill-repository";

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,13 +1,15 @@
 import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ContextSource } from "../core/skill/context-source";
-import type { DomainError } from "../core/types/errors";
+import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
+import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { ContextCollectorPort } from "./port/context-collector";
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -32,6 +34,8 @@ export type RunAgentSkillDeps = {
 	readonly contextCollector: ContextCollectorPort;
 	readonly agentExecutor: AgentExecutorPort;
 	readonly progressWriter?: ProgressWriter;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 };
 
 export async function runAgentSkill(
@@ -91,6 +95,8 @@ export async function runAgentSkill(
 
 	const context = contextParts.join("\n\n");
 
+	const startTime = Date.now();
+
 	const executeResult = await deps.agentExecutor.execute({
 		model: input.model,
 		systemPrompt,
@@ -98,13 +104,44 @@ export async function runAgentSkill(
 		toolNames: skill.metadata.tools,
 		maxSteps: MAX_STEPS,
 	});
+
+	const durationMs = Date.now() - startTime;
+
 	if (!executeResult.ok) {
+		await invokeHooks(deps, {
+			skillName: skill.metadata.name,
+			mode: "agent",
+			status: "failed",
+			durationMs,
+			error: domainErrorMessage(executeResult.error),
+		});
 		return executeResult;
 	}
+
+	await invokeHooks(deps, {
+		skillName: skill.metadata.name,
+		mode: "agent",
+		status: "success",
+		durationMs,
+	});
 
 	return ok({
 		skillName: skill.metadata.name,
 		result: executeResult.value,
+	});
+}
+
+async function invokeHooks(
+	deps: Pick<RunAgentSkillDeps, "hookExecutor" | "hooksConfig">,
+	hookContext: HookContext,
+): Promise<void> {
+	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
+		return;
+	}
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context: hookContext,
 	});
 }
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -5,7 +5,9 @@ import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
+import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -35,6 +37,8 @@ export type RunSkillDeps = {
 	readonly promptCollector: PromptCollector;
 	readonly commandExecutor: CommandExecutor;
 	readonly progressWriter?: ProgressWriter;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 };
 
 export async function runSkill(
@@ -83,6 +87,8 @@ export async function runSkill(
 		});
 	}
 
+	const startTime = Date.now();
+
 	// template モードではマークダウン内の bash コードブロックを順に実行する。
 	// force=true なら1つ失敗しても残りを続行する（CI パイプライン的な使い方に対応）
 	const commandResults = await executeCommands(
@@ -92,15 +98,46 @@ export async function runSkill(
 		deps.commandExecutor,
 		{ force: input.force, timeout: skill.metadata.timeout },
 	);
+
+	const durationMs = Date.now() - startTime;
+
 	if (!commandResults.ok) {
+		await invokeHooks(deps, {
+			skillName: skill.metadata.name,
+			mode: "template",
+			status: "failed",
+			durationMs,
+			error: domainErrorMessage(commandResults.error),
+		});
 		return commandResults;
 	}
+
+	await invokeHooks(deps, {
+		skillName: skill.metadata.name,
+		mode: "template",
+		status: "success",
+		durationMs,
+	});
 
 	return ok({
 		skillName: skill.metadata.name,
 		rendered,
 		commands: commandResults.value,
 		dryRun: false,
+	});
+}
+
+async function invokeHooks(
+	deps: Pick<RunSkillDeps, "hookExecutor" | "hooksConfig">,
+	context: HookContext,
+): Promise<void> {
+	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
+		return;
+	}
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context,
 	});
 }
 

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { runHooks } from "../../src/usecase/hook-runner";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
+
+function createMockExecutor(): HookExecutorPort & {
+	calls: { commands: readonly string[]; context: HookContext }[];
+} {
+	const calls: { commands: readonly string[]; context: HookContext }[] = [];
+	return {
+		calls,
+		execute: vi.fn(async (commands, context) => {
+			calls.push({ commands, context });
+			return commands.map((cmd: string) => ({ command: cmd, success: true }));
+		}),
+	};
+}
+
+describe("runHooks", () => {
+	it("calls on_success commands when status is success", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo ok"]);
+	});
+
+	it("calls on_failure commands when status is failed", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+			context: {
+				skillName: "deploy",
+				mode: "template",
+				status: "failed",
+				durationMs: 50,
+				error: "boom",
+			},
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo fail"]);
+	});
+
+	it("does not call executor when commands array is empty", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: [], on_failure: [] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does not call executor when commands are undefined", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: {},
+			context: { skillName: "deploy", mode: "agent", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("passes context to executor", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "build",
+			mode: "agent",
+			status: "failed",
+			durationMs: 5000,
+			error: "timeout",
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_failure: ["notify"] },
+			context,
+		});
+
+		expect(executor.calls[0].context).toEqual(context);
+	});
+});

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -4,6 +4,7 @@ import type { Skill } from "../../src/core/skill/skill";
 import { ok } from "../../src/core/types/result";
 import type { AgentExecutorPort } from "../../src/usecase/port/agent-executor";
 import type { ContextCollectorPort } from "../../src/usecase/port/context-collector";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
 import { runAgentSkill } from "../../src/usecase/run-agent-skill";
@@ -179,6 +180,125 @@ describe("runAgentSkill", () => {
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
 		expect(result.error.type).toBe("EXECUTION_ERROR");
+	});
+
+	describe("hooks", () => {
+		function stubHookExecutor(): HookExecutorPort & {
+			calls: { commands: readonly string[]; context: HookContext }[];
+		} {
+			const calls: { commands: readonly string[]; context: HookContext }[] = [];
+			return {
+				calls,
+				execute: vi.fn(async (commands, context) => {
+					calls.push({ commands, context });
+					return commands.map((cmd: string) => ({ command: cmd, success: true }));
+				}),
+			};
+		}
+
+		it("calls on_success hook after successful agent execution", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo agent-done"], on_failure: ["echo agent-fail"] },
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("success");
+			expect(hookExecutor.calls[0].context.mode).toBe("agent");
+			expect(hookExecutor.calls[0].context.skillName).toBe("test-agent");
+			expect(hookExecutor.calls[0].context.durationMs).toBeGreaterThanOrEqual(0);
+			expect(hookExecutor.calls[0].commands).toEqual(["echo agent-done"]);
+		});
+
+		it("calls on_failure hook after failed agent execution", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+				agentExecutor: {
+					execute: vi.fn().mockResolvedValue({
+						ok: false,
+						error: { type: "EXECUTION_ERROR", message: "Agent crashed" },
+					}),
+				},
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(false);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("failed");
+			expect(hookExecutor.calls[0].context.error).toBe("Agent crashed");
+			expect(hookExecutor.calls[0].commands).toEqual(["echo fail"]);
+		});
+
+		it("works without hookExecutor and hooksConfig (backward compatible)", async () => {
+			const skill = createAgentSkill();
+			const deps = createMockDeps(skill);
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("does not call executor when on_success is empty", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: [], on_failure: [] },
+			};
+
+			await runAgentSkill({ name: "test-agent", presets: {}, model: mockModel }, deps);
+
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
+
+		it("returns original error result even when hooks are configured", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_failure: ["notify"] },
+				agentExecutor: {
+					execute: vi.fn().mockResolvedValue({
+						ok: false,
+						error: { type: "EXECUTION_ERROR", message: "Agent timeout" },
+					}),
+				},
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			if (result.error.type === "EXECUTION_ERROR") {
+				expect(result.error.message).toBe("Agent timeout");
+			}
+		});
 	});
 
 	it("resolves model priority: CLI model takes precedence", async () => {

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Skill } from "../../src/core/skill/skill";
 import { createSkillBody } from "../../src/core/skill/skill-body";
 import { executionError, skillNotFoundError } from "../../src/core/types/errors";
 import { err, ok } from "../../src/core/types/result";
 import type { CommandExecutor } from "../../src/usecase/port/command-executor";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import { createNoopProgressWriter } from "../../src/usecase/port/progress-writer";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
@@ -313,5 +314,106 @@ echo "step 2 {{env}}"
 		const result = await runSkill(createInput(), deps);
 
 		expect(result.ok).toBe(true);
+	});
+
+	describe("hooks", () => {
+		function stubHookExecutor(): HookExecutorPort & {
+			calls: { commands: readonly string[]; context: HookContext }[];
+		} {
+			const calls: { commands: readonly string[]; context: HookContext }[] = [];
+			return {
+				calls,
+				execute: vi.fn(async (commands, context) => {
+					calls.push({ commands, context });
+					return commands.map((cmd: string) => ({ command: cmd, success: true }));
+				}),
+			};
+		}
+
+		it("calls on_success hook after successful execution", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"], on_failure: ["echo fail"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("success");
+			expect(hookExecutor.calls[0].context.mode).toBe("template");
+			expect(hookExecutor.calls[0].context.skillName).toBe("deploy");
+			expect(hookExecutor.calls[0].context.durationMs).toBeGreaterThanOrEqual(0);
+			expect(hookExecutor.calls[0].commands).toEqual(["echo done"]);
+		});
+
+		it("calls on_failure hook after failed execution", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				commandExecutor: stubExecutor("fail"),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"], on_failure: ["echo fail"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(false);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("failed");
+			expect(hookExecutor.calls[0].context.error).toBeDefined();
+			expect(hookExecutor.calls[0].commands).toEqual(["echo fail"]);
+		});
+
+		it("works without hookExecutor and hooksConfig (backward compatible)", async () => {
+			const deps = createDeps();
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("does not call executor when on_success is empty", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: [], on_failure: [] },
+			});
+
+			await runSkill(createInput(), deps);
+
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
+
+		it("returns original result even when hook returns failure results", async () => {
+			const hookExecutor: HookExecutorPort = {
+				execute: vi.fn(async (commands: readonly string[]) =>
+					commands.map((cmd) => ({ command: cmd, success: false, error: "hook failed" })),
+				),
+			};
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["failing-hook"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.skillName).toBe("deploy");
+		});
+
+		it("does not invoke hooks in dry-run mode", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"] },
+			});
+
+			const result = await runSkill(createInput({ dryRun: true }), deps);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
#### 概要

スキル実行完了後に on_success / on_failure フックを呼び出す機能を run-skill と run-agent-skill ユースケースに統合。

#### 変更内容

- `src/usecase/port/hook-executor.ts`: HookExecutorPort / HookContext / HookResult 型定義を新規追加
- `src/usecase/hook-runner.ts`: 共通フック実行ヘルパー（runHooks）と HooksConfig 型を新規追加
- `src/usecase/run-skill.ts`: RunSkillDeps に hookExecutor / hooksConfig を追加、実行時間計測とフック呼び出しを統合
- `src/usecase/run-agent-skill.ts`: 同上（agent モード）
- テスト: 成功/失敗フック、後方互換、空配列、dry-run スキップ、フック失敗時の結果保持をカバー

Closes #184