### PR TITLE
refactor: DRY adapter error handling with shared tryCatch utilities

### DIFF
--- a/src/adapter/command-runner.ts
+++ b/src/adapter/command-runner.ts
@@ -2,8 +2,8 @@ import { execaCommand } from "execa";
 import type { ExecutionError } from "../core/types/errors";
 import { executionError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { err, ok } from "../core/types/result";
 import type { CommandExecutor, ExecOptions, ExecResult } from "../usecase/port/command-executor";
+import { tryCatch } from "./error-handler-utils";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -19,29 +19,23 @@ export function createCommandRunner(deps?: CommandRunnerDeps): CommandExecutor {
 			command: string,
 			options?: ExecOptions,
 		): Promise<Result<ExecResult, ExecutionError>> => {
-			try {
-				const result = await execaCommand(command, {
-					shell: true,
-					cwd: options?.cwd,
-					env: options?.env as Record<string, string> | undefined,
-					timeout: options?.timeout ?? timeoutMs,
-				});
+			return tryCatch(
+				async () => {
+					const result = await execaCommand(command, {
+						shell: true,
+						cwd: options?.cwd,
+						env: options?.env as Record<string, string> | undefined,
+						timeout: options?.timeout ?? timeoutMs,
+					});
 
-				return ok({
-					stdout: result.stdout,
-					stderr: result.stderr,
-					exitCode: result.exitCode ?? 0,
-				});
-			} catch (error: unknown) {
-				return err(executionError(toErrorMessage(error)));
-			}
+					return {
+						stdout: result.stdout,
+						stderr: result.stderr,
+						exitCode: result.exitCode ?? 0,
+					};
+				},
+				(e) => executionError(e.message),
+			);
 		},
 	};
-}
-
-function toErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
-	}
-	return String(error);
 }

--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -5,6 +5,7 @@ import { parse as parseToml } from "smol-toml";
 import { z } from "zod";
 import { type ConfigError, configError } from "../core/types/errors";
 import { err, ok, type Result } from "../core/types/result";
+import { tryCatchSync } from "./error-handler-utils";
 
 const CONFIG_PATH = ".taskp/config.toml";
 
@@ -105,15 +106,13 @@ async function loadSingleConfig(path: string): Promise<Result<Config, ConfigErro
 }
 
 function parseConfig(raw: string, path: string): Result<Config, ConfigError> {
-	let parsed: unknown;
-	try {
-		parsed = parseToml(raw);
-	} catch (e) {
-		const message = e instanceof Error ? e.message : String(e);
-		return err(configError(`Failed to parse TOML (${path}): ${message}`));
-	}
+	const parseResult = tryCatchSync(
+		() => parseToml(raw),
+		(e) => configError(`Failed to parse TOML (${path}): ${e.message}`),
+	);
+	if (!parseResult.ok) return parseResult;
 
-	const result = configSchema.safeParse(parsed);
+	const result = configSchema.safeParse(parseResult.value);
 	if (!result.success) {
 		return err(configError(`Invalid config (${path}): ${result.error.message}`));
 	}

--- a/src/adapter/context-collector-deps.ts
+++ b/src/adapter/context-collector-deps.ts
@@ -1,6 +1,7 @@
 import { executionError } from "../core/types/errors";
 import { err, ok } from "../core/types/result";
 import type { ContextCollectorDeps } from "./context-collector";
+import { toErrorMessage, tryCatch } from "./error-handler-utils";
 
 export async function createDefaultContextCollectorDeps(): Promise<ContextCollectorDeps> {
 	const { execa } = await import("execa");
@@ -23,8 +24,9 @@ export async function createDefaultContextCollectorDeps(): Promise<ContextCollec
 				}
 				return ok(result.stdout);
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return err(executionError(`Failed to execute command: ${command} (${message})`));
+				return err(
+					executionError(`Failed to execute command: ${command} (${toErrorMessage(error)})`),
+				);
 			}
 		},
 		fetchUrl: async (url) => {
@@ -35,24 +37,20 @@ export async function createDefaultContextCollectorDeps(): Promise<ContextCollec
 				}
 				return ok(await response.text());
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return err(executionError(`Network error fetching ${url}: ${message}`));
+				return err(executionError(`Network error fetching ${url}: ${toErrorMessage(error)}`));
 			}
 		},
 		scanGlob: async (pattern, cwd) => {
-			try {
-				const matches: string[] = [];
-				for await (const entry of glob(pattern, { cwd })) {
-					matches.push(entry);
-				}
-				return ok(matches);
-			} catch (e) {
-				return err(
-					executionError(
-						`Failed to scan glob: ${pattern} (${e instanceof Error ? e.message : String(e)})`,
-					),
-				);
-			}
+			return tryCatch(
+				async () => {
+					const matches: string[] = [];
+					for await (const entry of glob(pattern, { cwd })) {
+						matches.push(entry);
+					}
+					return matches;
+				},
+				(e) => executionError(`Failed to scan glob: ${pattern} (${e.message})`),
+			);
 		},
 	};
 }

--- a/src/adapter/context-collector.ts
+++ b/src/adapter/context-collector.ts
@@ -4,7 +4,8 @@ import type { ContextSource } from "../core/skill/context-source";
 import type { ExecutionError } from "../core/types/errors";
 import { executionError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { err, ok } from "../core/types/result";
+import { ok } from "../core/types/result";
+import { tryCatch } from "./error-handler-utils";
 
 type CollectedContext = {
 	readonly source: ContextSource;
@@ -74,12 +75,13 @@ async function collectFile(
 	cwd: string,
 ): Promise<Result<readonly CollectedContext[], ExecutionError>> {
 	const fullPath = join(cwd, path);
-	try {
-		const content = await readFile(fullPath, "utf-8");
-		return ok([{ source: { type: "file", path }, content }]);
-	} catch {
-		return err(executionError(`Failed to read file: ${fullPath}`));
-	}
+	return tryCatch(
+		async () => {
+			const content = await readFile(fullPath, "utf-8");
+			return [{ source: { type: "file" as const, path }, content }];
+		},
+		() => executionError(`Failed to read file: ${fullPath}`),
+	);
 }
 
 async function collectGlob(
@@ -98,15 +100,13 @@ async function collectGlob(
 	for (let i = 0; i < total; i++) {
 		const path = paths[i];
 		const fullPath = join(cwd, path);
-		try {
-			const content = await readFile(fullPath, "utf-8");
-			matches.push({ source: { type: "glob", pattern }, content });
-		} catch (e) {
-			const message = e instanceof Error ? e.message : String(e);
-			return err(
-				executionError(`Failed to read glob match (${i + 1}/${total}): ${fullPath}: ${message}`),
-			);
-		}
+		const readResult = await tryCatch(
+			() => readFile(fullPath, "utf-8"),
+			(e) =>
+				executionError(`Failed to read glob match (${i + 1}/${total}): ${fullPath}: ${e.message}`),
+		);
+		if (!readResult.ok) return readResult;
+		matches.push({ source: { type: "glob", pattern }, content: readResult.value });
 	}
 
 	return ok(matches);

--- a/src/adapter/error-handler-utils.ts
+++ b/src/adapter/error-handler-utils.ts
@@ -1,0 +1,29 @@
+import { err, ok, type Result } from "../core/types/result";
+
+export function toErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
+}
+
+export async function tryCatch<T, E>(
+	fn: () => Promise<T>,
+	errorFactory: (e: Error) => E,
+): Promise<Result<T, E>> {
+	try {
+		return ok(await fn());
+	} catch (e) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return err(errorFactory(error));
+	}
+}
+
+export function tryCatchSync<T, E>(fn: () => T, errorFactory: (e: Error) => E): Result<T, E> {
+	try {
+		return ok(fn());
+	} catch (e) {
+		const error = e instanceof Error ? e : new Error(String(e));
+		return err(errorFactory(error));
+	}
+}

--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -6,6 +6,7 @@ import { executionError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { err, ok } from "../core/types/result";
 import type { PromptCollectOptions, PromptCollector } from "../usecase/port/prompt-collector";
+import { toErrorMessage, tryCatchSync } from "./error-handler-utils";
 
 type PromptFn = (skillInput: SkillInput) => Promise<Result<string, ExecutionError>>;
 
@@ -67,13 +68,6 @@ function resolveNonInteractive(skillInput: SkillInput): Result<string, Execution
 		);
 	}
 	return ok("");
-}
-
-function toErrorMessage(error: unknown): string {
-	if (error instanceof Error) {
-		return error.message;
-	}
-	return String(error);
 }
 
 function wrapPromptError(error: unknown): Result<never, ExecutionError> {
@@ -218,9 +212,8 @@ function buildNumberValidator(
 }
 
 function compileRegex(pattern: string): Result<RegExp, ExecutionError> {
-	try {
-		return ok(new RegExp(pattern));
-	} catch {
-		return err(executionError(`Invalid regex pattern: ${pattern}`));
-	}
+	return tryCatchSync(
+		() => new RegExp(pattern),
+		() => executionError(`Invalid regex pattern: ${pattern}`),
+	);
 }

--- a/src/adapter/skill-initializer.ts
+++ b/src/adapter/skill-initializer.ts
@@ -2,8 +2,8 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Result } from "../core/types/result";
-import { err, ok } from "../core/types/result";
 import type { InitOptions, SkillInitializer } from "../usecase/port/skill-initializer";
+import { tryCatch } from "./error-handler-utils";
 
 const SKILL_DIR_NAME = ".taskp/skills";
 const SKILL_FILE_NAME = "SKILL.md";
@@ -57,15 +57,14 @@ export function createSkillInitializer(deps: SkillInitializerDeps): SkillInitial
 			const skillDir = join(deps.baseDir, SKILL_DIR_NAME, name);
 			const skillPath = join(skillDir, SKILL_FILE_NAME);
 
-			try {
-				await mkdir(skillDir, { recursive: true });
-				await writeFile(skillPath, generateSkillContent(name, options), "utf-8");
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				return err(new Error(`Failed to create skill "${name}": ${message}`));
-			}
-
-			return ok(skillPath);
+			return tryCatch(
+				async () => {
+					await mkdir(skillDir, { recursive: true });
+					await writeFile(skillPath, generateSkillContent(name, options), "utf-8");
+					return skillPath;
+				},
+				(e) => new Error(`Failed to create skill "${name}": ${e.message}`),
+			);
 		},
 	};
 }

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -57,7 +57,6 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 	} finally {
 		renderer.destroy();
 	}
-
 }
 
 type ModelAndConfig = {


### PR DESCRIPTION
#### 概要

adapter 層に重複していた try-catch → Result パターンを共通ユーティリティ (`tryCatch`, `tryCatchSync`, `toErrorMessage`) に抽出し、DRY 違反を解消。

#### 変更内容

- `src/adapter/error-handler-utils.ts` を新規作成（`tryCatch`, `tryCatchSync`, `toErrorMessage`）
- `command-runner.ts`: `tryCatch` を使用、ローカル `toErrorMessage` を削除
- `config-loader.ts`: TOML パース部分に `tryCatchSync` を適用
- `context-collector.ts`: `collectFile` と `collectGlob` 内の try-catch を `tryCatch` に置換
- `context-collector-deps.ts`: `scanGlob` に `tryCatch` を適用、`executeCommand`/`fetchUrl` は共有 `toErrorMessage` を使用
- `prompt-runner.ts`: ローカル `toErrorMessage` を削除し共有版をインポート、`compileRegex` に `tryCatchSync` を適用
- `skill-initializer.ts`: `tryCatch` を使用

Closes #201