### PR TITLE
feat: CLI の skill:action パースとコマンド更新

### DIFF
--- a/src/adapter/skill-initializer.ts
+++ b/src/adapter/skill-initializer.ts
@@ -12,43 +12,93 @@ type SkillInitializerDeps = {
 	readonly baseDir: string;
 };
 
-function generateTemplateContent(name: string, description: string): string {
-	return [
+function generateActionsYaml(actions: readonly string[], mode: string): string {
+	const lines: string[] = ["actions:"];
+	for (const action of actions) {
+		lines.push(`  ${action}:`);
+		lines.push(`    description: "${action} action"`);
+		if (mode === "agent") {
+			lines.push(`    mode: agent`);
+		}
+	}
+	return lines.join("\n");
+}
+
+function generateTemplateContent(
+	name: string,
+	description: string,
+	actions?: readonly string[],
+): string {
+	const frontmatterLines = [
 		"---",
 		`name: ${name}`,
 		`description: ${description}`,
 		"mode: template",
-		"inputs: []",
-		"---",
-		"",
-		`# ${name}`,
-		"",
-		"```bash",
-		`echo "Hello from ${name}"`,
-		"```",
-		"",
-	].join("\n");
+	];
+
+	if (actions && actions.length > 0) {
+		frontmatterLines.push(generateActionsYaml(actions, "template"));
+	} else {
+		frontmatterLines.push("inputs: []");
+	}
+
+	frontmatterLines.push("---");
+
+	const bodyLines = ["", `# ${name}`, ""];
+
+	if (actions && actions.length > 0) {
+		for (const action of actions) {
+			bodyLines.push(`## action: ${action}`);
+			bodyLines.push("");
+			bodyLines.push("```bash");
+			bodyLines.push(`echo "Running ${name}:${action}"`);
+			bodyLines.push("```");
+			bodyLines.push("");
+		}
+	} else {
+		bodyLines.push("```bash");
+		bodyLines.push(`echo "Hello from ${name}"`);
+		bodyLines.push("```");
+		bodyLines.push("");
+	}
+
+	return [...frontmatterLines, ...bodyLines].join("\n");
 }
 
-function generateAgentContent(name: string, description: string): string {
-	return [
-		"---",
-		`name: ${name}`,
-		`description: ${description}`,
-		"mode: agent",
-		"---",
-		"",
-		`# ${name}`,
-		"",
-		"Describe what this skill should do.",
-		"",
-	].join("\n");
+function generateAgentContent(
+	name: string,
+	description: string,
+	actions?: readonly string[],
+): string {
+	const frontmatterLines = ["---", `name: ${name}`, `description: ${description}`, "mode: agent"];
+
+	if (actions && actions.length > 0) {
+		frontmatterLines.push(generateActionsYaml(actions, "agent"));
+	}
+
+	frontmatterLines.push("---");
+
+	const bodyLines = ["", `# ${name}`, ""];
+
+	if (actions && actions.length > 0) {
+		for (const action of actions) {
+			bodyLines.push(`## action: ${action}`);
+			bodyLines.push("");
+			bodyLines.push(`Describe what the ${action} action should do.`);
+			bodyLines.push("");
+		}
+	} else {
+		bodyLines.push("Describe what this skill should do.");
+		bodyLines.push("");
+	}
+
+	return [...frontmatterLines, ...bodyLines].join("\n");
 }
 
 function generateSkillContent(name: string, options: InitOptions): string {
 	return options.mode === "agent"
-		? generateAgentContent(name, options.description)
-		: generateTemplateContent(name, options.description);
+		? generateAgentContent(name, options.description, options.actions)
+		: generateTemplateContent(name, options.description, options.actions);
 }
 
 export function createSkillInitializer(deps: SkillInitializerDeps): SkillInitializer {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,9 +14,11 @@ import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
 import { createStreamWriter } from "./adapter/stream-writer";
 import { createSystemPromptResolver } from "./adapter/system-prompt-resolver";
+import type { Action } from "./core/skill/action";
+import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
-import type { SkillScope } from "./core/skill/skill";
-import { type DomainError, domainErrorMessage, EXIT_CODE } from "./core/types/errors";
+import type { Skill, SkillScope } from "./core/skill/skill";
+import { type DomainError, domainErrorMessage, ErrorType, EXIT_CODE } from "./core/types/errors";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
@@ -24,6 +26,29 @@ import type { RunOutput } from "./usecase/run-skill";
 import { runSkill } from "./usecase/run-skill";
 import type { ShowOutput } from "./usecase/show-skill";
 import { showSkill } from "./usecase/show-skill";
+
+type SkillRef = {
+	readonly name: string;
+	readonly action: string | undefined;
+};
+
+export function parseSkillRef(ref: string): SkillRef {
+	const parts = ref.split(":");
+	if (parts.length === 1) {
+		return { name: parts[0], action: undefined };
+	}
+	if (parts.length === 2) {
+		return { name: parts[0], action: parts[1] };
+	}
+	throw new InvalidSkillRefError(ref);
+}
+
+class InvalidSkillRefError extends Error {
+	constructor(ref: string) {
+		super(`Invalid skill reference "${ref}": expected "skill" or "skill:action"`);
+		this.name = "InvalidSkillRefError";
+	}
+}
 
 // --set key=value 形式の引数を Record に変換する。
 // "=" を含む値をサポートするため、最初の "=" のみで分割する
@@ -77,6 +102,31 @@ function formatError(error: DomainError): string {
 	return `Error: ${domainErrorMessage(error)}`;
 }
 
+function requireActionForActionsSkill(skill: Skill, actionName: string | undefined): void {
+	if (skill.metadata.actions && !actionName) {
+		const names = Object.keys(skill.metadata.actions).join(", ");
+		console.error(
+			`Error: Skill "${skill.metadata.name}" requires an action. Available actions: ${names}\nUse: taskp run ${skill.metadata.name}:<action> or use the TUI (taskp tui)`,
+		);
+		process.exit(EXIT_CODE[ErrorType.Config]);
+	}
+}
+
+function requireValidAction(skill: Skill, actionName: string | undefined): Action | undefined {
+	if (!actionName) return undefined;
+
+	const actions = skill.metadata.actions;
+	if (!actions || !(actionName in actions)) {
+		const available = actions ? Object.keys(actions).join(", ") : "none";
+		console.error(
+			`Error: Action "${actionName}" not found in skill "${skill.metadata.name}". Available actions: ${available}`,
+		);
+		process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
+	}
+
+	return actions[actionName];
+}
+
 const cli = Cli.create("taskp", {
 	version: "0.1.4",
 	description:
@@ -85,7 +135,7 @@ const cli = Cli.create("taskp", {
 	.command("run", {
 		description: "Execute a skill",
 		args: z.object({
-			skill: z.string().describe("Skill name to execute"),
+			skill: z.string().describe("Skill name or skill:action to execute"),
 		}),
 		options: z.object({
 			model: z.string().optional().describe("LLM model to use"),
@@ -102,13 +152,21 @@ const cli = Cli.create("taskp", {
 			set: "s",
 		},
 		async run(c) {
+			let ref: SkillRef;
+			try {
+				ref = parseSkillRef(c.args.skill);
+			} catch {
+				console.error(
+					`Error: Invalid skill reference "${c.args.skill}": expected "skill" or "skill:action"`,
+				);
+				process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
+			}
+
 			const presets = parsePresets(c.options.set ?? []);
 			const skillRepository = createDefaultSkillLoader(process.cwd());
 			const promptCollector = createPromptRunner();
 
-			// まずスキルを読み込んで mode を判定し、agent/template で処理を分岐する。
-			// agent モードは LLM 接続が必要なため、設定の読み込みやモデル解決が追加で発生する
-			const findResult = await skillRepository.findByName(c.args.skill);
+			const findResult = await skillRepository.findByName(ref.name);
 			if (!findResult.ok) {
 				console.error(formatError(findResult.error));
 				process.exit(EXIT_CODE[findResult.error.type]);
@@ -116,8 +174,21 @@ const cli = Cli.create("taskp", {
 
 			const skill = findResult.value;
 
-			if (skill.metadata.mode === "agent") {
-				await runAgentMode(c, presets, skillRepository, promptCollector);
+			requireActionForActionsSkill(skill, ref.action);
+			const action = requireValidAction(skill, ref.action);
+
+			// アクション指定時は resolveActionConfig で mode を決定
+			const effectiveMode = action
+				? resolveActionConfig(action, skill.metadata).mode
+				: skill.metadata.mode;
+
+			if (effectiveMode === "agent") {
+				await runAgentMode(
+					{ args: { skill: ref.name }, options: c.options },
+					presets,
+					skillRepository,
+					promptCollector,
+				);
 				return;
 			}
 
@@ -135,7 +206,8 @@ const cli = Cli.create("taskp", {
 
 			const result = await runSkill(
 				{
-					name: c.args.skill,
+					name: ref.name,
+					action: ref.action,
 					presets,
 					dryRun: c.options.dryRun ?? false,
 					force: c.options.force ?? false,
@@ -187,22 +259,27 @@ const cli = Cli.create("taskp", {
 		options: z.object({
 			global: z.boolean().optional().describe("Create in global directory"),
 			mode: z.enum(["template", "agent"]).optional().describe("Execution mode"),
+			actions: z.string().optional().describe("Comma-separated action names"),
 		}),
 		alias: {
 			global: "g",
 			mode: "m",
+			actions: "a",
 		},
 		async run(c) {
 			const isGlobal = c.options.global ?? false;
 			const baseDir = isGlobal ? homedir() : process.cwd();
 			const mode = c.options.mode ?? "template";
+			const actions = c.options.actions
+				? c.options.actions.split(",").map((a) => a.trim())
+				: undefined;
 
 			const skillRepository = createDefaultSkillLoader(process.cwd());
 			const skillInitializer = createSkillInitializer({ baseDir });
 
 			const result = await initSkill(
 				{ skillRepository, skillInitializer },
-				{ name: c.args.name, global: isGlobal, mode },
+				{ name: c.args.name, global: isGlobal, mode, actions },
 			);
 
 			if (!result.ok) {
@@ -216,11 +293,21 @@ const cli = Cli.create("taskp", {
 	.command("show", {
 		description: "Show skill details",
 		args: z.object({
-			skill: z.string().describe("Skill name to show"),
+			skill: z.string().describe("Skill name or skill:action to show"),
 		}),
 		async run(c) {
+			let ref: SkillRef;
+			try {
+				ref = parseSkillRef(c.args.skill);
+			} catch {
+				console.error(
+					`Error: Invalid skill reference "${c.args.skill}": expected "skill" or "skill:action"`,
+				);
+				process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
+			}
+
 			const repository = createDefaultSkillLoader(process.cwd());
-			const result = await showSkill(c.args.skill, repository);
+			const result = await showSkill(ref.name, repository, ref.action);
 
 			if (!result.ok) {
 				console.error(formatError(result.error));
@@ -348,16 +435,31 @@ const ansi = {
 
 function printSkillTable(
 	skills: ReadonlyArray<{
-		metadata: { name: string; description: string };
+		metadata: {
+			name: string;
+			description: string;
+			actions?: Record<string, Action>;
+		};
 		location: string;
 		scope: SkillScope;
 	}>,
 ): void {
 	for (const skill of skills) {
 		const scopeLabel = ansi.dim(`(${skill.scope})`);
+		const actionsLabel = formatActionsLabel(skill.metadata.actions);
 		console.log(`${ansi.bold(ansi.cyan(skill.metadata.name))} ${scopeLabel}`);
 		console.log(`  ${skill.metadata.description}`);
+		if (actionsLabel) {
+			console.log(`  Actions: ${actionsLabel}`);
+		}
 	}
+}
+
+function formatActionsLabel(actions: Record<string, Action> | undefined): string | undefined {
+	if (!actions) return undefined;
+	const names = Object.keys(actions);
+	if (names.length === 0) return undefined;
+	return names.join(", ");
 }
 
 function formatShowOutput(output: ShowOutput): string {
@@ -367,6 +469,21 @@ function formatShowOutput(output: ShowOutput): string {
 		`Mode: ${output.mode}`,
 		`Location: ${output.location}`,
 	];
+
+	if (output.actions && output.actions.length > 0 && !output.actionDetail) {
+		lines.push("");
+		lines.push("Actions:");
+		for (const action of output.actions) {
+			lines.push(`  ${action.name}  ${action.description}`);
+		}
+	}
+
+	if (output.actionDetail) {
+		lines.push("");
+		lines.push(`Action: ${output.actionDetail.name}`);
+		lines.push(`  Description: ${output.actionDetail.description}`);
+		lines.push(`  Mode: ${output.actionDetail.mode}`);
+	}
 
 	if (output.inputs.length > 0) {
 		lines.push("");

--- a/src/usecase/init-skill.ts
+++ b/src/usecase/init-skill.ts
@@ -16,6 +16,7 @@ export type InitSkillInput = {
 	readonly name: string;
 	readonly global: boolean;
 	readonly mode: ExecutionMode;
+	readonly actions?: readonly string[];
 };
 
 type Deps = {
@@ -35,6 +36,7 @@ export async function initSkill(
 	const createResult = await deps.skillInitializer.create(input.name, {
 		mode: input.mode,
 		description: `${input.name} skill`,
+		actions: input.actions,
 	});
 
 	if (!createResult.ok) {

--- a/src/usecase/port/skill-initializer.ts
+++ b/src/usecase/port/skill-initializer.ts
@@ -3,6 +3,7 @@ import type { Result } from "../../core/types/result";
 export type InitOptions = {
 	readonly mode: "template" | "agent";
 	readonly description: string;
+	readonly actions?: readonly string[];
 };
 
 export type SkillInitializer = {

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -14,6 +14,7 @@ import type { SkillRepository } from "./port/skill-repository";
 
 export type RunSkillInput = {
 	readonly name: string;
+	readonly action?: string;
 	readonly presets: Readonly<Record<string, string>>;
 	readonly dryRun: boolean;
 	readonly force: boolean;

--- a/src/usecase/show-skill.ts
+++ b/src/usecase/show-skill.ts
@@ -1,10 +1,23 @@
+import { resolveActionConfig } from "../core/skill/action";
 import type { ContextSource } from "../core/skill/context-source";
 import type { SkillInput } from "../core/skill/skill-input";
 import type { SkillMode } from "../core/skill/skill-metadata";
-import type { SkillNotFoundError } from "../core/types/errors";
+import type { DomainError } from "../core/types/errors";
+import { configError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { ok } from "../core/types/result";
+import { err, ok } from "../core/types/result";
 import type { SkillRepository } from "./port/skill-repository";
+
+export type ActionSummary = {
+	readonly name: string;
+	readonly description: string;
+};
+
+export type ActionDetail = {
+	readonly name: string;
+	readonly description: string;
+	readonly mode: SkillMode;
+};
 
 export type ShowOutput = {
 	readonly name: string;
@@ -13,18 +26,58 @@ export type ShowOutput = {
 	readonly location: string;
 	readonly inputs: readonly SkillInput[];
 	readonly context: readonly ContextSource[];
+	readonly actions?: readonly ActionSummary[];
+	readonly actionDetail?: ActionDetail;
 };
 
 export async function showSkill(
 	name: string,
 	repository: SkillRepository,
-): Promise<Result<ShowOutput, SkillNotFoundError>> {
+	actionName?: string,
+): Promise<Result<ShowOutput, DomainError>> {
 	const result = await repository.findByName(name);
 	if (!result.ok) {
 		return result;
 	}
 
 	const skill = result.value;
+
+	if (actionName) {
+		const actions = skill.metadata.actions;
+		if (!actions || !(actionName in actions)) {
+			const available = actions ? Object.keys(actions).join(", ") : "none";
+			return err(
+				configError(
+					`Action "${actionName}" not found in skill "${name}". Available actions: ${available}`,
+				),
+			);
+		}
+
+		const action = actions[actionName];
+		const resolved = resolveActionConfig(action, skill.metadata);
+
+		return ok({
+			name: skill.metadata.name,
+			description: skill.metadata.description,
+			mode: resolved.mode,
+			location: skill.location,
+			inputs: resolved.inputs,
+			context: resolved.context,
+			actionDetail: {
+				name: actionName,
+				description: resolved.description,
+				mode: resolved.mode,
+			},
+		});
+	}
+
+	const actionSummaries: ActionSummary[] | undefined = skill.metadata.actions
+		? Object.entries(skill.metadata.actions).map(([key, action]) => ({
+				name: key,
+				description: action.description,
+			}))
+		: undefined;
+
 	return ok({
 		name: skill.metadata.name,
 		description: skill.metadata.description,
@@ -32,5 +85,6 @@ export async function showSkill(
 		location: skill.location,
 		inputs: skill.metadata.inputs,
 		context: skill.metadata.context,
+		actions: actionSummaries,
 	});
 }

--- a/tests/e2e/init-command.test.ts
+++ b/tests/e2e/init-command.test.ts
@@ -80,4 +80,25 @@ describe("taskp init (E2E)", () => {
 		expect(result.stdout).toContain("path-test");
 		expect(result.stdout).toContain("SKILL.md");
 	});
+
+	it("creates a skill with --actions option", async () => {
+		const result = await execaCommand(
+			`bun run ${CLI_PATH} init my-task --actions add,delete,list`,
+			{ cwd: projectDir, reject: false },
+		);
+
+		expect(result.exitCode).toBe(0);
+
+		const skillPath = join(projectDir, ".taskp/skills/my-task/SKILL.md");
+		expect(existsSync(skillPath)).toBe(true);
+
+		const content = readFileSync(skillPath, "utf-8");
+		expect(content).toContain("actions:");
+		expect(content).toContain("add:");
+		expect(content).toContain("delete:");
+		expect(content).toContain("list:");
+		expect(content).toContain("## action: add");
+		expect(content).toContain("## action: delete");
+		expect(content).toContain("## action: list");
+	});
 });

--- a/tests/e2e/run-command.test.ts
+++ b/tests/e2e/run-command.test.ts
@@ -103,4 +103,88 @@ describe("taskp run (E2E)", () => {
 		expect(result.exitCode).toBe(2);
 		expect(result.stderr).toContain("not found");
 	});
+
+	const ACTION_SKILL = [
+		"---",
+		"name: task",
+		"description: Manage tasks",
+		"mode: template",
+		"actions:",
+		"  add:",
+		'    description: "Add a new task"',
+		"  delete:",
+		'    description: "Delete a task"',
+		"  list:",
+		'    description: "List tasks"',
+		"---",
+		"",
+		"# task",
+		"",
+		"## action: add",
+		"",
+		"```bash",
+		'echo "task added"',
+		"```",
+		"",
+		"## action: delete",
+		"",
+		"```bash",
+		'echo "task deleted"',
+		"```",
+		"",
+		"## action: list",
+		"",
+		"```bash",
+		'echo "task listed"',
+		"```",
+	].join("\n");
+
+	it("executes a skill action with task:add", async () => {
+		createSkillFile(projectDir, "task", ACTION_SKILL);
+
+		const result = await execaCommand(`bun run ${CLI_PATH} run task:add`, {
+			cwd: projectDir,
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("task added");
+	});
+
+	it("exits with error for task:add:extra (too many colons)", async () => {
+		createSkillFile(projectDir, "task", ACTION_SKILL);
+
+		const result = await execaCommand(`bun run ${CLI_PATH} run task:add:extra`, {
+			cwd: projectDir,
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toContain("Invalid skill reference");
+	});
+
+	it("exits with error for task:unknown (nonexistent action)", async () => {
+		createSkillFile(projectDir, "task", ACTION_SKILL);
+
+		const result = await execaCommand(`bun run ${CLI_PATH} run task:unknown`, {
+			cwd: projectDir,
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toContain("not found");
+	});
+
+	it("exits with error when actions skill used without action", async () => {
+		createSkillFile(projectDir, "task", ACTION_SKILL);
+
+		const result = await execaCommand(`bun run ${CLI_PATH} run task`, {
+			cwd: projectDir,
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(4);
+		expect(result.stderr).toContain("requires an action");
+		expect(result.stderr).toContain("add, delete, list");
+	});
 });

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -3,12 +3,27 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execaCommand } from "execa";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parseSkillRef } from "../../src/cli";
 
 const CLI_PATH = join(import.meta.dirname, "../../src/cli.ts");
 
 function run(args: string, cwd: string) {
 	return execaCommand(`bun run ${CLI_PATH} ${args}`, { cwd, reject: false });
 }
+
+describe("parseSkillRef", () => {
+	it("parses skill name without action", () => {
+		expect(parseSkillRef("task")).toEqual({ name: "task", action: undefined });
+	});
+
+	it("parses skill:action format", () => {
+		expect(parseSkillRef("task:add")).toEqual({ name: "task", action: "add" });
+	});
+
+	it("throws on skill:action:extra format", () => {
+		expect(() => parseSkillRef("task:add:extra")).toThrow("Invalid skill reference");
+	});
+});
 
 describe("CLI E2E: init → list → run", () => {
 	let projectDir: string;

--- a/tests/integration/list-command.test.ts
+++ b/tests/integration/list-command.test.ts
@@ -94,4 +94,36 @@ describe("taskp list E2E", () => {
 
 		expect(skills).toHaveLength(0);
 	});
+
+	it("アクション付きスキルの actions フィールドが含まれる", async () => {
+		const dir = join(localRoot, ".taskp", "skills", "task");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, "SKILL.md"),
+			[
+				"---",
+				"name: task",
+				'description: "タスクを管理する"',
+				"mode: template",
+				"actions:",
+				"  add:",
+				'    description: "タスクを追加"',
+				"  delete:",
+				'    description: "タスクを削除"',
+				"  list:",
+				'    description: "タスク一覧"',
+				"---",
+				"",
+				"# task",
+			].join("\n"),
+		);
+
+		const repository = createSkillLoader({ localRoot, globalRoot });
+		const usecase = createListSkillsUseCase(repository);
+		const { skills } = await usecase.execute({});
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].metadata.actions).toBeDefined();
+		expect(Object.keys(skills[0].metadata.actions!)).toEqual(["add", "delete", "list"]);
+	});
 });

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -126,4 +126,61 @@ describe("showSkill", () => {
 		expect(result.value.inputs).toHaveLength(0);
 		expect(result.value.context).toHaveLength(0);
 	});
+
+	it("アクション付きスキルのアクション一覧を返す", async () => {
+		const skill = createSkill({
+			actions: {
+				add: { description: "タスクを追加" },
+				delete: { description: "タスクを削除" },
+			},
+		});
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.actions).toHaveLength(2);
+		expect(result.value.actions![0].name).toBe("add");
+		expect(result.value.actions![0].description).toBe("タスクを追加");
+		expect(result.value.actionDetail).toBeUndefined();
+	});
+
+	it("アクション指定時はアクション詳細を返す", async () => {
+		const skill = createSkill({
+			actions: {
+				add: {
+					description: "タスクを追加",
+					mode: "agent",
+					inputs: [{ name: "title", type: "text", message: "タスク名は？" }],
+				},
+			},
+		});
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo, "add");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.actionDetail).toBeDefined();
+		expect(result.value.actionDetail!.name).toBe("add");
+		expect(result.value.actionDetail!.mode).toBe("agent");
+		expect(result.value.inputs).toHaveLength(1);
+		expect(result.value.inputs[0].name).toBe("title");
+	});
+
+	it("存在しないアクション指定時はエラーを返す", async () => {
+		const skill = createSkill({
+			actions: {
+				add: { description: "タスクを追加" },
+			},
+		});
+		const repo = createRepository([skill]);
+
+		const result = await showSkill("deploy", repo, "unknown");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+	});
 });


### PR DESCRIPTION
#### 概要

CLI の各コマンドを `skill:action` 形式に対応させ、アクション付きスキルの操作をサポート。

#### 変更内容

- `parseSkillRef` 関数で `skill:action` 形式をパース（`skill:action:extra` はエラー）
- `run` コマンド: アクション対応（mode 判定、actions ありスキルでアクション未指定時はエラー）
- `list` コマンド: Actions 行を追加表示
- `show` コマンド: `taskp show task` でアクション一覧、`taskp show task:add` でアクション詳細
- `init` コマンド: `--actions add,delete,list` オプションでアクション付き雛形を生成
- `RunSkillInput` に `action` フィールドを追加
- `InitSkillInput` / `SkillInitializer` に `actions` フィールドを追加
- 関連する unit / integration / E2E テストを追加・更新

Closes #241