### PR TITLE
feat: config.toml スキーマ変更時の JSON Schema 不一致を自動検出

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,5 +7,7 @@ pre-push:
       run: bun run typecheck
     test:
       run: bun run test
+    verify-config-schema:
+      run: bun run verify-config-schema
     build:
       run: bun run build

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
 		"src/"
 	],
 	"scripts": {
-		"prepare": "lefthook install || true",
+		"prepare": "bun run generate-config-schema && lefthook install || true",
 
 		"dev": "bun run src/cli.ts",
 		"build": "bun build src/cli.ts --outdir dist --target bun",
 		"check": "biome check .",
 		"fix": "biome check --write .",
+		"generate-config-schema": "bun run scripts/generate-config-schema.ts",
+		"verify-config-schema": "bun run scripts/verify-config-schema.ts",
 		"typecheck": "tsc --noEmit",
 		"test": "bun x vitest run",
 		"test:watch": "bun x vitest"

--- a/scripts/verify-config-schema.ts
+++ b/scripts/verify-config-schema.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env bun
+/**
+ * .taskp/config.schema.json が config-loader.ts の Zod スキーマと一致するか検証する。
+ *
+ * Usage:
+ *   bun run scripts/verify-config-schema.ts
+ *
+ * 不一致の場合は非ゼロで終了し、再生成コマンドを案内する。
+ */
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { z } from "zod";
+import { configSchema } from "../src/adapter/config-loader";
+
+const schemaPath = resolve(import.meta.dirname, "../.taskp/config.schema.json");
+
+const expected = `${JSON.stringify(
+	z.toJSONSchema(configSchema, { target: "draft-2020-12" }),
+	null,
+	2,
+)}\n`;
+
+const actual = await readFile(schemaPath, "utf-8").catch(() => undefined);
+
+if (actual === undefined) {
+	console.error(`❌ ${schemaPath} が見つかりません。`);
+	console.error("   bun run generate-config-schema で生成してください。");
+	process.exit(1);
+}
+
+if (actual !== expected) {
+	console.error("❌ .taskp/config.schema.json が Zod スキーマと一致しません。");
+	console.error("   bun run generate-config-schema で再生成してください。");
+	process.exit(1);
+}
+
+console.log("✅ .taskp/config.schema.json is up to date.");


### PR DESCRIPTION
#### 概要

config.toml のスキーマ（Zod）変更時に JSON Schema ファイルとの不一致を自動検出する仕組みを追加。

#### 変更内容

- `scripts/verify-config-schema.ts` を追加（Zod スキーマから生成した JSON Schema と `.taskp/config.schema.json` を比較し、不一致時に非ゼロ終了）
- `lefthook.yml` の pre-push フックに `verify-config-schema` を追加
- `package.json` の `prepare` スクリプトで JSON Schema を自動再生成するよう変更
- `generate-config-schema` / `verify-config-schema` スクリプトを `package.json` に追加

Closes #199