### PR TITLE
feat: SkillBody にアクションセクション対応メソッドを追加

### DIFF
--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -1,6 +1,8 @@
 import matter from "gray-matter";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
+import type { ActionSection } from "./action-section-parser";
+import { getActionSection, parseActionSections } from "./action-section-parser";
 
 export interface CodeBlock {
 	readonly lang: string;
@@ -10,6 +12,8 @@ export interface CodeBlock {
 export interface SkillBody {
 	readonly content: string;
 	readonly extractCodeBlocks: (lang?: string) => readonly CodeBlock[];
+	readonly extractActionSection: (name: string) => string | undefined;
+	readonly extractActionCodeBlocks: (name: string, lang?: string) => readonly CodeBlock[];
 }
 
 export function createSkillBody(rawMarkdown: string): SkillBody {
@@ -17,9 +21,29 @@ export function createSkillBody(rawMarkdown: string): SkillBody {
 	// （メタデータは SkillMetadata 側で管理するため分離）
 	const { content } = matter(rawMarkdown);
 
+	// アクションセクションは content から一度だけパースしてキャッシュする
+	let cachedSections: readonly ActionSection[] | null = null;
+	const getSections = (): readonly ActionSection[] => {
+		if (cachedSections === null) {
+			const result = parseActionSections(rawMarkdown);
+			if (!result.ok) return [];
+			cachedSections = result.value;
+		}
+		return cachedSections;
+	};
+
 	return {
 		content,
 		extractCodeBlocks: (lang = "bash") => extractCodeBlocks(content, lang),
+		extractActionSection: (name: string) => {
+			const section = getActionSection(getSections(), name);
+			return section?.content;
+		},
+		extractActionCodeBlocks: (name: string, lang = "bash") => {
+			const section = getActionSection(getSections(), name);
+			if (!section) return [];
+			return extractCodeBlocks(section.content, lang);
+		},
 	};
 }
 

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -3,6 +3,9 @@ import type { ParseError } from "../types/errors";
 import { parseError } from "../types/errors";
 import type { Result } from "../types/result";
 import { err, ok } from "../types/result";
+import type { Action } from "./action";
+import type { ActionSection } from "./action-section-parser";
+import { parseActionSections } from "./action-section-parser";
 import type { SkillBody } from "./skill-body";
 import { createSkillBody } from "./skill-body";
 import type { SkillMetadata } from "./skill-metadata";
@@ -37,12 +40,67 @@ export function parseSkill(
 		return metadataResult;
 	}
 
+	const metadata = metadataResult.value;
+
+	if (metadata.actions) {
+		const validationResult = validateActionSections(raw, metadata);
+		if (!validationResult.ok) {
+			return validationResult;
+		}
+	}
+
 	return ok({
-		metadata: metadataResult.value,
+		metadata,
 		body: createSkillBody(raw),
 		location,
 		scope: scope ?? inferScope(location),
 	});
+}
+
+function validateActionSections(raw: string, metadata: SkillMetadata): Result<void, ParseError> {
+	const actions = metadata.actions as Record<string, Action>;
+	const sectionsResult = parseActionSections(raw);
+	if (!sectionsResult.ok) return err(parseError("Failed to parse action sections"));
+	const sections: readonly ActionSection[] = sectionsResult.value;
+
+	const actionKeys = new Set(Object.keys(actions));
+	const sectionNames = new Set(sections.map((section: ActionSection) => section.name));
+
+	for (const key of actionKeys) {
+		if (!sectionNames.has(key)) {
+			return err(
+				parseError(
+					`Action "${key}" is defined in metadata but has no corresponding ## action:${key} section in body`,
+				),
+			);
+		}
+	}
+
+	for (const name of sectionNames) {
+		if (!actionKeys.has(name)) {
+			return err(
+				parseError(
+					`Section ## action:${name} exists in body but "${name}" is not defined in actions metadata`,
+				),
+			);
+		}
+	}
+
+	for (const [key, action] of Object.entries(actions) as [string, Action][]) {
+		const effectiveMode = action.mode ?? metadata.mode ?? "template";
+		if (effectiveMode === "template") {
+			const section = sections.find((s: ActionSection) => s.name === key);
+			if (section && section.codeBlocks.length === 0) {
+				return err(
+					parseError(
+						`Template action "${key}" requires at least one code block in ## action:${key} section`,
+					),
+				);
+			}
+		}
+	}
+
+	return ok(undefined);
 }
 
 function inferScope(location: string): SkillScope {

--- a/tests/core/skill/skill.test.ts
+++ b/tests/core/skill/skill.test.ts
@@ -84,6 +84,16 @@ describe("parseSkill", () => {
 			expect(result.value.scope).toBe("global");
 		});
 
+		it("with-actions フィクスチャをパースできる", () => {
+			const raw = readFixture("with-actions");
+			const result = parseSkill(raw, "/project/.taskp/skills/manage/SKILL.md");
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			expect(result.value.metadata.actions).toBeDefined();
+			expect(result.value.body.extractActionCodeBlocks("add", "bash")).toHaveLength(1);
+		});
+
 		it("invalid-frontmatter フィクスチャでエラーになる", () => {
 			const raw = readFixture("invalid-frontmatter");
 			const result = parseSkill(raw, "/path/to/SKILL.md");
@@ -100,6 +110,133 @@ describe("parseSkill", () => {
 			if (!result.ok) return;
 
 			expect(result.value.metadata.context).toHaveLength(4);
+		});
+	});
+
+	describe("アクションバリデーション", () => {
+		it("actions キーに対応するセクションがない場合エラーになる", () => {
+			const raw = [
+				"---",
+				"name: manage",
+				'description: "管理スキル"',
+				"actions:",
+				"  add:",
+				'    description: "追加"',
+				"  delete:",
+				'    description: "削除"',
+				"---",
+				"",
+				"## action:add",
+				"",
+				"```bash",
+				"echo add",
+				"```",
+			].join("\n");
+
+			const result = parseSkill(raw, "/path/to/SKILL.md");
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+
+			expect(result.error.type).toBe("PARSE_ERROR");
+			expect(result.error.message).toContain("delete");
+			expect(result.error.message).toContain("no corresponding");
+		});
+
+		it("セクションがあるが actions に定義がない場合エラーになる", () => {
+			const raw = [
+				"---",
+				"name: manage",
+				'description: "管理スキル"',
+				"actions:",
+				"  add:",
+				'    description: "追加"',
+				"---",
+				"",
+				"## action:add",
+				"",
+				"```bash",
+				"echo add",
+				"```",
+				"",
+				"## action:delete",
+				"",
+				"```bash",
+				"echo delete",
+				"```",
+			].join("\n");
+
+			const result = parseSkill(raw, "/path/to/SKILL.md");
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+
+			expect(result.error.type).toBe("PARSE_ERROR");
+			expect(result.error.message).toContain("delete");
+			expect(result.error.message).toContain("not defined in actions");
+		});
+
+		it("template モードのアクションにコードブロックがない場合エラーになる", () => {
+			const raw = [
+				"---",
+				"name: manage",
+				'description: "管理スキル"',
+				"mode: template",
+				"actions:",
+				"  add:",
+				'    description: "追加"',
+				"---",
+				"",
+				"## action:add",
+				"",
+				"No code blocks here.",
+			].join("\n");
+
+			const result = parseSkill(raw, "/path/to/SKILL.md");
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+
+			expect(result.error.type).toBe("PARSE_ERROR");
+			expect(result.error.message).toContain("requires at least one code block");
+		});
+
+		it("agent モードのアクションはコードブロックなしでもパースできる", () => {
+			const raw = [
+				"---",
+				"name: manage",
+				'description: "管理スキル"',
+				"mode: agent",
+				"actions:",
+				"  review:",
+				'    description: "レビュー"',
+				"---",
+				"",
+				"## action:review",
+				"",
+				"Please review the code.",
+			].join("\n");
+
+			const result = parseSkill(raw, "/path/to/SKILL.md");
+			expect(result.ok).toBe(true);
+		});
+
+		it("アクション個別に agent モードを指定した場合コードブロック不要", () => {
+			const raw = [
+				"---",
+				"name: manage",
+				'description: "管理スキル"',
+				"mode: template",
+				"actions:",
+				"  review:",
+				'    description: "レビュー"',
+				"    mode: agent",
+				"---",
+				"",
+				"## action:review",
+				"",
+				"Please review the code.",
+			].join("\n");
+
+			const result = parseSkill(raw, "/path/to/SKILL.md");
+			expect(result.ok).toBe(true);
 		});
 	});
 });

--- a/tests/fixtures/skills/with-actions/SKILL.md
+++ b/tests/fixtures/skills/with-actions/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: manage
+description: "リソースを管理する"
+mode: template
+actions:
+  add:
+    description: "リソースを追加する"
+  delete:
+    description: "リソースを削除する"
+---
+
+# リソース管理
+
+このスキルはリソースの追加・削除を行います。
+
+## action:add
+
+リソースを追加します。
+
+```bash
+echo "adding resource"
+```
+
+## action:delete
+
+リソースを削除します。
+
+```bash
+echo "deleting resource"
+```

--- a/tests/unit/skill/skill-body.test.ts
+++ b/tests/unit/skill/skill-body.test.ts
@@ -3,6 +3,37 @@ import { createSkillBody } from "../../../src/core/skill/skill-body";
 
 const withFrontmatter = (body: string) => `---\nname: test\ndescription: test skill\n---\n${body}`;
 
+const withActionSections = () =>
+	withFrontmatter(
+		[
+			"",
+			"# Overview",
+			"",
+			"General description.",
+			"",
+			"## action:add",
+			"",
+			"Add something.",
+			"",
+			"```bash",
+			"echo add",
+			"```",
+			"",
+			"## action:delete",
+			"",
+			"Delete something.",
+			"",
+			"```bash",
+			"echo delete",
+			"```",
+			"",
+			"```python",
+			"print('delete')",
+			"```",
+			"",
+		].join("\n"),
+	);
+
 describe("createSkillBody", () => {
 	it("フロントマターを除去した本文を保持する", () => {
 		const raw = withFrontmatter("\n# Title\n\nSome content\n");
@@ -88,5 +119,46 @@ describe("extractCodeBlocks", () => {
 		const blocks = body.extractCodeBlocks("python");
 
 		expect(blocks).toEqual([{ lang: "python", code: "print('hi')" }]);
+	});
+});
+
+describe("extractActionSection", () => {
+	it("指定アクション名のセクション内容を返す", () => {
+		const body = createSkillBody(withActionSections());
+		const content = body.extractActionSection("add");
+
+		expect(content).toBeDefined();
+		expect(content).toContain("Add something.");
+		expect(content).toContain("echo add");
+	});
+
+	it("存在しないアクション名は undefined を返す", () => {
+		const body = createSkillBody(withActionSections());
+		const content = body.extractActionSection("nonexistent");
+
+		expect(content).toBeUndefined();
+	});
+});
+
+describe("extractActionCodeBlocks", () => {
+	it("指定アクションの bash コードブロックを返す", () => {
+		const body = createSkillBody(withActionSections());
+		const blocks = body.extractActionCodeBlocks("add");
+
+		expect(blocks).toEqual([{ lang: "bash", code: "echo add" }]);
+	});
+
+	it("lang 引数で任意の言語を指定して抽出できる", () => {
+		const body = createSkillBody(withActionSections());
+		const blocks = body.extractActionCodeBlocks("delete", "python");
+
+		expect(blocks).toEqual([{ lang: "python", code: "print('delete')" }]);
+	});
+
+	it("存在しないアクション名は空配列を返す", () => {
+		const body = createSkillBody(withActionSections());
+		const blocks = body.extractActionCodeBlocks("nonexistent");
+
+		expect(blocks).toEqual([]);
 	});
 });

--- a/tests/usecase/init-skill.test.ts
+++ b/tests/usecase/init-skill.test.ts
@@ -31,7 +31,12 @@ function makeSkill(name: string): Skill {
 			tools: [],
 			context: [],
 		},
-		body: { content: "", extractCodeBlocks: () => [] },
+		body: {
+			content: "",
+			extractCodeBlocks: () => [],
+			extractActionSection: () => undefined,
+			extractActionCodeBlocks: () => [],
+		},
 		location: `.taskp/skills/${name}/SKILL.md`,
 		scope: "local",
 	};

--- a/tests/usecase/list-skills.test.ts
+++ b/tests/usecase/list-skills.test.ts
@@ -15,7 +15,12 @@ function createSkill(name: string, scope: SkillScope): Skill {
 			tools: ["bash", "read", "write"],
 			context: [],
 		},
-		body: { content: `# ${name}`, extractCodeBlocks: () => [] },
+		body: {
+			content: `# ${name}`,
+			extractCodeBlocks: () => [],
+			extractActionSection: () => undefined,
+			extractActionCodeBlocks: () => [],
+		},
 		location:
 			scope === "local" ? `/project/.taskp/skills/${name}/SKILL.md` : `/global/${name}/SKILL.md`,
 		scope,

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -27,6 +27,8 @@ function createAgentSkill(overrides?: Partial<Skill["metadata"]>): Skill {
 		body: {
 			content: "You are a helpful assistant.",
 			extractCodeBlocks: () => [],
+			extractActionSection: () => undefined,
+			extractActionCodeBlocks: () => [],
 		},
 		location: "/tmp/test",
 		scope: "local",

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -37,7 +37,12 @@ function createSkill(overrides: Partial<Skill["metadata"]> = {}): Skill {
 			],
 			...overrides,
 		},
-		body: { content: "# deploy", extractCodeBlocks: () => [] },
+		body: {
+			content: "# deploy",
+			extractCodeBlocks: () => [],
+			extractActionSection: () => undefined,
+			extractActionCodeBlocks: () => [],
+		},
 		location: "/project/.taskp/skills/deploy/SKILL.md",
 		scope: "local",
 	};


### PR DESCRIPTION
#### 概要

SkillBody にアクションセクション関連メソッドを追加し、parseSkill で actions とセクションの整合性バリデーションを実装。

#### 変更内容

- `extractActionSection` / `extractActionCodeBlocks` メソッドを SkillBody インターフェースに追加
- `parseSkill` で actions メタデータと本文の `## action:<name>` セクションの双方向整合性チェック
- template モードアクションのコードブロック必須バリデーション
- テスト追加（skill-body.test.ts, skill.test.ts）
- with-actions フィクスチャ追加

Closes #238