### PR TITLE
refactor: remove --provider CLI option in favor of provider/model format

### DIFF
--- a/src/adapter/ai-provider.ts
+++ b/src/adapter/ai-provider.ts
@@ -17,7 +17,6 @@ export type ModelSpec = {
 
 export type ModelSource = {
 	readonly cliModel?: string;
-	readonly cliProvider?: string;
 	readonly skillModel?: string;
 	readonly config: AiConfig;
 };
@@ -185,8 +184,8 @@ export function resolveModelSpec(source: ModelSource): Result<ModelSpec, ConfigE
 		return resolveWithProvider(explicitSpec, source);
 	}
 
-	// 2. provider を解決（CLI --provider > config default_provider）
-	const resolvedProvider = source.cliProvider ?? source.config.default_provider;
+	// 2. config の default_provider を使用
+	const resolvedProvider = source.config.default_provider;
 
 	// 3. 解決された provider の default_model > トップレベル default_model
 	const providerDefaultModel = resolvedProvider
@@ -215,7 +214,7 @@ function resolveWithProvider(rawSpec: string, source: ModelSource): Result<Model
 		return ok({ provider, model });
 	}
 
-	const resolvedProvider = source.cliProvider ?? source.config.default_provider;
+	const resolvedProvider = source.config.default_provider;
 	if (resolvedProvider === undefined) {
 		return err(
 			configError(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,6 @@ const cli = Cli.create("taskp", {
 		}),
 		options: z.object({
 			model: z.string().optional().describe("LLM model to use"),
-			provider: z.string().optional().describe("LLM provider"),
 			dryRun: z.boolean().optional().describe("Show execution plan without running"),
 			force: z.boolean().optional().describe("Continue on error (template mode)"),
 			verbose: z.boolean().optional().describe("Show detailed logs"),
@@ -98,7 +97,6 @@ const cli = Cli.create("taskp", {
 		}),
 		alias: {
 			model: "m",
-			provider: "p",
 			force: "f",
 			verbose: "v",
 			set: "s",
@@ -236,15 +234,13 @@ const cli = Cli.create("taskp", {
 		description: "Launch interactive TUI",
 		options: z.object({
 			model: z.string().optional().describe("LLM model to use"),
-			provider: z.string().optional().describe("LLM provider"),
 		}),
 		alias: {
 			model: "m",
-			provider: "p",
 		},
 		async run(c) {
 			const { startTui } = await import("./tui/app");
-			await startTui({ model: c.options.model, provider: c.options.provider });
+			await startTui({ model: c.options.model });
 		},
 	})
 	.command("serve", {
@@ -258,7 +254,6 @@ type RunCommandContext = {
 	readonly args: { readonly skill: string };
 	readonly options: {
 		readonly model?: string;
-		readonly provider?: string;
 		readonly verbose?: boolean;
 		readonly skipPrompt?: boolean;
 	};
@@ -280,7 +275,6 @@ async function runAgentMode(
 	const aiConfig = configResult.value.ai ?? {};
 	const modelSpecResult = resolveModelSpec({
 		cliModel: c.options.model,
-		cliProvider: c.options.provider,
 		config: aiConfig,
 	});
 	if (!modelSpecResult.ok) {

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -19,7 +19,6 @@ import { showSkillSelector } from "./screens/skill-selector";
 
 export type TuiOptions = {
 	readonly model?: string;
-	readonly provider?: string;
 };
 
 export async function startTui(options?: TuiOptions): Promise<void> {
@@ -98,7 +97,6 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 	const aiConfig = configResult.value.ai ?? {};
 	const specResult = resolveModelSpec({
 		cliModel: options?.model,
-		cliProvider: options?.provider,
 		config: aiConfig,
 	});
 	if (!specResult.ok) return { model: null, modelSpec: null, hooksConfig, commandTimeoutMs };

--- a/tests/adapter/ai-provider.test.ts
+++ b/tests/adapter/ai-provider.test.ts
@@ -103,39 +103,11 @@ describe("resolveModelSpec", () => {
 		expect(result.error.message).toContain("No model specified");
 	});
 
-	it("cliProvider overrides config default_provider", () => {
-		const result = resolveModelSpec({
-			cliModel: "some-model",
-			cliProvider: "ollama",
-			config: { default_provider: "anthropic" },
-		});
-
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
-		expect(result.value).toEqual({ provider: "ollama", model: "some-model" });
-	});
-
-	it("uses provider-specific default_model when cliProvider is specified", () => {
-		const result = resolveModelSpec({
-			cliProvider: "ollama",
-			config: {
-				default_model: "global-model",
-				providers: {
-					ollama: { default_model: "qwen3.5:9b" },
-				},
-			},
-		});
-
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
-		expect(result.value).toEqual({ provider: "ollama", model: "qwen3.5:9b" });
-	});
-
 	it("cliModel takes priority over provider-specific default_model", () => {
 		const result = resolveModelSpec({
 			cliModel: "my-model",
-			cliProvider: "ollama",
 			config: {
+				default_provider: "ollama",
 				providers: {
 					ollama: { default_model: "qwen3.5:9b" },
 				},
@@ -165,8 +137,8 @@ describe("resolveModelSpec", () => {
 
 	it("falls back to top-level default_model when provider has no default_model", () => {
 		const result = resolveModelSpec({
-			cliProvider: "ollama",
 			config: {
+				default_provider: "ollama",
 				default_model: "global-model",
 				providers: {
 					ollama: { base_url: "http://localhost:11434/v1" },


### PR DESCRIPTION
#### 概要

`--provider` オプションを廃止し、`--model` の `provider/model` 形式に統一する。

#### 変更内容

- `run` コマンドの options から `provider` オプションを削除
- `tui` コマンドの options から `provider` オプションを削除
- `TuiOptions` 型から `provider` フィールドを削除
- `ModelSource` 型から `cliProvider` フィールドを削除
- `resolveModelSpec` / `resolveWithProvider` から `cliProvider` 参照を削除
- `cliProvider` 関連テストを削除・更新

Closes #234