### PR TITLE
fix: tryLoadSkill のファイル読み取りエラーを Result 型で伝播

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import type { Skill, SkillScope } from "../core/skill/skill";
 import { parseSkill } from "../core/skill/skill";
 import type { ParseError } from "../core/types/errors";
-import { type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
+import { parseError, type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { err } from "../core/types/result";
 import type { SkillLoadResult, SkillRepository } from "../usecase/port/skill-repository";
@@ -97,10 +97,19 @@ async function tryLoadSkill(
 	path: string,
 	scope: SkillScope,
 ): Promise<Result<Skill, ParseError> | undefined> {
-	const raw = await readFile(path, "utf-8").catch(() => undefined);
-	if (raw === undefined) {
-		return undefined;
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf-8");
+	} catch (e: unknown) {
+		if (isFileNotFound(e)) {
+			return undefined;
+		}
+		return err(parseError(`Failed to read skill file: ${path}`));
 	}
 
 	return parseSkill(raw, path, scope);
+}
+
+function isFileNotFound(e: unknown): boolean {
+	return e instanceof Error && "code" in e && e.code === "ENOENT";
 }

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -170,6 +170,21 @@ describe("SkillLoader", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("valid");
 			expect(failures).toHaveLength(1);
+		});
+
+		it("ファイル読み取りエラー時に failures に記録する", async () => {
+			createSkillFile(localRoot, "unreadable", makeSkillMd("unreadable", "読み取れない"));
+			const filePath = join(localRoot, ".taskp", "skills", "unreadable", "SKILL.md");
+			chmodSync(filePath, 0o000);
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const { skills, failures } = await loader.listLocal();
+
+			chmodSync(filePath, 0o644);
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(1);
+			expect(failures[0].path).toMatch(/unreadable/);
+			expect(failures[0].error).toMatch(/Failed to read skill file/);
 		});
 
 		it("ファイル不在時は failures に記録しない", async () => {


### PR DESCRIPTION
#### 概要

`tryLoadSkill` が ENOENT 以外のファイル読み取りエラー（EACCES 等）を握りつぶしていた問題を修正し、`Result` 型でエラーを返すようにした。

#### 変更内容

- `tryLoadSkill` の `.catch(() => undefined)` を try-catch に置き換え、ENOENT は `undefined`（既存動作維持）、それ以外は `err(parseError(...))` を返すように変更
- `isFileNotFound` ヘルパー関数を追加
- ファイル読み取りエラー時に `failures` に記録されることを検証するテストを追加

Closes #210