### PR TITLE
feat: taskp_run ツール定義と基本実装

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -4,7 +4,11 @@ import type { JSONSchema7, Tool } from "ai";
 import { jsonSchema } from "ai";
 import { execa } from "execa";
 import { toJSONSchema, z } from "zod";
-import { type ExecutionError, executionError } from "../types/errors";
+import type { CommandExecutor } from "../../usecase/port/command-executor";
+import type { PromptCollector } from "../../usecase/port/prompt-collector";
+import type { SkillRepository } from "../../usecase/port/skill-repository";
+import { type RunOutput, runSkill } from "../../usecase/run-skill";
+import { domainErrorMessage, type ExecutionError, executionError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
 
 // Vercel AI SDK は JSONSchema7 形式のツール定義を要求するが、
@@ -14,7 +18,7 @@ function zodToJsonSchema<T extends z.ZodType>(schema: T) {
 	return jsonSchema<z.infer<T>>(toJSONSchema(schema) as JSONSchema7);
 }
 
-const TOOL_NAMES = ["bash", "read", "write", "glob", "ask_user"] as const;
+const TOOL_NAMES = ["bash", "read", "write", "glob", "ask_user", "taskp_run"] as const;
 type ToolName = (typeof TOOL_NAMES)[number];
 
 const bashParams = z.object({
@@ -39,6 +43,14 @@ const globParams = z.object({
 
 const askUserParams = z.object({
 	question: z.string().describe("The question to ask the user"),
+});
+
+const taskpRunParams = z.object({
+	skill: z.string().describe("Skill reference to run. Format: '<skill>' or '<skill>:<action>'."),
+	set: z
+		.record(z.string(), z.string())
+		.optional()
+		.describe("Variables to pass to the skill inputs (skips interactive prompts)."),
 });
 
 type BashInput = z.infer<typeof bashParams>;
@@ -119,7 +131,8 @@ const askUserTool: Tool<AskUserInput, string> = {
 // 1つの Record にまとめるには型パラメータを消去する必要がある
 type AnyTool = Tool<Record<string, unknown>, unknown>;
 
-const allTools: Record<ToolName, AnyTool> = {
+// taskp_run 以外の静的ツール
+const staticTools: Record<string, AnyTool> = {
 	bash: bashTool as AnyTool,
 	read: readTool as AnyTool,
 	write: writeTool as AnyTool,
@@ -127,12 +140,130 @@ const allTools: Record<ToolName, AnyTool> = {
 	ask_user: askUserTool as AnyTool,
 };
 
+const MAX_NESTING_DEPTH = 3;
+
+type TaskpRunInput = z.infer<typeof taskpRunParams>;
+
+type TaskpRunResult = {
+	readonly status: "success" | "failed";
+	readonly output: string;
+	readonly error?: string;
+};
+
+type TaskpRunDeps = {
+	readonly skillRepository: SkillRepository;
+	readonly commandExecutor: CommandExecutor;
+	readonly promptCollector: PromptCollector;
+	readonly callStack?: readonly string[];
+};
+
+function parseSkillRef(ref: string): {
+	readonly name: string;
+	readonly action: string | undefined;
+} {
+	const colonIndex = ref.indexOf(":");
+	if (colonIndex === -1) {
+		return { name: ref, action: undefined };
+	}
+	return { name: ref.slice(0, colonIndex), action: ref.slice(colonIndex + 1) };
+}
+
+function buildTaskpRunOutput(runOutput: RunOutput): string {
+	const parts: string[] = [runOutput.rendered];
+	for (const cmd of runOutput.commands) {
+		if (cmd.result.stdout) parts.push(cmd.result.stdout);
+		if (cmd.result.stderr) parts.push(cmd.result.stderr);
+	}
+	return parts.join("\n");
+}
+
+function createTaskpRunTool(deps: TaskpRunDeps): AnyTool {
+	const callStack = deps.callStack ?? [];
+
+	const tool: Tool<TaskpRunInput, TaskpRunResult> = {
+		description:
+			"Run another taskp skill (template mode only). Use to invoke predefined skills with variable inputs.",
+		inputSchema: zodToJsonSchema(taskpRunParams),
+		execute: async ({ skill, set }) => {
+			const ref = parseSkillRef(skill);
+			const skillId = ref.action ? `${ref.name}:${ref.action}` : ref.name;
+
+			if (callStack.includes(skillId)) {
+				return { status: "failed", output: "", error: `Recursive call detected: ${skillId}` };
+			}
+
+			if (callStack.length >= MAX_NESTING_DEPTH) {
+				return {
+					status: "failed",
+					output: "",
+					error: `Maximum nesting depth (${MAX_NESTING_DEPTH}) exceeded`,
+				};
+			}
+
+			const findResult = await deps.skillRepository.findByName(ref.name);
+			if (!findResult.ok) {
+				return { status: "failed", output: "", error: `Skill not found: ${ref.name}` };
+			}
+
+			const foundSkill = findResult.value;
+
+			const effectiveMode = ref.action
+				? (foundSkill.metadata.actions?.[ref.action]?.mode ?? foundSkill.metadata.mode)
+				: foundSkill.metadata.mode;
+
+			if (effectiveMode === "agent") {
+				return {
+					status: "failed",
+					output: "",
+					error: `Cannot call agent mode skill: ${skillId}. Only template mode skills are allowed.`,
+				};
+			}
+
+			const result = await runSkill(
+				{
+					name: ref.name,
+					action: ref.action,
+					presets: (set ?? {}) as Readonly<Record<string, string>>,
+					dryRun: false,
+					force: false,
+					noInput: true,
+				},
+				{
+					skillRepository: deps.skillRepository,
+					commandExecutor: deps.commandExecutor,
+					promptCollector: deps.promptCollector,
+				},
+			);
+
+			if (!result.ok) {
+				return { status: "failed", output: "", error: domainErrorMessage(result.error) };
+			}
+
+			return { status: "success", output: buildTaskpRunOutput(result.value) };
+		},
+	};
+
+	return tool as AnyTool;
+}
+
+export type BuildToolsOptions = {
+	readonly taskpRunDeps?: TaskpRunDeps;
+};
+
 export function buildTools(
 	toolNames: readonly string[],
+	options?: BuildToolsOptions,
 ): Result<Record<string, AnyTool>, ExecutionError> {
 	const tools: Record<string, AnyTool> = {};
 	for (const name of toolNames) {
-		const t = allTools[name as ToolName];
+		if (name === "taskp_run") {
+			if (!options?.taskpRunDeps) {
+				return err(executionError("taskp_run requires taskpRunDeps in BuildToolsOptions"));
+			}
+			tools[name] = createTaskpRunTool(options.taskpRunDeps);
+			continue;
+		}
+		const t = staticTools[name];
 		if (t === undefined) {
 			return err(executionError(`Unknown tool: ${name}`));
 		}
@@ -143,8 +274,11 @@ export function buildTools(
 
 /** ツール名からその description を返す。未知のツール名は undefined を返す。 */
 export function getToolDescription(name: string): string | undefined {
-	return allTools[name as ToolName]?.description;
+	if (name === "taskp_run") {
+		return "Run another taskp skill (template mode only). Use to invoke predefined skills with variable inputs.";
+	}
+	return staticTools[name]?.description;
 }
 
-export type { AnyTool, ToolName };
+export type { AnyTool, TaskpRunDeps, TaskpRunResult, ToolName };
 export { TOOL_NAMES };

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -2,6 +2,12 @@
 
 export type { AgentLoopInput, AgentLoopResult } from "./agent-loop.js";
 export { createAgentLoop } from "./agent-loop.js";
-export type { AnyTool, ToolName } from "./agent-tools.js";
+export type {
+	AnyTool,
+	BuildToolsOptions,
+	TaskpRunDeps,
+	TaskpRunResult,
+	ToolName,
+} from "./agent-tools.js";
 export { buildTools, TOOL_NAMES } from "./agent-tools.js";
 export type { ExecutionMode } from "./execution-mode.js";

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -14,11 +14,12 @@ describe("buildTools", () => {
 		expect(result.value.read.execute).toBeTypeOf("function");
 	});
 
-	it("すべてのツールを取得できる", () => {
-		const result = buildTools([...TOOL_NAMES]);
+	it("taskp_run 以外の静的ツールをすべて取得できる", () => {
+		const staticNames = TOOL_NAMES.filter((n) => n !== "taskp_run");
+		const result = buildTools(staticNames);
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
-		expect(Object.keys(result.value)).toHaveLength(5);
+		expect(Object.keys(result.value)).toHaveLength(staticNames.length);
 	});
 
 	it("空のツール名配列で空のオブジェクトを返す", () => {

--- a/tests/core/execution/taskp-run-tool.test.ts
+++ b/tests/core/execution/taskp-run-tool.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest";
+import type { TaskpRunDeps, TaskpRunResult } from "../../../src/core/execution/agent-tools";
+import { buildTools, TOOL_NAMES } from "../../../src/core/execution/agent-tools";
+import type { Skill } from "../../../src/core/skill/skill";
+import { createSkillBody } from "../../../src/core/skill/skill-body";
+import { createInMemorySkillRepository } from "../../stubs/in-memory-skill-repository";
+import { createStubCommandExecutor } from "../../stubs/stub-command-executor";
+import { createStubPromptCollector } from "../../stubs/stub-prompt-collector";
+
+const TEMPLATE_SKILL_MD = `---
+name: greet
+description: Greeting skill
+mode: template
+inputs:
+  - name: target
+    type: text
+    message: "Who?"
+---
+
+Hello {{target}}!
+
+\`\`\`bash
+echo "Hello {{target}}"
+\`\`\`
+`;
+
+const AGENT_SKILL_MD = `---
+name: agent-skill
+description: Agent skill
+mode: agent
+inputs: []
+---
+
+Do agent stuff.
+`;
+
+const ACTION_SKILL_MD = `---
+name: multi
+description: Multi action skill
+mode: template
+actions:
+  list:
+    description: List items
+    inputs:
+      - name: filter
+        type: text
+        message: "Filter?"
+  agent-action:
+    description: Agent action
+    mode: agent
+    inputs: []
+---
+
+## action:list
+
+List items with filter={{filter}}.
+
+\`\`\`bash
+echo "listing {{filter}}"
+\`\`\`
+
+## action:agent-action
+
+Agent action content.
+`;
+
+function createSkill(raw: string, nameOverride?: string): Skill {
+	const frontmatter = raw.match(/^---\n([\s\S]*?)\n---/);
+	const nameMatch = frontmatter?.[1].match(/name:\s*(.+)/);
+	const name = nameOverride ?? nameMatch?.[1].trim() ?? "test";
+
+	const descMatch = frontmatter?.[1].match(/description:\s*(.+)/);
+	const modeMatch = frontmatter?.[1].match(/mode:\s*(.+)/);
+	const mode = (modeMatch?.[1].trim() ?? "template") as "template" | "agent";
+
+	const inputsMatch = frontmatter?.[1].match(/inputs:\n((?:\s+-[\s\S]*?)?)(?=\n\w|\nactions:|$)/);
+	const inputs: Skill["metadata"]["inputs"] = [];
+	if (inputsMatch?.[1]) {
+		const inputBlocks = inputsMatch[1].split(/\n\s+-\s+name:\s+/).filter(Boolean);
+		for (const block of inputBlocks) {
+			const nameM = block.match(/^(\S+)|name:\s+(\S+)/);
+			const inputName = nameM?.[1] ?? nameM?.[2] ?? "";
+			inputs.push({
+				name: inputName,
+				type: "text" as const,
+				message: `${inputName}?`,
+			});
+		}
+	}
+
+	const actionsMatch = frontmatter?.[1].match(/actions:\n([\s\S]*?)$/);
+	let actions:
+		| Record<
+				string,
+				{ description: string; mode?: "template" | "agent"; inputs: Skill["metadata"]["inputs"] }
+		  >
+		| undefined;
+	if (actionsMatch) {
+		actions = {};
+		const actionBlocks = actionsMatch[1].split(/\n\s{2}(?=\S)/);
+		for (const block of actionBlocks) {
+			const lines = block.trim().split("\n");
+			const actionName = lines[0].replace(":", "").trim();
+			if (!actionName) continue;
+			const actionMode = block.match(/mode:\s+(\S+)/)?.[1] as "template" | "agent" | undefined;
+			actions[actionName] = {
+				description: `${actionName} action`,
+				mode: actionMode,
+				inputs: [],
+			};
+		}
+	}
+
+	return {
+		metadata: {
+			name,
+			description: descMatch?.[1].trim() ?? "test",
+			mode,
+			inputs,
+			model: undefined,
+			tools: ["bash", "read", "write"],
+			context: [],
+			...(actions ? { actions } : {}),
+		},
+		body: createSkillBody(raw),
+		location: `/skills/${name}`,
+		scope: "global",
+	};
+}
+
+function createDeps(skills: readonly Skill[], callStack?: readonly string[]): TaskpRunDeps {
+	return {
+		skillRepository: createInMemorySkillRepository(skills),
+		commandExecutor: createStubCommandExecutor(),
+		promptCollector: createStubPromptCollector({}),
+		callStack,
+	};
+}
+
+function unwrapTaskpRun(deps: TaskpRunDeps) {
+	const result = buildTools(["taskp_run"], { taskpRunDeps: deps });
+	if (!result.ok) throw new Error(`buildTools failed: ${result.error.message}`);
+	return result.value.taskp_run;
+}
+
+const toolContext = { toolCallId: "1", messages: [], abortSignal: AbortSignal.timeout(5000) };
+
+describe("TOOL_NAMES", () => {
+	it("taskp_run を含む", () => {
+		expect(TOOL_NAMES).toContain("taskp_run");
+	});
+});
+
+describe("buildTools with taskp_run", () => {
+	it("taskpRunDeps なしで taskp_run を要求するとエラー", () => {
+		const result = buildTools(["taskp_run"]);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.message).toContain("taskpRunDeps");
+	});
+
+	it("taskpRunDeps ありで taskp_run を構築できる", () => {
+		const deps = createDeps([]);
+		const result = buildTools(["taskp_run"], { taskpRunDeps: deps });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.taskp_run).toBeDefined();
+		expect(result.value.taskp_run.execute).toBeTypeOf("function");
+	});
+
+	it("taskp_run と他のツールを同時に構築できる", () => {
+		const deps = createDeps([]);
+		const result = buildTools(["bash", "taskp_run"], { taskpRunDeps: deps });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(Object.keys(result.value)).toEqual(["bash", "taskp_run"]);
+	});
+});
+
+describe("taskp_run tool", () => {
+	it("template スキルを実行して success を返す", async () => {
+		const skill = createSkill(TEMPLATE_SKILL_MD);
+		const deps = createDeps([skill]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.(
+			{ skill: "greet", set: { target: "world" } },
+			toolContext,
+		)) as TaskpRunResult;
+
+		expect(result.status).toBe("success");
+		expect(result.output).toContain("Hello world");
+	});
+
+	it("skill:action 形式でアクション付きスキルを実行できる", async () => {
+		const skill = createSkill(ACTION_SKILL_MD);
+		const deps = createDeps([skill]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.(
+			{ skill: "multi:list", set: { filter: "done" } },
+			toolContext,
+		)) as TaskpRunResult;
+
+		expect(result.status).toBe("success");
+		expect(result.output).toContain("listing done");
+	});
+
+	it("agent モードスキルの呼び出しを拒否する", async () => {
+		const skill = createSkill(AGENT_SKILL_MD);
+		const deps = createDeps([skill]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.({ skill: "agent-skill" }, toolContext)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Cannot call agent mode skill");
+	});
+
+	it("agent モードのアクションの呼び出しを拒否する", async () => {
+		const skill = createSkill(ACTION_SKILL_MD);
+		const deps = createDeps([skill]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.(
+			{ skill: "multi:agent-action" },
+			toolContext,
+		)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Cannot call agent mode skill");
+	});
+
+	it("存在しないスキルでエラーを返す", async () => {
+		const deps = createDeps([]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.({ skill: "nonexistent" }, toolContext)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Skill not found");
+	});
+
+	it("再帰呼び出しを検出してブロックする", async () => {
+		const skill = createSkill(TEMPLATE_SKILL_MD);
+		const deps = createDeps([skill], ["greet"]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.({ skill: "greet" }, toolContext)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Recursive call detected");
+	});
+
+	it("アクション付き再帰呼び出しも検出する", async () => {
+		const skill = createSkill(ACTION_SKILL_MD);
+		const deps = createDeps([skill], ["multi:list"]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.(
+			{ skill: "multi:list", set: { filter: "x" } },
+			toolContext,
+		)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Recursive call detected");
+	});
+
+	it("ネスト深度3超過でエラーを返す", async () => {
+		const skill = createSkill(TEMPLATE_SKILL_MD);
+		const deps = createDeps([skill], ["a", "b", "c"]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.(
+			{ skill: "greet", set: { target: "x" } },
+			toolContext,
+		)) as TaskpRunResult;
+
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Maximum nesting depth");
+	});
+
+	it("set で変数を渡せる", async () => {
+		const skill = createSkill(TEMPLATE_SKILL_MD);
+		const executor = createStubCommandExecutor();
+		const deps: TaskpRunDeps = {
+			skillRepository: createInMemorySkillRepository([skill]),
+			commandExecutor: executor,
+			promptCollector: createStubPromptCollector({}),
+		};
+		const tool = unwrapTaskpRun(deps);
+
+		await tool.execute?.({ skill: "greet", set: { target: "pibot" } }, toolContext);
+
+		expect(executor.executedCommands.length).toBe(1);
+		expect(executor.executedCommands[0].command).toContain("pibot");
+	});
+
+	it("set なしで required 入力が不足している場合はエラーを返す", async () => {
+		const skill = createSkill(TEMPLATE_SKILL_MD);
+		const deps = createDeps([skill]);
+		const tool = unwrapTaskpRun(deps);
+
+		const result = (await tool.execute?.({ skill: "greet" }, toolContext)) as TaskpRunResult;
+
+		// noInput=true かつ set なしなので、テンプレート変数が未解決でエラー
+		expect(result.status).toBe("failed");
+	});
+});


### PR DESCRIPTION
#### 概要

agent モードの LLM が別の taskp スキル（template モードのみ）を呼び出せる組み込みツール `taskp_run` の実装。

#### 変更内容

- `taskp_run` ツールを `agent-tools.ts` に追加（template モードのスキルのみ呼び出し可能）
- `TOOL_NAMES` に `"taskp_run"` を追加
- `buildTools` にファクトリパターン導入（`BuildToolsOptions` で deps を注入）
- 再帰呼び出し検出（callStack）と最大ネスト深度制限（3）
- `noInput: true` で実行、`set` パラメータで変数を渡す
- agent モードスキルの呼び出しを拒否するガード
- 14 件の新規テスト追加

Closes #244