### PR TITLE
feat: runSkill のアクション対応（template モード）

### DIFF
--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,8 +1,11 @@
 import { dirname } from "node:path";
+import { resolveActionConfig } from "../core/skill/action";
+import { getActionSection, parseActionSections } from "../core/skill/action-section-parser";
+import type { Skill } from "../core/skill/skill";
 import type { CodeBlock } from "../core/skill/skill-body";
-import { type DomainError, domainErrorMessage } from "../core/types/errors";
+import { type DomainError, domainErrorMessage, executionError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { ok } from "../core/types/result";
+import { err, ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
@@ -14,6 +17,7 @@ import type { SkillRepository } from "./port/skill-repository";
 
 export type RunSkillInput = {
 	readonly name: string;
+	readonly action?: string;
 	readonly presets: Readonly<Record<string, string>>;
 	readonly dryRun: boolean;
 	readonly force: boolean;
@@ -51,7 +55,97 @@ export async function runSkill(
 	}
 
 	const skill = findResult.value;
+	const hasActions = skill.metadata.actions !== undefined;
 
+	if (hasActions && !input.action) {
+		return err(
+			executionError(
+				`Skill "${skill.metadata.name}" has actions defined. Specify an action to run.`,
+			),
+		);
+	}
+
+	if (input.action) {
+		return runWithAction({ ...input, action: input.action }, skill, deps);
+	}
+
+	return runWithoutAction(input, skill, deps);
+}
+
+async function runWithAction(
+	input: RunSkillInput & { readonly action: string },
+	skill: Skill,
+	deps: RunSkillDeps,
+): Promise<Result<RunOutput, DomainError>> {
+	const actions = skill.metadata.actions;
+	if (!actions) {
+		return err(executionError(`Skill "${skill.metadata.name}" does not define actions.`));
+	}
+
+	const action = actions[input.action];
+	if (!action) {
+		return err(
+			executionError(`Action "${input.action}" not found in skill "${skill.metadata.name}".`),
+		);
+	}
+
+	const config = resolveActionConfig(action, skill.metadata);
+
+	const collectResult = await deps.promptCollector.collect(config.inputs, input.presets, {
+		noInput: input.noInput,
+	});
+	if (!collectResult.ok) {
+		return collectResult;
+	}
+	const variables = collectResult.value;
+
+	const progress = deps.progressWriter ?? createNoopProgressWriter();
+	progress.writeInputs(config.inputs, variables);
+
+	const reserved: ReservedVars = {
+		cwd: process.cwd(),
+		skillDir: dirname(skill.location),
+		date: new Date().toISOString().split("T")[0],
+		timestamp: new Date().toISOString(),
+	};
+
+	const sectionsResult = parseActionSections(skill.body.content);
+	if (!sectionsResult.ok) {
+		return sectionsResult;
+	}
+
+	const section = getActionSection(sectionsResult.value, input.action);
+	if (!section) {
+		return err(executionError(`Action section "action:${input.action}" not found in skill body.`));
+	}
+
+	const renderResult = renderTemplate(section.content, variables, reserved);
+	if (!renderResult.ok) {
+		return renderResult;
+	}
+
+	const rendered = renderResult.value;
+	const codeBlocks = section.codeBlocks;
+
+	if (input.dryRun) {
+		return ok({
+			skillName: skill.metadata.name,
+			rendered,
+			commands: [],
+			dryRun: true,
+		});
+	}
+
+	const timeout = config.timeout;
+
+	return executeAndReport(skill, codeBlocks, variables, reserved, input, deps, rendered, timeout);
+}
+
+async function runWithoutAction(
+	input: RunSkillInput,
+	skill: Skill,
+	deps: RunSkillDeps,
+): Promise<Result<RunOutput, DomainError>> {
 	const collectResult = await deps.promptCollector.collect(skill.metadata.inputs, input.presets, {
 		noInput: input.noInput,
 	});
@@ -87,16 +181,36 @@ export async function runSkill(
 		});
 	}
 
+	return executeAndReport(
+		skill,
+		codeBlocks,
+		variables,
+		reserved,
+		input,
+		deps,
+		rendered,
+		skill.metadata.timeout,
+	);
+}
+
+async function executeAndReport(
+	skill: Skill,
+	codeBlocks: readonly CodeBlock[],
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+	input: RunSkillInput,
+	deps: RunSkillDeps,
+	rendered: string,
+	timeout: number | undefined,
+): Promise<Result<RunOutput, DomainError>> {
 	const startTime = Date.now();
 
-	// template モードではマークダウン内の bash コードブロックを順に実行する。
-	// force=true なら1つ失敗しても残りを続行する（CI パイプライン的な使い方に対応）
 	const commandResults = await executeCommands(
 		codeBlocks,
 		variables,
 		reserved,
 		deps.commandExecutor,
-		{ force: input.force, timeout: skill.metadata.timeout },
+		{ force: input.force, timeout },
 	);
 
 	const durationMs = Date.now() - startTime;

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -416,4 +416,179 @@ echo "step 2 {{env}}"
 			expect(hookExecutor.execute).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("action support", () => {
+		const ACTION_SKILL_MD = `---
+name: task
+description: Task manager
+mode: template
+actions:
+  add:
+    description: Add a task
+    inputs:
+      - name: title
+        type: text
+        message: "Task title?"
+  list:
+    description: List tasks
+---
+
+## action: add
+
+Add task: {{title}}
+
+\`\`\`bash
+echo "adding {{title}}"
+\`\`\`
+
+## action: list
+
+\`\`\`bash
+echo "listing tasks"
+\`\`\`
+`;
+
+		function createActionSkill(): Skill {
+			return {
+				metadata: {
+					name: "task",
+					description: "Task manager",
+					mode: "template",
+					inputs: [],
+					model: undefined,
+					tools: ["bash", "read", "write"],
+					context: [],
+					actions: {
+						add: {
+							description: "Add a task",
+							inputs: [{ name: "title", type: "text", message: "Task title?" }],
+						},
+						list: {
+							description: "List tasks",
+						},
+					},
+				},
+				body: createSkillBody(ACTION_SKILL_MD),
+				location: "/skills/task",
+				scope: "global",
+			};
+		}
+
+		it("executes only the specified action's code blocks", async () => {
+			const executedCommands: string[] = [];
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: stubCollector({}),
+				commandExecutor: {
+					execute: async (command: string) => {
+						executedCommands.push(command);
+						return ok({ stdout: `ok: ${command}`, stderr: "", exitCode: 0 });
+					},
+				},
+			});
+
+			const result = await runSkill(createInput({ name: "task", action: "list" }), deps);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.commands).toHaveLength(1);
+			expect(result.value.commands[0].command).toContain("listing tasks");
+			expect(executedCommands).not.toContain(expect.stringContaining("adding"));
+		});
+
+		it("collects action-specific inputs", async () => {
+			let collectedInputNames: string[] = [];
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: {
+					collect: async (inputs, _presets) => {
+						collectedInputNames = inputs.map((i) => i.name);
+						return ok({ title: "my task" });
+					},
+				},
+			});
+
+			const result = await runSkill(createInput({ name: "task", action: "add" }), deps);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(collectedInputNames).toEqual(["title"]);
+			expect(result.value.commands[0].command).toContain("adding my task");
+		});
+
+		it("returns error for non-existent action", async () => {
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: stubCollector({}),
+			});
+
+			const result = await runSkill(createInput({ name: "task", action: "nonexistent" }), deps);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			if (result.error.type !== "EXECUTION_ERROR") return;
+			expect(result.error.message).toContain("nonexistent");
+		});
+
+		it("returns error when action is not specified for skill with actions", async () => {
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: stubCollector({}),
+			});
+
+			const result = await runSkill(createInput({ name: "task" }), deps);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			if (result.error.type !== "EXECUTION_ERROR") return;
+			expect(result.error.message).toContain("actions defined");
+		});
+
+		it("supports --set presets for action variables", async () => {
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: {
+					collect: async (_inputs, presets) => ok({ title: "default", ...presets }),
+				},
+			});
+
+			const result = await runSkill(
+				createInput({ name: "task", action: "add", presets: { title: "preset task" } }),
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.commands[0].command).toContain("adding preset task");
+		});
+
+		it("returns rendered content without executing in --dry-run mode for action", async () => {
+			const deps = createDeps({
+				skillRepository: stubRepository(createActionSkill()),
+				promptCollector: stubCollector({ title: "dry run task" }),
+			});
+
+			const result = await runSkill(
+				createInput({ name: "task", action: "add", dryRun: true }),
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.dryRun).toBe(true);
+			expect(result.value.commands).toHaveLength(0);
+			expect(result.value.rendered).toContain("adding dry run task");
+		});
+
+		it("does not break existing non-action skills", async () => {
+			const result = await runSkill(createInput(), createDeps());
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.skillName).toBe("deploy");
+			expect(result.value.commands).toHaveLength(1);
+		});
+	});
 });


### PR DESCRIPTION
#### 概要

`runSkill` ユースケースをアクション対応に拡張。アクション指定時は該当セクションのコードブロックのみを実行する。

#### 変更内容

- `RunSkillInput` に `action?: string` フィールドを追加
- アクション指定時: `resolveActionConfig` で設定を解決し、アクション固有の `inputs` で変数収集、セクション内のコードブロックのみ実行
- `actions` ありスキルでアクション未指定時はエラーを返す
- `executeAndReport` ヘルパーで実行・フック呼び出しロジックを共通化
- テスト7件追加（アクション実行、inputs 収集、エラーケース、dry-run、presets、従来動作の維持）

Closes #239