### PR TITLE
fix: repairToolCall の修復失敗時にデバッグ情報をログ出力

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -93,7 +93,10 @@ export const repairToolCall: ToolCallRepairFunction<ToolSet> = async (options) =
 	try {
 		const parsed = JSON.parse(escaped) as Record<string, unknown>;
 		return { ...options.toolCall, input: JSON.stringify(parsed) };
-	} catch {
-		return null; // 修復失敗
+	} catch (error) {
+		console.debug(
+			`[taskp] Tool call repair failed. Original: ${raw}, Escaped: ${escaped}, Error: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return null;
 	}
 };

--- a/tests/adapter/repair-tool-call.test.ts
+++ b/tests/adapter/repair-tool-call.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, type MockInstance, vi } from "vitest";
 import { repairToolCall } from "../../src/adapter/agent-executor";
 
 // repairToolCall は AI SDK の ToolCallRepairFunction 型だが、
@@ -30,10 +30,17 @@ describe("repairToolCall", () => {
 		expect(result).toBeNull();
 	});
 
-	it("returns null when escaped JSON is still invalid", async () => {
-		// 制御文字はあるが JSON 構造自体が壊れている
-		const broken = '{"command": \x01';
-		const result = await repairToolCall(makeOptions(broken));
-		expect(result).toBeNull();
+	it("returns null and logs debug info when escaped JSON is still invalid", async () => {
+		const debugSpy: MockInstance = vi.spyOn(console, "debug").mockImplementation(() => {});
+		try {
+			// 制御文字はあるが JSON 構造自体が壊れている
+			const broken = '{"command": \x01';
+			const result = await repairToolCall(makeOptions(broken));
+			expect(result).toBeNull();
+			expect(debugSpy).toHaveBeenCalledOnce();
+			expect(debugSpy.mock.calls[0]?.[0]).toMatch(/Tool call repair failed/);
+		} finally {
+			debugSpy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
#### 概要

repairToolCall で制御文字エスケープ後のJSON再パースが失敗した場合に、デバッグ情報（元の入力・エスケープ後の文字列・エラーメッセージ）を console.debug で出力するように改善。

#### 変更内容

- `src/adapter/agent-executor.ts`: catch ブロックでエラー詳細を console.debug で出力
- `tests/adapter/repair-tool-call.test.ts`: デバッグログ出力を検証するテストを追加

Closes #197