### PR TITLE
fix: parseSkillMetadata のエラーメッセージにフィールドパス情報を含める

### DIFF
--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -35,12 +35,12 @@ type SkillMode = z.infer<typeof skillModeSchema>;
 type SkillMetadata = z.infer<typeof skillMetadataSchema>;
 
 function parseSkillMetadata(data: unknown): Result<SkillMetadata, ParseError> {
-	try {
-		return ok(skillMetadataSchema.parse(data));
-	} catch (e) {
-		const message = e instanceof Error ? e.message : String(e);
-		return err(parseError(`Invalid skill metadata: ${message}`));
+	const result = skillMetadataSchema.safeParse(data);
+	if (!result.success) {
+		const details = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+		return err(parseError(`Invalid skill metadata: ${details}`));
 	}
+	return ok(result.data);
 }
 
 export type { ContextSource, SkillInput, SkillMetadata, SkillMode };

--- a/tests/core/skill/skill-metadata.test.ts
+++ b/tests/core/skill/skill-metadata.test.ts
@@ -223,5 +223,16 @@ describe("parseSkillMetadata", () => {
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
 		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("name:");
+	});
+
+	it("エラーメッセージに不足フィールドのパス情報が含まれる", () => {
+		const result = parseSkillMetadata({});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.message).toContain("Invalid skill metadata:");
+		expect(result.error.message).toContain("name:");
+		expect(result.error.message).toContain("description:");
 	});
 });


### PR DESCRIPTION
#### 概要

parseSkillMetadata のエラーメッセージを詳細化し、不足フィールドのパス情報を含めるようにした。

#### 変更内容

- `schema.parse()` + try-catch を `schema.safeParse()` に置き換え
- Zod の issues からフィールドパスとメッセージを整形して返すように変更
- エラーメッセージにフィールドパス情報が含まれることを検証するテストを追加

Closes #200