### PR TITLE
feat: hooks にアクション情報の環境変数を追加

### DIFF
--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -14,10 +14,16 @@ function getParentEnv(): Record<string, string> {
 	return result;
 }
 
+function buildSkillRef(skillName: string, actionName: string | undefined): string {
+	return actionName ? `${skillName}:${actionName}` : skillName;
+}
+
 function buildEnvVars(context: HookContext): Record<string, string> {
 	const errorValue = context.error ?? "";
 	return {
 		TASKP_SKILL_NAME: context.skillName,
+		TASKP_ACTION_NAME: context.actionName ?? "",
+		TASKP_SKILL_REF: buildSkillRef(context.skillName, context.actionName),
 		TASKP_MODE: context.mode,
 		TASKP_STATUS: context.status,
 		TASKP_DURATION_MS: String(context.durationMs),

--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -1,5 +1,6 @@
 export type HookContext = {
 	readonly skillName: string;
+	readonly actionName?: string;
 	readonly mode: "template" | "agent";
 	readonly status: "success" | "failed";
 	readonly durationMs: number;

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -139,6 +139,7 @@ export async function runAgentSkill(
 			hooksConfig: deps.hooksConfig,
 			context: {
 				skillName: skill.metadata.name,
+				actionName: input.action,
 				mode: "agent",
 				status: "failed",
 				durationMs,
@@ -153,6 +154,7 @@ export async function runAgentSkill(
 		hooksConfig: deps.hooksConfig,
 		context: {
 			skillName: skill.metadata.name,
+			actionName: input.action,
 			mode: "agent",
 			status: "success",
 			durationMs,

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -221,6 +221,7 @@ async function executeAndReport(
 			hooksConfig: deps.hooksConfig,
 			context: {
 				skillName: skill.metadata.name,
+				actionName: input.action,
 				mode: "template",
 				status: "failed",
 				durationMs,
@@ -235,6 +236,7 @@ async function executeAndReport(
 		hooksConfig: deps.hooksConfig,
 		context: {
 			skillName: skill.metadata.name,
+			actionName: input.action,
 			mode: "template",
 			status: "success",
 			durationMs,

--- a/tests/adapter/hook-executor.test.ts
+++ b/tests/adapter/hook-executor.test.ts
@@ -74,11 +74,54 @@ describe("HookExecutor", () => {
 		const env = executor.executedCommands[0].options?.env;
 		expect(env).toMatchObject({
 			TASKP_SKILL_NAME: "deploy",
+			TASKP_ACTION_NAME: "",
+			TASKP_SKILL_REF: "deploy",
 			TASKP_MODE: "template",
 			TASKP_STATUS: "success",
 			TASKP_DURATION_MS: "1234",
 			TASKP_ERROR: "",
 		});
+	});
+
+	it("injects TASKP_ACTION_NAME when actionName is present", async () => {
+		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
+		const hookExecutor = createHookExecutor(executor);
+		const contextWithAction: HookContext = {
+			...successContext,
+			actionName: "add",
+		};
+
+		await hookExecutor.execute(["echo test"], contextWithAction);
+
+		const env = executor.executedCommands[0].options?.env;
+		expect(env?.TASKP_ACTION_NAME).toBe("add");
+	});
+
+	it("injects TASKP_SKILL_REF as skillName:actionName when actionName is present", async () => {
+		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
+		const hookExecutor = createHookExecutor(executor);
+		const contextWithAction: HookContext = {
+			skillName: "task",
+			actionName: "add",
+			mode: "template",
+			status: "success",
+			durationMs: 100,
+		};
+
+		await hookExecutor.execute(["echo test"], contextWithAction);
+
+		const env = executor.executedCommands[0].options?.env;
+		expect(env?.TASKP_SKILL_REF).toBe("task:add");
+	});
+
+	it("injects TASKP_SKILL_REF as skillName only when no actionName", async () => {
+		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
+		const hookExecutor = createHookExecutor(executor);
+
+		await hookExecutor.execute(["echo test"], successContext);
+
+		const env = executor.executedCommands[0].options?.env;
+		expect(env?.TASKP_SKILL_REF).toBe("deploy");
 	});
 
 	it("injects TASKP_ERROR on failure context", async () => {

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -124,4 +124,41 @@ describe("runHooks", () => {
 
 		expect(executor.calls[0].context).toEqual(context);
 	});
+
+	it("passes actionName in context when action is specified", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "task",
+			actionName: "add",
+			mode: "template",
+			status: "success",
+			durationMs: 100,
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"] },
+			context,
+		});
+
+		expect(executor.calls[0].context.actionName).toBe("add");
+	});
+
+	it("omits actionName in context for single skill execution", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "deploy",
+			mode: "template",
+			status: "success",
+			durationMs: 100,
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"] },
+			context,
+		});
+
+		expect(executor.calls[0].context.actionName).toBeUndefined();
+	});
 });


### PR DESCRIPTION
#### 概要

フック実行時の環境変数に `TASKP_ACTION_NAME` と `TASKP_SKILL_REF` を追加し、アクション情報をフックスクリプトから参照可能にした。

#### 変更内容

- `HookContext` に `actionName?: string` フィールドを追加
- `buildEnvVars` で `TASKP_ACTION_NAME`（アクション名、単一スキルは空文字）と `TASKP_SKILL_REF`（完全参照、`skill:action` 形式）を注入
- `run-skill.ts` / `run-agent-skill.ts` の `runHooks` 呼び出しに `actionName` を伝搬
- 対応するユニットテストを追加

Closes #243