### PR TITLE
feat: TUI のアクション対応（展開/折りたたみUI・ファジー検索・アクション実行）

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -6,6 +6,9 @@ import { createDefaultConfigLoader } from "../adapter/config-loader";
 import { createHookExecutor } from "../adapter/hook-executor";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import { createSystemPromptResolver } from "../adapter/system-prompt-resolver";
+import { resolveActionConfig } from "../core/skill/action";
+import type { Skill } from "../core/skill/skill";
+import type { SkillInput } from "../core/skill/skill-input";
 import type { HooksConfig } from "../usecase/hook-runner";
 import { copyToClipboard } from "./clipboard";
 import {
@@ -58,18 +61,21 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 		};
 
 		while (true) {
-			const skill = await showSkillSelector(renderer, skills);
-			if (!skill) break;
+			const selection = await showSkillSelector(renderer, skills);
+			if (!selection) break;
 
-			const variables = await showInputForm(renderer, skill);
+			const { skill, actionName } = selection;
+
+			const actionInputs = resolveActionInputs(skill, actionName);
+			const variables = await showInputForm(renderer, skill, actionInputs);
 			if (!variables) continue;
 
-			const action = await showExecution(
+			const navAction = await showExecution(
 				renderer,
-				{ skill, variables, model, modelSpec },
+				{ skill, variables, model, modelSpec, actionName },
 				executionDeps,
 			);
-			if (action === "exit") break;
+			if (navAction === "exit") break;
 		}
 	} finally {
 		renderer.destroy();
@@ -105,4 +111,11 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 	if (!modelResult.ok) return { model: null, modelSpec: null, hooksConfig, commandTimeoutMs };
 
 	return { model: modelResult.value, modelSpec: specResult.value, hooksConfig, commandTimeoutMs };
+}
+
+function resolveActionInputs(skill: Skill, actionName?: string): readonly SkillInput[] | undefined {
+	if (!actionName || !skill.metadata.actions) return undefined;
+	const action = skill.metadata.actions[actionName];
+	if (!action) return undefined;
+	return resolveActionConfig(action, skill.metadata).inputs;
 }

--- a/src/tui/components/fuzzy-select.ts
+++ b/src/tui/components/fuzzy-select.ts
@@ -3,6 +3,8 @@ import fuzzysort from "fuzzysort";
 export type SkillOption = {
 	readonly name: string;
 	readonly description: string;
+	readonly actionName?: string;
+	readonly parentSkillName?: string;
 };
 
 export function filterSkills(query: string, skills: readonly SkillOption[]): SkillOption[] {
@@ -16,4 +18,28 @@ export function filterSkills(query: string, skills: readonly SkillOption[]): Ski
 	});
 
 	return results.map((r) => r.obj);
+}
+
+export function buildSkillOptionsWithActions(
+	skills: readonly {
+		readonly name: string;
+		readonly description: string;
+		readonly actions?: Record<string, { readonly description: string }>;
+	}[],
+): SkillOption[] {
+	const options: SkillOption[] = [];
+	for (const skill of skills) {
+		options.push({ name: skill.name, description: skill.description });
+		if (skill.actions) {
+			for (const [actionName, action] of Object.entries(skill.actions)) {
+				options.push({
+					name: `${skill.name}:${actionName}`,
+					description: action.description,
+					actionName,
+					parentSkillName: skill.name,
+				});
+			}
+		}
+	}
+	return options;
 }

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { createAgentExecutor } from "../../adapter/agent-executor";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
+import { resolveActionConfig } from "../../core/skill/action";
 import type { Skill } from "../../core/skill/skill";
 import { domainErrorMessage } from "../../core/types/errors";
 import { ok } from "../../core/types/result";
@@ -39,8 +40,11 @@ export async function runExecution(
 	model: LanguageModelV3 | null,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
+	actionName?: string,
 ): Promise<void> {
-	if (skill.metadata.mode === "agent" && model === null) {
+	const effectiveMode = resolveEffectiveMode(skill, actionName);
+
+	if (effectiveMode === "agent" && model === null) {
 		viewPort.appendOutput("Error: LLM model not configured.\n");
 		viewPort.appendOutput("Set default_provider and default_model in .taskp/config.toml\n");
 		viewPort.showSummary(0, 0);
@@ -48,10 +52,10 @@ export async function runExecution(
 	}
 
 	try {
-		if (skill.metadata.mode === "agent" && model !== null) {
-			await executeAgentMode(skill, variables, model, viewPort, deps);
+		if (effectiveMode === "agent" && model !== null) {
+			await executeAgentMode(skill, variables, model, viewPort, deps, actionName);
 		} else {
-			await executeTemplateMode(skill, variables, viewPort, deps);
+			await executeTemplateMode(skill, variables, viewPort, deps, actionName);
 		}
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -77,12 +81,20 @@ export function createPresetPromptCollector(
 	};
 }
 
+function resolveEffectiveMode(skill: Skill, actionName?: string): "template" | "agent" {
+	if (!actionName || !skill.metadata.actions) return skill.metadata.mode;
+	const action = skill.metadata.actions[actionName];
+	if (!action) return skill.metadata.mode;
+	return resolveActionConfig(action, skill.metadata).mode;
+}
+
 async function executeAgentMode(
 	skill: Skill,
 	variables: Readonly<Record<string, string>>,
 	model: LanguageModelV3,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
+	actionName?: string,
 ): Promise<void> {
 	const writer = createTuiStreamWriter(viewPort);
 	const progressWriter = createTuiProgressWriter(viewPort);
@@ -92,7 +104,7 @@ async function executeAgentMode(
 	const contextCollector = createContextCollector(contextCollectorDeps);
 
 	const result = await runAgentSkill(
-		{ name: skill.metadata.name, presets: variables, model },
+		{ name: skill.metadata.name, action: actionName, presets: variables, model },
 		{
 			skillRepository: deps.skillRepositoryFactory(skill),
 			promptCollector: deps.promptCollectorFactory(variables),
@@ -116,11 +128,18 @@ async function executeTemplateMode(
 	variables: Readonly<Record<string, string>>,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
+	actionName?: string,
 ): Promise<void> {
 	const progressWriter = createTuiProgressWriter(viewPort);
 
 	const result = await runSkill(
-		{ name: skill.metadata.name, presets: variables, dryRun: false, force: false },
+		{
+			name: skill.metadata.name,
+			action: actionName,
+			presets: variables,
+			dryRun: false,
+			force: false,
+		},
 		{
 			skillRepository: deps.skillRepositoryFactory(skill),
 			promptCollector: deps.promptCollectorFactory(variables),

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -30,6 +30,7 @@ export type ExecutionParams = {
 	readonly variables: Readonly<Record<string, string>>;
 	readonly model: LanguageModelV3 | null;
 	readonly modelSpec: ModelSpec | null;
+	readonly actionName?: string;
 };
 
 export async function showExecution(
@@ -37,18 +38,19 @@ export async function showExecution(
 	params: ExecutionParams,
 	deps: ExecutionDeps,
 ): Promise<"back" | "exit"> {
-	const { skill, variables, model, modelSpec } = params;
+	const { skill, variables, model, modelSpec, actionName } = params;
 	return new Promise((resolve) => {
 		clearScreen(renderer);
 
 		const modelLabel = modelSpec ? ` ─── ${modelSpec.provider}/${modelSpec.model}` : "";
+		const skillLabel = actionName ? `${skill.metadata.name}:${actionName}` : skill.metadata.name;
 
 		const container = new BoxRenderable(renderer, {
 			id: CONTAINER_ID,
 			width: "100%",
 			height: "100%",
 			borderStyle: "rounded",
-			title: `${skill.metadata.name} [Running]${modelLabel}`,
+			title: `${skillLabel} [Running]${modelLabel}`,
 			padding: 1,
 			flexDirection: "column",
 			justifyContent: "flex-start",
@@ -138,12 +140,12 @@ export async function showExecution(
 				stopSpinner();
 				const seconds = (elapsedMs / 1000).toFixed(1);
 				summaryText.content = `Done in ${seconds}s (${steps} steps)`;
-				container.title = `${skill.metadata.name} [Done]${modelLabel}`;
+				container.title = `${skillLabel} [Done]${modelLabel}`;
 				helpBox.visible = true;
 			},
 		};
 
-		runExecution(skill, variables, model, viewPort, deps).then(() => {
+		runExecution(skill, variables, model, viewPort, deps, actionName).then(() => {
 			const doneHandler = (key: KeyEvent) => {
 				if (key.name === "return") {
 					cleanup(doneHandler);

--- a/src/tui/screens/input-form.ts
+++ b/src/tui/screens/input-form.ts
@@ -201,8 +201,9 @@ function createKeyHandler(
 export async function showInputForm(
 	renderer: CliRenderer,
 	skill: Skill,
+	inputsOverride?: readonly SkillInput[],
 ): Promise<Readonly<Record<string, string>> | null> {
-	const inputs = skill.metadata.inputs;
+	const inputs = inputsOverride ?? skill.metadata.inputs;
 	if (inputs.length === 0) {
 		return {};
 	}

--- a/src/tui/screens/skill-selector.ts
+++ b/src/tui/screens/skill-selector.ts
@@ -9,30 +9,60 @@ import {
 	SelectRenderableEvents,
 } from "@opentui/core";
 import type { Skill } from "../../core/skill/skill";
-import { filterSkills, type SkillOption } from "../components/fuzzy-select";
+import {
+	buildSkillOptionsWithActions,
+	filterSkills,
+	type SkillOption,
+} from "../components/fuzzy-select";
 import { KeyHelp } from "../components/key-help";
 import { flatSelectStyle } from "../components/styles";
 
 const CONTAINER_ID = "selector-container";
 
+export type SkillSelection = {
+	readonly skill: Skill;
+	readonly actionName?: string;
+};
+
 export async function showSkillSelector(
 	renderer: CliRenderer,
 	skills: readonly Skill[],
-): Promise<Skill | null> {
+): Promise<SkillSelection | null> {
 	return new Promise((resolve) => {
 		clearScreen(renderer);
 
-		const skillOptions: SkillOption[] = skills.map((s) => ({
-			name: s.metadata.name,
-			description: s.metadata.description,
-		}));
+		const allOptions = buildSkillOptionsWithActions(
+			skills.map((s) => ({
+				name: s.metadata.name,
+				description: s.metadata.description,
+				actions: s.metadata.actions,
+			})),
+		);
+
+		const skillsWithActions = new Set(
+			skills.filter((s) => s.metadata.actions).map((s) => s.metadata.name),
+		);
+
+		const expandedSkills = new Set<string>();
+
+		const getVisibleOptions = (options: readonly SkillOption[]): SkillOption[] =>
+			options.filter((opt) => {
+				if (!opt.parentSkillName) return true;
+				return expandedSkills.has(opt.parentSkillName);
+			});
 
 		const toSelectOptions = (filtered: SkillOption[]): SelectOption[] =>
-			filtered.map((s) => ({
-				name: s.name,
-				description: s.description,
-				value: s.name,
-			}));
+			filtered.map((s) => {
+				const indicator = getExpandIndicator(s, skillsWithActions, expandedSkills);
+				return {
+					name: s.name,
+					description: `${s.description}${indicator}`,
+					value: s.name,
+				};
+			});
+
+		let currentFiltered = getVisibleOptions(allOptions);
+		let isSearchActive = false;
 
 		const container = new BoxRenderable(renderer, {
 			id: CONTAINER_ID,
@@ -55,7 +85,7 @@ export async function showSkillSelector(
 			id: "skill-list",
 			width: "100%",
 			flexGrow: 1,
-			options: toSelectOptions(skillOptions),
+			options: toSelectOptions(currentFiltered),
 			showDescription: true,
 			wrapSelection: true,
 			...flatSelectStyle,
@@ -63,7 +93,7 @@ export async function showSkillSelector(
 
 		const help = KeyHelp([
 			{ key: "↑↓", description: "Navigate" },
-			{ key: "Enter", description: "Select" },
+			{ key: "Enter", description: "Select/Expand" },
 			{ key: "Esc", description: "Quit" },
 		]);
 
@@ -72,17 +102,45 @@ export async function showSkillSelector(
 		container.add(help);
 		renderer.root.add(container);
 
-		// ファジー検索: 入力ごとにリストを更新
+		const refreshList = () => {
+			currentFiltered = getVisibleOptions(
+				isSearchActive ? filterSkills(searchInput.value, allOptions) : allOptions,
+			);
+			selectList.options = toSelectOptions(currentFiltered);
+		};
+
 		searchInput.on(InputRenderableEvents.INPUT, (query: string) => {
-			const filtered = filterSkills(query, skillOptions);
-			selectList.options = toSelectOptions(filtered);
+			isSearchActive = query !== "";
+			if (isSearchActive) {
+				autoExpandForSearch(query, allOptions, expandedSkills);
+			}
+			refreshList();
 		});
 
-		// Enter でスキル選択を確定
 		selectList.on(SelectRenderableEvents.ITEM_SELECTED, (_index: number, option: SelectOption) => {
+			const selected = currentFiltered.find((o) => o.name === option.value);
+			if (!selected) return;
+
+			if (!selected.parentSkillName && skillsWithActions.has(selected.name)) {
+				toggleExpand(selected.name, expandedSkills);
+				refreshList();
+				return;
+			}
+
 			cleanup();
-			const selected = skills.find((s) => s.metadata.name === option.value);
-			resolve(selected ?? null);
+
+			const skill = skills.find(
+				(s) => s.metadata.name === (selected.parentSkillName ?? selected.name),
+			);
+			if (!skill) {
+				resolve(null);
+				return;
+			}
+
+			resolve({
+				skill,
+				actionName: selected.actionName,
+			});
 		});
 
 		const keyHandler = (key: KeyEvent) => {
@@ -92,13 +150,11 @@ export async function showSkillSelector(
 				return;
 			}
 
-			// 検索入力にフォーカス中、↑↓ でリストにフォーカス移動
 			if (searchInput.focused && (key.name === "down" || key.name === "up")) {
 				selectList.focus();
 				return;
 			}
 
-			// リストにフォーカス中、文字入力で検索入力にフォーカス移動
 			if (selectList.focused && key.name.length === 1 && !key.ctrl && !key.meta) {
 				searchInput.focus();
 			}
@@ -113,6 +169,37 @@ export async function showSkillSelector(
 
 		searchInput.focus();
 	});
+}
+
+function getExpandIndicator(
+	option: SkillOption,
+	skillsWithActions: Set<string>,
+	expandedSkills: Set<string>,
+): string {
+	if (option.parentSkillName) return "";
+	if (!skillsWithActions.has(option.name)) return "";
+	return expandedSkills.has(option.name) ? "  ▼" : "  ▶";
+}
+
+function toggleExpand(skillName: string, expandedSkills: Set<string>): void {
+	if (expandedSkills.has(skillName)) {
+		expandedSkills.delete(skillName);
+	} else {
+		expandedSkills.add(skillName);
+	}
+}
+
+function autoExpandForSearch(
+	query: string,
+	allOptions: readonly SkillOption[],
+	expandedSkills: Set<string>,
+): void {
+	const matched = filterSkills(query, allOptions);
+	for (const opt of matched) {
+		if (opt.parentSkillName) {
+			expandedSkills.add(opt.parentSkillName);
+		}
+	}
 }
 
 function clearScreen(renderer: CliRenderer): void {

--- a/tests/tui/components/fuzzy-select.test.ts
+++ b/tests/tui/components/fuzzy-select.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { filterSkills, type SkillOption } from "../../../src/tui/components/fuzzy-select";
+import {
+	buildSkillOptionsWithActions,
+	filterSkills,
+	type SkillOption,
+} from "../../../src/tui/components/fuzzy-select";
 
 const skills: SkillOption[] = [
 	{ name: "code-review", description: "コードレビューを実行する" },
@@ -69,5 +73,125 @@ describe("filterSkills", () => {
 		expect(names).toContain("commit");
 		expect(names).not.toContain("brainstorming");
 		expect(names).not.toContain("frontend-design");
+	});
+
+	it("matches action names in fuzzy search", () => {
+		const optionsWithActions: SkillOption[] = [
+			{ name: "task", description: "タスクを管理する" },
+			{
+				name: "task:add",
+				description: "タスクを追加する",
+				actionName: "add",
+				parentSkillName: "task",
+			},
+			{
+				name: "task:delete",
+				description: "タスクを削除する",
+				actionName: "delete",
+				parentSkillName: "task",
+			},
+			{ name: "deploy", description: "アプリをデプロイする" },
+		];
+
+		const result = filterSkills("add", optionsWithActions);
+		const names = result.map((s) => s.name);
+		expect(names).toContain("task:add");
+	});
+
+	it("matches skill name and includes its actions", () => {
+		const optionsWithActions: SkillOption[] = [
+			{ name: "task", description: "タスクを管理する" },
+			{
+				name: "task:add",
+				description: "タスクを追加する",
+				actionName: "add",
+				parentSkillName: "task",
+			},
+			{
+				name: "task:delete",
+				description: "タスクを削除する",
+				actionName: "delete",
+				parentSkillName: "task",
+			},
+			{ name: "deploy", description: "アプリをデプロイする" },
+		];
+
+		const result = filterSkills("task", optionsWithActions);
+		const names = result.map((s) => s.name);
+		expect(names).toContain("task");
+		expect(names).toContain("task:add");
+		expect(names).toContain("task:delete");
+	});
+
+	it("matches colon-separated action format", () => {
+		const optionsWithActions: SkillOption[] = [
+			{ name: "task", description: "タスクを管理する" },
+			{
+				name: "task:add",
+				description: "タスクを追加する",
+				actionName: "add",
+				parentSkillName: "task",
+			},
+			{
+				name: "task:delete",
+				description: "タスクを削除する",
+				actionName: "delete",
+				parentSkillName: "task",
+			},
+		];
+
+		const result = filterSkills("task:d", optionsWithActions);
+		const names = result.map((s) => s.name);
+		expect(names).toContain("task:delete");
+	});
+});
+
+describe("buildSkillOptionsWithActions", () => {
+	it("builds flat list for skills without actions", () => {
+		const skills = [
+			{ name: "deploy", description: "Deploy app" },
+			{ name: "test", description: "Run tests" },
+		];
+
+		const result = buildSkillOptionsWithActions(skills);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({ name: "deploy", description: "Deploy app" });
+		expect(result[1]).toEqual({ name: "test", description: "Run tests" });
+	});
+
+	it("includes action sub-items for skills with actions", () => {
+		const skills = [
+			{
+				name: "task",
+				description: "タスクを管理する",
+				actions: {
+					add: { description: "タスクを追加する" },
+					delete: { description: "タスクを削除する" },
+				},
+			},
+			{ name: "deploy", description: "アプリをデプロイする" },
+		];
+
+		const result = buildSkillOptionsWithActions(skills);
+		expect(result).toHaveLength(4);
+		expect(result[0]).toEqual({ name: "task", description: "タスクを管理する" });
+		expect(result[1]).toEqual({
+			name: "task:add",
+			description: "タスクを追加する",
+			actionName: "add",
+			parentSkillName: "task",
+		});
+		expect(result[2]).toEqual({
+			name: "task:delete",
+			description: "タスクを削除する",
+			actionName: "delete",
+			parentSkillName: "task",
+		});
+		expect(result[3]).toEqual({ name: "deploy", description: "アプリをデプロイする" });
+	});
+
+	it("returns empty array for empty input", () => {
+		const result = buildSkillOptionsWithActions([]);
+		expect(result).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
#### 概要

TUI のスキル選択画面をアクション対応に拡張。展開/折りたたみUI、ファジー検索、アクション固有 inputs フォームへの対応。

#### 変更内容

- `src/tui/components/fuzzy-select.ts` — `SkillOption` にアクション情報を追加、`buildSkillOptionsWithActions` を新設
- `src/tui/screens/skill-selector.ts` — 展開/折りたたみ UI（▶/▼）、`SkillSelection` 型で skill + actionName を返却
- `src/tui/screens/input-form.ts` — アクション固有 inputs のオーバーライドに対応
- `src/tui/screens/execution-runner.ts` — actionName を `runSkill`/`runAgentSkill` に伝播、`resolveEffectiveMode` でアクション固有の mode を解決
- `src/tui/screens/execution-view.ts` — actionName を `ExecutionParams` に追加、タイトルバーに `skill:action` 表示
- `src/tui/app.ts` — アクション選択フロー統合（選択→inputs→実行）
- `tests/tui/components/fuzzy-select.test.ts` — アクション名での検索・`buildSkillOptionsWithActions` のテスト追加

Closes #242