### PR TITLE
refactor: hooks コードレビュー指摘事項の修正

### DIFF
--- a/.taskp/config.toml
+++ b/.taskp/config.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/takemo101/taskp/main/.taskp/config.schema.json
+
 [ai]
 default_provider = "omlx"
 default_model = "Qwen3.5-4B-MLX-4bit"

--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -35,12 +35,12 @@ export function createHookExecutor(commandExecutor: CommandExecutor): HookExecut
 				return [];
 			}
 
-			const env = buildEnvVars(context);
+			const mergedEnv = { ...getParentEnv(), ...buildEnvVars(context) };
 			const results: HookResult[] = [];
 
 			for (const command of commands) {
 				const result = await commandExecutor.execute(command, {
-					env: { ...getParentEnv(), ...env },
+					env: mergedEnv,
 					timeout: TIMEOUT_MS,
 				});
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,6 @@ import { createStreamWriter } from "./adapter/stream-writer";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
 import { type DomainError, EXIT_CODE } from "./core/types/errors";
-import type { HooksConfig } from "./usecase/hook-runner";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
@@ -137,7 +136,9 @@ const cli = Cli.create("taskp", {
 			const commandExecutor = createCommandRunner();
 			const progressWriter = createCliProgressWriter(process.stdout);
 
-			const hooksConfig = await loadHooksConfig();
+			const configLoader = createDefaultConfigLoader(process.cwd());
+			const configResult = await configLoader.load();
+			const hooksConfig = configResult.ok ? configResult.value.hooks : undefined;
 			const hookExecutor = createHookExecutor(commandExecutor);
 
 			const result = await runSkill(
@@ -324,13 +325,6 @@ async function runAgentMode(
 		console.error(formatError(result.error));
 		process.exit(EXIT_CODE[result.error.type]);
 	}
-}
-
-async function loadHooksConfig(): Promise<HooksConfig | undefined> {
-	const configLoader = createDefaultConfigLoader(process.cwd());
-	const configResult = await configLoader.load();
-	if (!configResult.ok) return undefined;
-	return configResult.value.hooks;
 }
 
 function resolveScope(

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1,11 +1,13 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { createCliRenderer } from "@opentui/core";
 import { createLanguageModel, resolveModelSpec } from "../adapter/ai-provider";
+import { createCommandRunner } from "../adapter/command-runner";
 import { createDefaultConfigLoader } from "../adapter/config-loader";
+import { createHookExecutor } from "../adapter/hook-executor";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import type { HooksConfig } from "../usecase/hook-runner";
 import { copyToClipboard } from "./clipboard";
-import { showExecution } from "./screens/execution-view";
+import { type ExecutionDeps, showExecution } from "./screens/execution-view";
 import { showInputForm } from "./screens/input-form";
 import { showSkillSelector } from "./screens/skill-selector";
 
@@ -33,6 +35,10 @@ export async function startTui(): Promise<void> {
 
 	const { model, hooksConfig } = await resolveModelAndConfig();
 
+	const commandExecutor = createCommandRunner();
+	const hookExecutor = createHookExecutor(commandExecutor);
+	const executionDeps: ExecutionDeps = { commandExecutor, hookExecutor, hooksConfig };
+
 	while (true) {
 		const skill = await showSkillSelector(renderer, skills);
 		if (!skill) break;
@@ -40,7 +46,7 @@ export async function startTui(): Promise<void> {
 		const variables = await showInputForm(renderer, skill);
 		if (!variables) continue;
 
-		const action = await showExecution(renderer, skill, variables, model, hooksConfig);
+		const action = await showExecution(renderer, skill, variables, model, executionDeps);
 		if (action === "exit") break;
 	}
 

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -9,14 +9,14 @@ import {
 	TextRenderable,
 } from "@opentui/core";
 import { createAgentExecutor } from "../../adapter/agent-executor";
-import { createCommandRunner } from "../../adapter/command-runner";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
-import { createHookExecutor } from "../../adapter/hook-executor";
 import type { Skill } from "../../core/skill/skill";
 import type { DomainError } from "../../core/types/errors";
 import { ok } from "../../core/types/result";
 import type { HooksConfig } from "../../usecase/hook-runner";
+import type { CommandExecutor } from "../../usecase/port/command-executor";
+import type { HookExecutorPort } from "../../usecase/port/hook-executor";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { runAgentSkill } from "../../usecase/run-agent-skill";
@@ -32,12 +32,18 @@ import {
 
 const CONTAINER_ID = "exec-container";
 
+export type ExecutionDeps = {
+	readonly commandExecutor: CommandExecutor;
+	readonly hookExecutor: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
+};
+
 export async function showExecution(
 	renderer: CliRenderer,
 	skill: Skill,
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3 | null,
-	hooksConfig?: HooksConfig,
+	deps: ExecutionDeps,
 ): Promise<"back" | "exit"> {
 	return new Promise((resolve) => {
 		clearScreen(renderer);
@@ -142,7 +148,7 @@ export async function showExecution(
 			},
 		};
 
-		runExecution(skill, variables, model, viewPort, hooksConfig).then(() => {
+		runExecution(skill, variables, model, viewPort, deps).then(() => {
 			const doneHandler = (key: KeyEvent) => {
 				if (key.name === "return") {
 					cleanup(doneHandler);
@@ -170,7 +176,7 @@ async function runExecution(
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3 | null,
 	viewPort: ExecutionViewPort,
-	hooksConfig?: HooksConfig,
+	deps: ExecutionDeps,
 ): Promise<void> {
 	if (skill.metadata.mode === "agent" && model === null) {
 		viewPort.appendOutput("Error: LLM model not configured.\n");
@@ -181,9 +187,9 @@ async function runExecution(
 
 	try {
 		if (skill.metadata.mode === "agent" && model !== null) {
-			await executeAgentMode(skill, variables, model, viewPort, hooksConfig);
+			await executeAgentMode(skill, variables, model, viewPort, deps);
 		} else {
-			await executeTemplateMode(skill, variables, viewPort, hooksConfig);
+			await executeTemplateMode(skill, variables, viewPort, deps);
 		}
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -212,13 +218,11 @@ async function executeAgentMode(
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3,
 	viewPort: ExecutionViewPort,
-	hooksConfig?: HooksConfig,
+	deps: ExecutionDeps,
 ): Promise<void> {
 	const writer = createTuiStreamWriter(viewPort);
 	const progressWriter = createTuiProgressWriter(viewPort);
 	const agentExecutor = createAgentExecutor(writer);
-	const commandExecutor = createCommandRunner();
-	const hookExecutor = createHookExecutor(commandExecutor);
 
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
 	const contextCollector = createContextCollector(contextCollectorDeps);
@@ -231,8 +235,8 @@ async function executeAgentMode(
 			contextCollector,
 			agentExecutor,
 			progressWriter,
-			hookExecutor,
-			hooksConfig,
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
 		},
 	);
 
@@ -246,21 +250,19 @@ async function executeTemplateMode(
 	skill: Skill,
 	variables: Readonly<Record<string, string>>,
 	viewPort: ExecutionViewPort,
-	hooksConfig?: HooksConfig,
+	deps: ExecutionDeps,
 ): Promise<void> {
-	const commandExecutor = createCommandRunner();
 	const progressWriter = createTuiProgressWriter(viewPort);
-	const hookExecutor = createHookExecutor(commandExecutor);
 
 	const result = await runSkill(
 		{ name: skill.metadata.name, presets: variables, dryRun: false, force: false },
 		{
 			skillRepository: buildSkillRepository(skill),
 			promptCollector: buildPromptCollector(variables),
-			commandExecutor,
+			commandExecutor: deps.commandExecutor,
 			progressWriter,
-			hookExecutor,
-			hooksConfig,
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
 		},
 	);
 

--- a/src/usecase/hook-runner.ts
+++ b/src/usecase/hook-runner.ts
@@ -1,17 +1,19 @@
+import type { HooksConfig } from "../adapter/config-loader";
 import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 
-export type HooksConfig = {
-	readonly on_success?: readonly string[];
-	readonly on_failure?: readonly string[];
-};
+export type { HooksConfig };
 
 type RunHooksParams = {
-	readonly hookExecutor: HookExecutorPort;
-	readonly hooksConfig: HooksConfig;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 	readonly context: HookContext;
 };
 
 export async function runHooks(params: RunHooksParams): Promise<void> {
+	if (params.hookExecutor === undefined || params.hooksConfig === undefined) {
+		return;
+	}
+
 	const commands =
 		params.context.status === "success"
 			? params.hooksConfig.on_success
@@ -21,5 +23,10 @@ export async function runHooks(params: RunHooksParams): Promise<void> {
 		return;
 	}
 
-	await params.hookExecutor.execute(commands, params.context);
+	try {
+		await params.hookExecutor.execute(commands, params.context);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`[taskp] hook error: ${message}`);
+	}
 }

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -9,7 +9,7 @@ import { renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { ContextCollectorPort } from "./port/context-collector";
-import type { HookContext, HookExecutorPort } from "./port/hook-executor";
+import type { HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -108,40 +108,34 @@ export async function runAgentSkill(
 	const durationMs = Date.now() - startTime;
 
 	if (!executeResult.ok) {
-		await invokeHooks(deps, {
-			skillName: skill.metadata.name,
-			mode: "agent",
-			status: "failed",
-			durationMs,
-			error: domainErrorMessage(executeResult.error),
+		await runHooks({
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
+			context: {
+				skillName: skill.metadata.name,
+				mode: "agent",
+				status: "failed",
+				durationMs,
+				error: domainErrorMessage(executeResult.error),
+			},
 		});
 		return executeResult;
 	}
 
-	await invokeHooks(deps, {
-		skillName: skill.metadata.name,
-		mode: "agent",
-		status: "success",
-		durationMs,
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context: {
+			skillName: skill.metadata.name,
+			mode: "agent",
+			status: "success",
+			durationMs,
+		},
 	});
 
 	return ok({
 		skillName: skill.metadata.name,
 		result: executeResult.value,
-	});
-}
-
-async function invokeHooks(
-	deps: Pick<RunAgentSkillDeps, "hookExecutor" | "hooksConfig">,
-	hookContext: HookContext,
-): Promise<void> {
-	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
-		return;
-	}
-	await runHooks({
-		hookExecutor: deps.hookExecutor,
-		hooksConfig: deps.hooksConfig,
-		context: hookContext,
 	});
 }
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -7,7 +7,7 @@ import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
-import type { HookContext, HookExecutorPort } from "./port/hook-executor";
+import type { HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -102,21 +102,29 @@ export async function runSkill(
 	const durationMs = Date.now() - startTime;
 
 	if (!commandResults.ok) {
-		await invokeHooks(deps, {
-			skillName: skill.metadata.name,
-			mode: "template",
-			status: "failed",
-			durationMs,
-			error: domainErrorMessage(commandResults.error),
+		await runHooks({
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
+			context: {
+				skillName: skill.metadata.name,
+				mode: "template",
+				status: "failed",
+				durationMs,
+				error: domainErrorMessage(commandResults.error),
+			},
 		});
 		return commandResults;
 	}
 
-	await invokeHooks(deps, {
-		skillName: skill.metadata.name,
-		mode: "template",
-		status: "success",
-		durationMs,
+	await runHooks({
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+		context: {
+			skillName: skill.metadata.name,
+			mode: "template",
+			status: "success",
+			durationMs,
+		},
 	});
 
 	return ok({
@@ -124,20 +132,6 @@ export async function runSkill(
 		rendered,
 		commands: commandResults.value,
 		dryRun: false,
-	});
-}
-
-async function invokeHooks(
-	deps: Pick<RunSkillDeps, "hookExecutor" | "hooksConfig">,
-	context: HookContext,
-): Promise<void> {
-	if (deps.hookExecutor === undefined || deps.hooksConfig === undefined) {
-		return;
-	}
-	await runHooks({
-		hookExecutor: deps.hookExecutor,
-		hooksConfig: deps.hooksConfig,
-		context,
 	});
 }
 

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -68,6 +68,44 @@ describe("runHooks", () => {
 		expect(executor.execute).not.toHaveBeenCalled();
 	});
 
+	it("does nothing when hookExecutor is undefined", async () => {
+		await runHooks({
+			hookExecutor: undefined,
+			hooksConfig: { on_success: ["echo ok"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+		// no throw = pass
+	});
+
+	it("does nothing when hooksConfig is undefined", async () => {
+		const executor = createMockExecutor();
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: undefined,
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("catches and logs executor exceptions without rethrowing", async () => {
+		const throwingExecutor: HookExecutorPort = {
+			execute: vi.fn(async () => {
+				throw new Error("network error");
+			}),
+		};
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await runHooks({
+			hookExecutor: throwingExecutor,
+			hooksConfig: { on_success: ["echo ok"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(errorSpy).toHaveBeenCalledWith("[taskp] hook error: network error");
+		vi.restoreAllMocks();
+	});
+
 	it("passes context to executor", async () => {
 		const executor = createMockExecutor();
 		const context: HookContext = {


### PR DESCRIPTION
## 概要

hooks 実装のセルフレビューで発見した6つの問題を修正。

## 修正内容

| # | 問題 | 修正 |
|---|------|------|
| 1 | `getParentEnv()` がループ内で毎回呼ばれる | ループ外で1回だけマージ |
| 2 | `HooksConfig` 型が `config-loader.ts` と `hook-runner.ts` で重複 | `hook-runner.ts` は `config-loader.ts` から re-export |
| 3 | `loadHooksConfig()` が config を二重ロード | 削除し、インラインで config を取得 |
| 4 | `execution-view.ts` がアダプター層を直接 import | `ExecutionDeps` を定義し `app.ts` から注入 |
| 5 | `invokeHooks()` が `run-skill.ts` と `run-agent-skill.ts` で重複 | 削除し `runHooks()` を直接呼び出し（optional ガードを `runHooks` に内蔵） |
| 6 | フック実行中の予期せぬ例外がキャッチされない | `runHooks` に try-catch を追加 |

## テスト

- 新規テスト3件追加（undefined hookExecutor/hooksConfig、例外キャッチ）
- `bun run typecheck` ✅
- `bun run test` ✅（395テスト通過）
- `biome check` ✅