### PR TITLE
feat: Action 型定義と Zod スキーマを追加

### DIFF
--- a/src/core/skill/action.ts
+++ b/src/core/skill/action.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { ContextSource } from "./context-source";
+import { contextSourceSchema } from "./context-source";
+import type { SkillInput } from "./skill-input";
+import { skillInputSchema } from "./skill-input";
+import type { SkillMetadata } from "./skill-metadata";
+
+const skillModeSchema = z.enum(["template", "agent"]);
+
+const DEFAULT_TOOLS = ["bash", "read", "write"] as const;
+
+const actionSchema = z.object({
+	description: z.string().min(1),
+	mode: skillModeSchema.optional(),
+	model: z.string().min(1).optional(),
+	inputs: z.array(skillInputSchema).optional(),
+	context: z.array(contextSourceSchema).optional(),
+	tools: z.array(z.string().min(1)).optional(),
+	timeout: z.number().int().positive().max(3_600_000).optional(),
+});
+
+type Action = z.infer<typeof actionSchema>;
+
+type ResolvedActionConfig = {
+	readonly description: string;
+	readonly mode: "template" | "agent";
+	readonly model: string | undefined;
+	readonly inputs: readonly SkillInput[];
+	readonly context: readonly ContextSource[];
+	readonly tools: readonly string[];
+	readonly timeout: number | undefined;
+};
+
+function resolveActionConfig(action: Action, skill: SkillMetadata): ResolvedActionConfig {
+	return {
+		description: action.description,
+		mode: action.mode ?? skill.mode ?? "template",
+		model: action.model ?? skill.model ?? undefined,
+		inputs: action.inputs ?? [],
+		context: action.context ?? skill.context ?? [],
+		tools: action.tools ?? skill.tools ?? [...DEFAULT_TOOLS],
+		timeout: action.timeout ?? skill.timeout ?? undefined,
+	};
+}
+
+export type { Action, ResolvedActionConfig };
+export { actionSchema, resolveActionConfig };

--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -1,5 +1,7 @@
 // Skill domain models
 
+export type { Action, ResolvedActionConfig } from "./action";
+export { resolveActionConfig } from "./action";
 export type { ContextSource } from "./context-source";
 export { parseContextSource } from "./context-source";
 export type { Skill, SkillScope } from "./skill";

--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -3,6 +3,7 @@ import type { ParseError } from "../types/errors";
 import { parseError } from "../types/errors";
 import type { Result } from "../types/result";
 import { err, ok } from "../types/result";
+import { actionSchema } from "./action";
 import type { ContextSource } from "./context-source";
 import { contextSourceSchema } from "./context-source";
 import type { SkillInput } from "./skill-input";
@@ -14,22 +15,38 @@ const skillModeSchema = z.enum(["template", "agent"]);
 // ツール未指定時のデフォルトセットを定義
 const DEFAULT_TOOLS = ["bash", "read", "write"] as const;
 
-const skillMetadataSchema = z.object({
-	name: z.string().min(1),
-	description: z.string().min(1),
-	mode: skillModeSchema.default("template"),
-	inputs: z.array(skillInputSchema).default([]),
-	model: z.string().min(1).optional(),
-	timeout: z
-		.number()
-		.int()
-		.positive()
-		.max(3_600_000)
-		.optional()
-		.describe("Timeout in milliseconds (max: 3,600,000 = 1 hour)"),
-	tools: z.array(z.string().min(1)).default([...DEFAULT_TOOLS]),
-	context: z.array(contextSourceSchema).default([]),
-});
+const skillMetadataSchema = z
+	.object({
+		name: z.string().min(1),
+		description: z.string().min(1),
+		mode: skillModeSchema.default("template"),
+		inputs: z.array(skillInputSchema).default([]),
+		model: z.string().min(1).optional(),
+		timeout: z
+			.number()
+			.int()
+			.positive()
+			.max(3_600_000)
+			.optional()
+			.describe("Timeout in milliseconds (max: 3,600,000 = 1 hour)"),
+		tools: z.array(z.string().min(1)).default([...DEFAULT_TOOLS]),
+		context: z.array(contextSourceSchema).default([]),
+		actions: z.record(z.string(), actionSchema).optional(),
+	})
+	.refine((data) => !data.actions || Object.keys(data.actions).length > 0, {
+		message: "actions must not be empty",
+		path: ["actions"],
+	})
+	.refine(
+		(data) => {
+			if (!data.actions) return true;
+			return Object.keys(data.actions).every((name) => !name.includes(":"));
+		},
+		{
+			message: "action name must not contain ':'",
+			path: ["actions"],
+		},
+	);
 
 type SkillMode = z.infer<typeof skillModeSchema>;
 type SkillMetadata = z.infer<typeof skillMetadataSchema>;

--- a/tests/core/skill/action.test.ts
+++ b/tests/core/skill/action.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { Action } from "../../../src/core/skill/action";
+import { resolveActionConfig } from "../../../src/core/skill/action";
+import type { SkillMetadata } from "../../../src/core/skill/skill-metadata";
+
+function baseSkill(overrides: Partial<SkillMetadata> = {}): SkillMetadata {
+	return {
+		name: "test-skill",
+		description: "A test skill",
+		mode: "template",
+		inputs: [{ name: "target", type: "text", message: "Target?" }],
+		tools: ["bash", "read", "write"],
+		context: [],
+		...overrides,
+	};
+}
+
+function baseAction(overrides: Partial<Action> = {}): Action {
+	return {
+		description: "An action",
+		...overrides,
+	};
+}
+
+describe("resolveActionConfig", () => {
+	it("アクション未指定フィールドはスキルから継承される", () => {
+		const skill = baseSkill({
+			mode: "agent",
+			model: "claude-sonnet-4-20250514",
+			context: [{ type: "file", path: "README.md" }],
+			tools: ["bash"],
+			timeout: 60000,
+		});
+		const action = baseAction();
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.mode).toBe("agent");
+		expect(resolved.model).toBe("claude-sonnet-4-20250514");
+		expect(resolved.context).toStrictEqual([{ type: "file", path: "README.md" }]);
+		expect(resolved.tools).toStrictEqual(["bash"]);
+		expect(resolved.timeout).toBe(60000);
+	});
+
+	it("アクション指定フィールドはスキルより優先される", () => {
+		const skill = baseSkill({
+			mode: "template",
+			model: "gpt-4",
+			context: [{ type: "file", path: "old.md" }],
+			tools: ["bash"],
+			timeout: 30000,
+		});
+		const action = baseAction({
+			mode: "agent",
+			model: "claude-sonnet-4-20250514",
+			context: [{ type: "file", path: "new.md" }],
+			tools: ["bash", "read", "write"],
+			timeout: 120000,
+		});
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.mode).toBe("agent");
+		expect(resolved.model).toBe("claude-sonnet-4-20250514");
+		expect(resolved.context).toStrictEqual([{ type: "file", path: "new.md" }]);
+		expect(resolved.tools).toStrictEqual(["bash", "read", "write"]);
+		expect(resolved.timeout).toBe(120000);
+	});
+
+	it("スキルも未指定のフィールドはデフォルト値にフォールバックする", () => {
+		const skill = baseSkill();
+		const action = baseAction();
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.mode).toBe("template");
+		expect(resolved.model).toBeUndefined();
+		expect(resolved.context).toStrictEqual([]);
+		expect(resolved.tools).toStrictEqual(["bash", "read", "write"]);
+		expect(resolved.timeout).toBeUndefined();
+	});
+
+	it("inputs はスキルから継承しない", () => {
+		const skill = baseSkill({
+			inputs: [{ name: "target", type: "text", message: "Target?" }],
+		});
+		const action = baseAction();
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.inputs).toStrictEqual([]);
+	});
+
+	it("アクション固有の inputs が使用される", () => {
+		const skill = baseSkill({
+			inputs: [{ name: "skill-input", type: "text", message: "Skill input?" }],
+		});
+		const actionInputs = [
+			{ name: "action-input", type: "text" as const, message: "Action input?" },
+		];
+		const action = baseAction({ inputs: actionInputs });
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.inputs).toStrictEqual(actionInputs);
+	});
+
+	it("description はアクション自身のものが使用される", () => {
+		const skill = baseSkill();
+		const action = baseAction({ description: "Custom action description" });
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.description).toBe("Custom action description");
+	});
+});

--- a/tests/core/skill/skill-metadata.test.ts
+++ b/tests/core/skill/skill-metadata.test.ts
@@ -235,4 +235,67 @@ describe("parseSkillMetadata", () => {
 		expect(result.error.message).toContain("name:");
 		expect(result.error.message).toContain("description:");
 	});
+
+	it("actions 付きメタデータが正しくパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "multi-action",
+			description: "複数アクションを持つスキル",
+			mode: "agent",
+			actions: {
+				lint: {
+					description: "Lint を実行する",
+					mode: "template",
+				},
+				fix: {
+					description: "自動修正する",
+					mode: "agent",
+					model: "claude-sonnet-4-20250514",
+					inputs: [{ name: "target", type: "text", message: "対象ファイル" }],
+					context: [{ type: "file", path: "src/" }],
+					tools: ["bash", "read", "write"],
+					timeout: 120000,
+				},
+			},
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.actions).toBeDefined();
+		const { actions } = result.value;
+		expect(actions).toBeDefined();
+		if (!actions) return;
+		expect(Object.keys(actions)).toStrictEqual(["lint", "fix"]);
+		expect(actions.lint.description).toBe("Lint を実行する");
+		expect(actions.fix.model).toBe("claude-sonnet-4-20250514");
+	});
+
+	it("actions が空オブジェクトでエラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "test",
+			description: "test",
+			actions: {},
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("actions must not be empty");
+	});
+
+	it("アクション名にコロンを含む場合エラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "test",
+			description: "test",
+			actions: {
+				"ns:action": {
+					description: "invalid name",
+				},
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("action name must not contain ':'");
+	});
 });


### PR DESCRIPTION
#### 概要

スキルアクション機能のドメインモデルとして Action 型・Zod スキーマを定義し、フロントマターの actions フィールドをパース可能にした。

#### 変更内容

- `src/core/skill/action.ts`: Action型、ResolvedActionConfig型、actionSchema、resolveActionConfig関数を新規作成
- `src/core/skill/skill-metadata.ts`: actionsフィールド追加（空オブジェクト・コロン含み名のバリデーション付き）
- `src/core/skill/index.ts`: Action関連のre-export追加
- `tests/core/skill/action.test.ts`: resolveActionConfigの継承・フォールバックテスト（6件）
- `tests/core/skill/skill-metadata.test.ts`: actionsバリデーションテスト追加（3件）

Closes #236