### PR TITLE
feat: hooks の CLI / TUI 組み込み

### DIFF
--- a/.pi/mcp.json
+++ b/.pi/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "isuner": {
+      "command": "isuner",
+      "args": [
+        "mcp",
+        "serve",
+        "--context",
+        "{\"sessionId\":97,\"issueNumber\":185,\"sessionName\":\"taskp-185-default\",\"workflow\":{\"name\":\"default\",\"steps\":[{\"name\":\"plan\",\"status\":\"pending\"},{\"name\":\"implement\",\"status\":\"pending\"},{\"name\":\"review\",\"status\":\"pending\"},{\"name\":\"merge\",\"status\":\"pending\"}]},\"dbPath\":\"/Users/kawasakiisao/Desktop/ai/task-preset/.isuner/isuner.db\",\"worktreePath\":\"/Users/kawasakiisao/Desktop/ai/task-preset/.worktrees/issue-185\",\"agentType\":\"pi\"}"
+      ],
+      "lifecycle": "keep-alive",
+      "directTools": true
+    }
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { createCommandRunner } from "./adapter/command-runner";
 import { createDefaultConfigLoader } from "./adapter/config-loader";
 import { createContextCollector } from "./adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "./adapter/context-collector-deps";
+import { createHookExecutor } from "./adapter/hook-executor";
 import { createCliProgressWriter } from "./adapter/progress-formatter";
 import { createPromptRunner } from "./adapter/prompt-runner";
 import { createSkillInitializer } from "./adapter/skill-initializer";
@@ -15,6 +16,7 @@ import { createStreamWriter } from "./adapter/stream-writer";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
 import { type DomainError, EXIT_CODE } from "./core/types/errors";
+import type { HooksConfig } from "./usecase/hook-runner";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
@@ -134,6 +136,10 @@ const cli = Cli.create("taskp", {
 
 			const commandExecutor = createCommandRunner();
 			const progressWriter = createCliProgressWriter(process.stdout);
+
+			const hooksConfig = await loadHooksConfig();
+			const hookExecutor = createHookExecutor(commandExecutor);
+
 			const result = await runSkill(
 				{
 					name: c.args.skill,
@@ -142,7 +148,14 @@ const cli = Cli.create("taskp", {
 					force: c.options.force ?? false,
 					noInput: c.options.skipPrompt,
 				},
-				{ skillRepository, promptCollector, commandExecutor, progressWriter },
+				{
+					skillRepository,
+					promptCollector,
+					commandExecutor,
+					progressWriter,
+					hookExecutor,
+					hooksConfig,
+				},
 			);
 
 			if (!result.ok) {
@@ -286,6 +299,10 @@ async function runAgentMode(
 
 	const agentExecutor = createAgentExecutor(writer);
 
+	const commandExecutor = createCommandRunner();
+	const hookExecutor = createHookExecutor(commandExecutor);
+	const hooksConfig = configResult.value.hooks;
+
 	const result = await runAgentSkill(
 		{
 			name: c.args.skill,
@@ -299,12 +316,21 @@ async function runAgentMode(
 			contextCollector,
 			agentExecutor,
 			progressWriter: createCliProgressWriter(process.stdout),
+			hookExecutor,
+			hooksConfig,
 		},
 	);
 	if (!result.ok) {
 		console.error(formatError(result.error));
 		process.exit(EXIT_CODE[result.error.type]);
 	}
+}
+
+async function loadHooksConfig(): Promise<HooksConfig | undefined> {
+	const configLoader = createDefaultConfigLoader(process.cwd());
+	const configResult = await configLoader.load();
+	if (!configResult.ok) return undefined;
+	return configResult.value.hooks;
 }
 
 function resolveScope(

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -3,6 +3,7 @@ import { createCliRenderer } from "@opentui/core";
 import { createLanguageModel, resolveModelSpec } from "../adapter/ai-provider";
 import { createDefaultConfigLoader } from "../adapter/config-loader";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
+import type { HooksConfig } from "../usecase/hook-runner";
 import { copyToClipboard } from "./clipboard";
 import { showExecution } from "./screens/execution-view";
 import { showInputForm } from "./screens/input-form";
@@ -30,7 +31,7 @@ export async function startTui(): Promise<void> {
 		return;
 	}
 
-	const model = await resolveModel();
+	const { model, hooksConfig } = await resolveModelAndConfig();
 
 	while (true) {
 		const skill = await showSkillSelector(renderer, skills);
@@ -39,26 +40,33 @@ export async function startTui(): Promise<void> {
 		const variables = await showInputForm(renderer, skill);
 		if (!variables) continue;
 
-		const action = await showExecution(renderer, skill, variables, model);
+		const action = await showExecution(renderer, skill, variables, model, hooksConfig);
 		if (action === "exit") break;
 	}
 
 	renderer.destroy();
 }
 
-// config.toml からデフォルトの LLM モデルを解決する。
-// いずれかの段階で失敗した場合は null を返す（agent モード実行時にエラー表示）
-async function resolveModel(): Promise<LanguageModelV3 | null> {
+type ModelAndConfig = {
+	readonly model: LanguageModelV3 | null;
+	readonly hooksConfig: HooksConfig | undefined;
+};
+
+// config.toml からデフォルトの LLM モデルとフック設定を解決する。
+// モデル解決がいずれかの段階で失敗した場合は null を返す（agent モード実行時にエラー表示）
+async function resolveModelAndConfig(): Promise<ModelAndConfig> {
 	const configLoader = createDefaultConfigLoader(process.cwd());
 	const configResult = await configLoader.load();
-	if (!configResult.ok) return null;
+	if (!configResult.ok) return { model: null, hooksConfig: undefined };
+
+	const hooksConfig = configResult.value.hooks;
 
 	const aiConfig = configResult.value.ai ?? {};
 	const specResult = resolveModelSpec({ config: aiConfig });
-	if (!specResult.ok) return null;
+	if (!specResult.ok) return { model: null, hooksConfig };
 
 	const modelResult = createLanguageModel(specResult.value, aiConfig);
-	if (!modelResult.ok) return null;
+	if (!modelResult.ok) return { model: null, hooksConfig };
 
-	return modelResult.value;
+	return { model: modelResult.value, hooksConfig };
 }

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -12,9 +12,11 @@ import { createAgentExecutor } from "../../adapter/agent-executor";
 import { createCommandRunner } from "../../adapter/command-runner";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
+import { createHookExecutor } from "../../adapter/hook-executor";
 import type { Skill } from "../../core/skill/skill";
 import type { DomainError } from "../../core/types/errors";
 import { ok } from "../../core/types/result";
+import type { HooksConfig } from "../../usecase/hook-runner";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { runAgentSkill } from "../../usecase/run-agent-skill";
@@ -35,6 +37,7 @@ export async function showExecution(
 	skill: Skill,
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3 | null,
+	hooksConfig?: HooksConfig,
 ): Promise<"back" | "exit"> {
 	return new Promise((resolve) => {
 		clearScreen(renderer);
@@ -139,7 +142,7 @@ export async function showExecution(
 			},
 		};
 
-		runExecution(skill, variables, model, viewPort).then(() => {
+		runExecution(skill, variables, model, viewPort, hooksConfig).then(() => {
 			const doneHandler = (key: KeyEvent) => {
 				if (key.name === "return") {
 					cleanup(doneHandler);
@@ -167,6 +170,7 @@ async function runExecution(
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3 | null,
 	viewPort: ExecutionViewPort,
+	hooksConfig?: HooksConfig,
 ): Promise<void> {
 	if (skill.metadata.mode === "agent" && model === null) {
 		viewPort.appendOutput("Error: LLM model not configured.\n");
@@ -177,9 +181,9 @@ async function runExecution(
 
 	try {
 		if (skill.metadata.mode === "agent" && model !== null) {
-			await executeAgentMode(skill, variables, model, viewPort);
+			await executeAgentMode(skill, variables, model, viewPort, hooksConfig);
 		} else {
-			await executeTemplateMode(skill, variables, viewPort);
+			await executeTemplateMode(skill, variables, viewPort, hooksConfig);
 		}
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -208,10 +212,13 @@ async function executeAgentMode(
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3,
 	viewPort: ExecutionViewPort,
+	hooksConfig?: HooksConfig,
 ): Promise<void> {
 	const writer = createTuiStreamWriter(viewPort);
 	const progressWriter = createTuiProgressWriter(viewPort);
 	const agentExecutor = createAgentExecutor(writer);
+	const commandExecutor = createCommandRunner();
+	const hookExecutor = createHookExecutor(commandExecutor);
 
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
 	const contextCollector = createContextCollector(contextCollectorDeps);
@@ -224,6 +231,8 @@ async function executeAgentMode(
 			contextCollector,
 			agentExecutor,
 			progressWriter,
+			hookExecutor,
+			hooksConfig,
 		},
 	);
 
@@ -237,9 +246,11 @@ async function executeTemplateMode(
 	skill: Skill,
 	variables: Readonly<Record<string, string>>,
 	viewPort: ExecutionViewPort,
+	hooksConfig?: HooksConfig,
 ): Promise<void> {
 	const commandExecutor = createCommandRunner();
 	const progressWriter = createTuiProgressWriter(viewPort);
+	const hookExecutor = createHookExecutor(commandExecutor);
 
 	const result = await runSkill(
 		{ name: skill.metadata.name, presets: variables, dryRun: false, force: false },
@@ -248,6 +259,8 @@ async function executeTemplateMode(
 			promptCollector: buildPromptCollector(variables),
 			commandExecutor,
 			progressWriter,
+			hookExecutor,
+			hooksConfig,
 		},
 	);
 

--- a/src/usecase/hook-runner.ts
+++ b/src/usecase/hook-runner.ts
@@ -1,0 +1,25 @@
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
+
+export type HooksConfig = {
+	readonly on_success?: readonly string[];
+	readonly on_failure?: readonly string[];
+};
+
+type RunHooksParams = {
+	readonly hookExecutor: HookExecutorPort;
+	readonly hooksConfig: HooksConfig;
+	readonly context: HookContext;
+};
+
+export async function runHooks(params: RunHooksParams): Promise<void> {
+	const commands =
+		params.context.status === "success"
+			? params.hooksConfig.on_success
+			: params.hooksConfig.on_failure;
+
+	if (commands === undefined || commands.length === 0) {
+		return;
+	}
+
+	await params.hookExecutor.execute(commands, params.context);
+}

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,13 +1,15 @@
 import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ContextSource } from "../core/skill/context-source";
-import type { DomainError } from "../core/types/errors";
+import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
+import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { ContextCollectorPort } from "./port/context-collector";
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -32,6 +34,8 @@ export type RunAgentSkillDeps = {
 	readonly contextCollector: ContextCollectorPort;
 	readonly agentExecutor: AgentExecutorPort;
 	readonly progressWriter?: ProgressWriter;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 };
 
 export async function runAgentSkill(
@@ -91,6 +95,8 @@ export async function runAgentSkill(
 
 	const context = contextParts.join("\n\n");
 
+	const startTime = Date.now();
+
 	const executeResult = await deps.agentExecutor.execute({
 		model: input.model,
 		systemPrompt,
@@ -98,13 +104,44 @@ export async function runAgentSkill(
 		toolNames: skill.metadata.tools,
 		maxSteps: MAX_STEPS,
 	});
+
+	const durationMs = Date.now() - startTime;
+
 	if (!executeResult.ok) {
+		await invokeHooks(deps, {
+			skillName: skill.metadata.name,
+			mode: "agent",
+			status: "failed",
+			durationMs,
+			error: domainErrorMessage(executeResult.error),
+		});
 		return executeResult;
 	}
+
+	await invokeHooks(deps, {
+		skillName: skill.metadata.name,
+		mode: "agent",
+		status: "success",
+		durationMs,
+	});
 
 	return ok({
 		skillName: skill.metadata.name,
 		result: executeResult.value,
+	});
+}
+
+async function invokeHooks(
+	deps: Pick<RunAgentSkillDeps, "hookExecutor" | "hooksConfig">,
+	hookContext: HookContext,
+): Promise<void> {
+	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
+		return;
+	}
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context: hookContext,
 	});
 }
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -5,7 +5,9 @@ import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
+import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
+import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -35,6 +37,8 @@ export type RunSkillDeps = {
 	readonly promptCollector: PromptCollector;
 	readonly commandExecutor: CommandExecutor;
 	readonly progressWriter?: ProgressWriter;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 };
 
 export async function runSkill(
@@ -83,6 +87,8 @@ export async function runSkill(
 		});
 	}
 
+	const startTime = Date.now();
+
 	// template モードではマークダウン内の bash コードブロックを順に実行する。
 	// force=true なら1つ失敗しても残りを続行する（CI パイプライン的な使い方に対応）
 	const commandResults = await executeCommands(
@@ -92,15 +98,46 @@ export async function runSkill(
 		deps.commandExecutor,
 		{ force: input.force, timeout: skill.metadata.timeout },
 	);
+
+	const durationMs = Date.now() - startTime;
+
 	if (!commandResults.ok) {
+		await invokeHooks(deps, {
+			skillName: skill.metadata.name,
+			mode: "template",
+			status: "failed",
+			durationMs,
+			error: domainErrorMessage(commandResults.error),
+		});
 		return commandResults;
 	}
+
+	await invokeHooks(deps, {
+		skillName: skill.metadata.name,
+		mode: "template",
+		status: "success",
+		durationMs,
+	});
 
 	return ok({
 		skillName: skill.metadata.name,
 		rendered,
 		commands: commandResults.value,
 		dryRun: false,
+	});
+}
+
+async function invokeHooks(
+	deps: Pick<RunSkillDeps, "hookExecutor" | "hooksConfig">,
+	context: HookContext,
+): Promise<void> {
+	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
+		return;
+	}
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context,
 	});
 }
 

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { runHooks } from "../../src/usecase/hook-runner";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
+
+function createMockExecutor(): HookExecutorPort & {
+	calls: { commands: readonly string[]; context: HookContext }[];
+} {
+	const calls: { commands: readonly string[]; context: HookContext }[] = [];
+	return {
+		calls,
+		execute: vi.fn(async (commands, context) => {
+			calls.push({ commands, context });
+			return commands.map((cmd: string) => ({ command: cmd, success: true }));
+		}),
+	};
+}
+
+describe("runHooks", () => {
+	it("calls on_success commands when status is success", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo ok"]);
+	});
+
+	it("calls on_failure commands when status is failed", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+			context: {
+				skillName: "deploy",
+				mode: "template",
+				status: "failed",
+				durationMs: 50,
+				error: "boom",
+			},
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo fail"]);
+	});
+
+	it("does not call executor when commands array is empty", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: [], on_failure: [] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does not call executor when commands are undefined", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: {},
+			context: { skillName: "deploy", mode: "agent", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("passes context to executor", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "build",
+			mode: "agent",
+			status: "failed",
+			durationMs: 5000,
+			error: "timeout",
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_failure: ["notify"] },
+			context,
+		});
+
+		expect(executor.calls[0].context).toEqual(context);
+	});
+});

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -4,6 +4,7 @@ import type { Skill } from "../../src/core/skill/skill";
 import { ok } from "../../src/core/types/result";
 import type { AgentExecutorPort } from "../../src/usecase/port/agent-executor";
 import type { ContextCollectorPort } from "../../src/usecase/port/context-collector";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
 import { runAgentSkill } from "../../src/usecase/run-agent-skill";
@@ -179,6 +180,125 @@ describe("runAgentSkill", () => {
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
 		expect(result.error.type).toBe("EXECUTION_ERROR");
+	});
+
+	describe("hooks", () => {
+		function stubHookExecutor(): HookExecutorPort & {
+			calls: { commands: readonly string[]; context: HookContext }[];
+		} {
+			const calls: { commands: readonly string[]; context: HookContext }[] = [];
+			return {
+				calls,
+				execute: vi.fn(async (commands, context) => {
+					calls.push({ commands, context });
+					return commands.map((cmd: string) => ({ command: cmd, success: true }));
+				}),
+			};
+		}
+
+		it("calls on_success hook after successful agent execution", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo agent-done"], on_failure: ["echo agent-fail"] },
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("success");
+			expect(hookExecutor.calls[0].context.mode).toBe("agent");
+			expect(hookExecutor.calls[0].context.skillName).toBe("test-agent");
+			expect(hookExecutor.calls[0].context.durationMs).toBeGreaterThanOrEqual(0);
+			expect(hookExecutor.calls[0].commands).toEqual(["echo agent-done"]);
+		});
+
+		it("calls on_failure hook after failed agent execution", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
+				agentExecutor: {
+					execute: vi.fn().mockResolvedValue({
+						ok: false,
+						error: { type: "EXECUTION_ERROR", message: "Agent crashed" },
+					}),
+				},
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(false);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("failed");
+			expect(hookExecutor.calls[0].context.error).toBe("Agent crashed");
+			expect(hookExecutor.calls[0].commands).toEqual(["echo fail"]);
+		});
+
+		it("works without hookExecutor and hooksConfig (backward compatible)", async () => {
+			const skill = createAgentSkill();
+			const deps = createMockDeps(skill);
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("does not call executor when on_success is empty", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_success: [], on_failure: [] },
+			};
+
+			await runAgentSkill({ name: "test-agent", presets: {}, model: mockModel }, deps);
+
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
+
+		it("returns original error result even when hooks are configured", async () => {
+			const skill = createAgentSkill();
+			const hookExecutor = stubHookExecutor();
+			const deps = {
+				...createMockDeps(skill),
+				hookExecutor,
+				hooksConfig: { on_failure: ["notify"] },
+				agentExecutor: {
+					execute: vi.fn().mockResolvedValue({
+						ok: false,
+						error: { type: "EXECUTION_ERROR", message: "Agent timeout" },
+					}),
+				},
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel },
+				deps,
+			);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			if (result.error.type === "EXECUTION_ERROR") {
+				expect(result.error.message).toBe("Agent timeout");
+			}
+		});
 	});
 
 	it("resolves model priority: CLI model takes precedence", async () => {

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Skill } from "../../src/core/skill/skill";
 import { createSkillBody } from "../../src/core/skill/skill-body";
 import { executionError, skillNotFoundError } from "../../src/core/types/errors";
 import { err, ok } from "../../src/core/types/result";
 import type { CommandExecutor } from "../../src/usecase/port/command-executor";
+import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import { createNoopProgressWriter } from "../../src/usecase/port/progress-writer";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
@@ -313,5 +314,106 @@ echo "step 2 {{env}}"
 		const result = await runSkill(createInput(), deps);
 
 		expect(result.ok).toBe(true);
+	});
+
+	describe("hooks", () => {
+		function stubHookExecutor(): HookExecutorPort & {
+			calls: { commands: readonly string[]; context: HookContext }[];
+		} {
+			const calls: { commands: readonly string[]; context: HookContext }[] = [];
+			return {
+				calls,
+				execute: vi.fn(async (commands, context) => {
+					calls.push({ commands, context });
+					return commands.map((cmd: string) => ({ command: cmd, success: true }));
+				}),
+			};
+		}
+
+		it("calls on_success hook after successful execution", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"], on_failure: ["echo fail"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("success");
+			expect(hookExecutor.calls[0].context.mode).toBe("template");
+			expect(hookExecutor.calls[0].context.skillName).toBe("deploy");
+			expect(hookExecutor.calls[0].context.durationMs).toBeGreaterThanOrEqual(0);
+			expect(hookExecutor.calls[0].commands).toEqual(["echo done"]);
+		});
+
+		it("calls on_failure hook after failed execution", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				commandExecutor: stubExecutor("fail"),
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"], on_failure: ["echo fail"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(false);
+			expect(hookExecutor.execute).toHaveBeenCalledOnce();
+			expect(hookExecutor.calls[0].context.status).toBe("failed");
+			expect(hookExecutor.calls[0].context.error).toBeDefined();
+			expect(hookExecutor.calls[0].commands).toEqual(["echo fail"]);
+		});
+
+		it("works without hookExecutor and hooksConfig (backward compatible)", async () => {
+			const deps = createDeps();
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+		});
+
+		it("does not call executor when on_success is empty", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: [], on_failure: [] },
+			});
+
+			await runSkill(createInput(), deps);
+
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
+
+		it("returns original result even when hook returns failure results", async () => {
+			const hookExecutor: HookExecutorPort = {
+				execute: vi.fn(async (commands: readonly string[]) =>
+					commands.map((cmd) => ({ command: cmd, success: false, error: "hook failed" })),
+				),
+			};
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["failing-hook"] },
+			});
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.skillName).toBe("deploy");
+		});
+
+		it("does not invoke hooks in dry-run mode", async () => {
+			const hookExecutor = stubHookExecutor();
+			const deps = createDeps({
+				hookExecutor,
+				hooksConfig: { on_success: ["echo done"] },
+			});
+
+			const result = await runSkill(createInput({ dryRun: true }), deps);
+
+			expect(result.ok).toBe(true);
+			expect(hookExecutor.execute).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
#### 概要

CLI と TUI のエントリポイントで config から hooks を読み取り、HookExecutor を生成してユースケースの deps に注入する。

#### 変更内容

- `HookExecutorPort` / `HookContext` / `HookResult` 型を定義（`src/usecase/port/hook-executor.ts`）
- `CommandExecutor` ベースの `HookExecutor` アダプタを実装（`src/adapter/hook-executor.ts`）
- `config-loader` に `hooksConfigSchema` とマージ戦略を追加
- `runSkill` / `runAgentSkill` の deps に `hookExecutor` / `hooksConfig` を追加し、実行後にフック発火
- `cli.ts` で `HookExecutor` を生成して deps に注入
- `tui/app.ts` / `execution-view.ts` で同様にフックを組み込み

Closes #185