### PR TITLE
refactor: execution-view のファクトリー関数を DIP に準拠させる

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import type { Skill, SkillScope } from "../core/skill/skill";
 import { parseSkill } from "../core/skill/skill";
 import type { ParseError } from "../core/types/errors";
-import { type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
+import { parseError, type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { err } from "../core/types/result";
 import type { SkillLoadResult, SkillRepository } from "../usecase/port/skill-repository";
@@ -97,10 +97,19 @@ async function tryLoadSkill(
 	path: string,
 	scope: SkillScope,
 ): Promise<Result<Skill, ParseError> | undefined> {
-	const raw = await readFile(path, "utf-8").catch(() => undefined);
-	if (raw === undefined) {
-		return undefined;
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf-8");
+	} catch (e: unknown) {
+		if (isFileNotFound(e)) {
+			return undefined;
+		}
+		return err(parseError(`Failed to read skill file: ${path}`));
 	}
 
 	return parseSkill(raw, path, scope);
+}
+
+function isFileNotFound(e: unknown): boolean {
+	return e instanceof Error && "code" in e && e.code === "ENOENT";
 }

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -7,7 +7,12 @@ import { createHookExecutor } from "../adapter/hook-executor";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import type { HooksConfig } from "../usecase/hook-runner";
 import { copyToClipboard } from "./clipboard";
-import { type ExecutionDeps, showExecution } from "./screens/execution-view";
+import {
+	createPresetPromptCollector,
+	createSingleSkillRepository,
+	type ExecutionDeps,
+	showExecution,
+} from "./screens/execution-view";
 import { showInputForm } from "./screens/input-form";
 import { showSkillSelector } from "./screens/skill-selector";
 
@@ -42,7 +47,13 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 
 		const commandExecutor = createCommandRunner({ defaultTimeoutMs: commandTimeoutMs });
 		const hookExecutor = createHookExecutor(commandExecutor);
-		const executionDeps: ExecutionDeps = { commandExecutor, hookExecutor, hooksConfig };
+		const executionDeps: ExecutionDeps = {
+			commandExecutor,
+			hookExecutor,
+			hooksConfig,
+			skillRepositoryFactory: createSingleSkillRepository,
+			promptCollectorFactory: createPresetPromptCollector,
+		};
 
 		while (true) {
 			const skill = await showSkillSelector(renderer, skills);

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -18,10 +18,17 @@ import {
 	type ExecutionViewPort,
 } from "../tui-stream-writer";
 
+export type SkillRepositoryFactory = (skill: Skill) => SkillRepository;
+export type PromptCollectorFactory = (
+	variables: Readonly<Record<string, string>>,
+) => PromptCollector;
+
 export type ExecutionDeps = {
 	readonly commandExecutor: CommandExecutor;
 	readonly hookExecutor: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
+	readonly skillRepositoryFactory: SkillRepositoryFactory;
+	readonly promptCollectorFactory: PromptCollectorFactory;
 };
 
 export async function runExecution(
@@ -58,7 +65,7 @@ export function formatDomainError(error: DomainError): string {
 	return error.message;
 }
 
-export function buildSkillRepository(skill: Skill): SkillRepository {
+export function createSingleSkillRepository(skill: Skill): SkillRepository {
 	return {
 		findByName: async () => ok(skill),
 		listAll: async () => ({ skills: [], failures: [] }),
@@ -67,7 +74,9 @@ export function buildSkillRepository(skill: Skill): SkillRepository {
 	};
 }
 
-export function buildPromptCollector(variables: Readonly<Record<string, string>>): PromptCollector {
+export function createPresetPromptCollector(
+	variables: Readonly<Record<string, string>>,
+): PromptCollector {
 	return {
 		collect: async () => ok(variables as Record<string, string>),
 	};
@@ -90,8 +99,8 @@ async function executeAgentMode(
 	const result = await runAgentSkill(
 		{ name: skill.metadata.name, presets: variables, model },
 		{
-			skillRepository: buildSkillRepository(skill),
-			promptCollector: buildPromptCollector(variables),
+			skillRepository: deps.skillRepositoryFactory(skill),
+			promptCollector: deps.promptCollectorFactory(variables),
 			contextCollector,
 			agentExecutor,
 			progressWriter,
@@ -117,8 +126,8 @@ async function executeTemplateMode(
 	const result = await runSkill(
 		{ name: skill.metadata.name, presets: variables, dryRun: false, force: false },
 		{
-			skillRepository: buildSkillRepository(skill),
-			promptCollector: buildPromptCollector(variables),
+			skillRepository: deps.skillRepositoryFactory(skill),
+			promptCollector: deps.promptCollectorFactory(variables),
 			commandExecutor: deps.commandExecutor,
 			progressWriter,
 			hookExecutor: deps.hookExecutor,

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -15,7 +15,12 @@ import { ToolStatusDisplay } from "../components/tool-status";
 import type { ExecutionViewPort } from "../tui-stream-writer";
 import { type ExecutionDeps, runExecution } from "./execution-runner";
 
-export type { ExecutionDeps } from "./execution-runner";
+export type {
+	ExecutionDeps,
+	PromptCollectorFactory,
+	SkillRepositoryFactory,
+} from "./execution-runner";
+export { createPresetPromptCollector, createSingleSkillRepository } from "./execution-runner";
 
 const CONTAINER_ID = "exec-container";
 

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -170,6 +170,21 @@ describe("SkillLoader", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("valid");
 			expect(failures).toHaveLength(1);
+		});
+
+		it("ファイル読み取りエラー時に failures に記録する", async () => {
+			createSkillFile(localRoot, "unreadable", makeSkillMd("unreadable", "読み取れない"));
+			const filePath = join(localRoot, ".taskp", "skills", "unreadable", "SKILL.md");
+			chmodSync(filePath, 0o000);
+			const loader = createSkillLoader({ localRoot, globalRoot });
+
+			const { skills, failures } = await loader.listLocal();
+
+			chmodSync(filePath, 0o644);
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(1);
+			expect(failures[0].path).toMatch(/unreadable/);
+			expect(failures[0].error).toMatch(/Failed to read skill file/);
 		});
 
 		it("ファイル不在時は failures に記録しない", async () => {

--- a/tests/tui/screens/execution-view.test.ts
+++ b/tests/tui/screens/execution-view.test.ts
@@ -18,8 +18,8 @@ vi.mock("../../../src/adapter/context-collector-deps", () => ({
 }));
 
 import {
-	buildPromptCollector,
-	buildSkillRepository,
+	createPresetPromptCollector,
+	createSingleSkillRepository,
 	type ExecutionDeps,
 	formatDomainError,
 	runExecution,
@@ -72,6 +72,8 @@ function createMockDeps(): ExecutionDeps {
 	return {
 		commandExecutor: { execute: vi.fn() },
 		hookExecutor: { execute: vi.fn() },
+		skillRepositoryFactory: createSingleSkillRepository,
+		promptCollectorFactory: createPresetPromptCollector,
 	};
 }
 
@@ -92,27 +94,27 @@ describe("formatDomainError", () => {
 	});
 });
 
-describe("buildSkillRepository", () => {
+describe("createSingleSkillRepository", () => {
 	it("returns the skill from findByName", async () => {
 		const skill = createSkill("test", "template");
-		const repo = buildSkillRepository(skill);
+		const repo = createSingleSkillRepository(skill);
 		const result = await repo.findByName("anything");
 		expect(result).toEqual(ok(skill));
 	});
 
 	it("returns empty arrays for list methods", async () => {
 		const skill = createSkill("test", "template");
-		const repo = buildSkillRepository(skill);
+		const repo = createSingleSkillRepository(skill);
 		expect(await repo.listAll()).toEqual({ skills: [], failures: [] });
 		expect(await repo.listLocal()).toEqual({ skills: [], failures: [] });
 		expect(await repo.listGlobal()).toEqual({ skills: [], failures: [] });
 	});
 });
 
-describe("buildPromptCollector", () => {
+describe("createPresetPromptCollector", () => {
 	it("returns the provided variables", async () => {
 		const vars = { key: "value" };
-		const collector = buildPromptCollector(vars);
+		const collector = createPresetPromptCollector(vars);
 		const result = await collector.collect([], {});
 		expect(result).toEqual(ok({ key: "value" }));
 	});


### PR DESCRIPTION
#### 概要

execution-view.ts のファクトリー関数を依存性逆転原則（DIP）に準拠するようリファクタリング。

#### 変更内容

- `buildSkillRepository` → `createSingleSkillRepository` にリネーム・エクスポート
- `buildPromptCollector` → `createPresetPromptCollector` にリネーム・エクスポート
- `SkillRepositoryFactory` / `PromptCollectorFactory` 型を定義
- `ExecutionDeps` にファクトリーを必須フィールドとして追加（テスト時にモック注入可能）
- `app.ts` で具象ファクトリーを注入するように更新

Closes #211