### PR TITLE
feat: buildTaskpRunDescription で taskp_run の description にスキル一覧を動的注入

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -21,7 +21,7 @@ async function executeAgentLoop(
 	writer: StreamWriter,
 ): ReturnType<AgentExecutorPort["execute"]> {
 	const startTime = Date.now();
-	const toolsResult = buildTools(input.toolNames);
+	const toolsResult = buildTools(input.toolNames, input.buildToolsOptions);
 	if (!toolsResult.ok) {
 		return toolsResult;
 	}

--- a/src/core/execution/agent-loop.ts
+++ b/src/core/execution/agent-loop.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { stepCountIs, streamText } from "ai";
 import { type ExecutionError, executionError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
+import type { BuildToolsOptions } from "./agent-tools";
 import { buildTools } from "./agent-tools";
 
 // エージェントの無限ループを防ぐための安全装置。
@@ -18,6 +19,7 @@ export type AgentLoopInput = {
 	readonly systemPrompt: string;
 	readonly context: string;
 	readonly toolNames: readonly string[];
+	readonly buildToolsOptions?: BuildToolsOptions;
 };
 
 export function createAgentLoop() {
@@ -30,7 +32,7 @@ export function createAgentLoop() {
 async function executeAgentLoop(
 	input: AgentLoopInput,
 ): Promise<Result<AgentLoopResult, ExecutionError>> {
-	const toolsResult = buildTools(input.toolNames);
+	const toolsResult = buildTools(input.toolNames, input.buildToolsOptions);
 	if (!toolsResult.ok) {
 		return toolsResult;
 	}

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -8,6 +8,9 @@ import type { CommandExecutor } from "../../usecase/port/command-executor";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { type RunOutput, runSkill } from "../../usecase/run-skill";
+import type { Action } from "../skill/action";
+import { resolveActionConfig } from "../skill/action";
+import type { Skill } from "../skill/skill";
 import { domainErrorMessage, type ExecutionError, executionError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
 
@@ -177,12 +180,11 @@ function buildTaskpRunOutput(runOutput: RunOutput): string {
 	return parts.join("\n");
 }
 
-function createTaskpRunTool(deps: TaskpRunDeps): AnyTool {
+function createTaskpRunTool(deps: TaskpRunDeps, description: string): AnyTool {
 	const callStack = deps.callStack ?? [];
 
 	const tool: Tool<TaskpRunInput, TaskpRunResult> = {
-		description:
-			"Run another taskp skill (template mode only). Use to invoke predefined skills with variable inputs.",
+		description,
 		inputSchema: zodToJsonSchema(taskpRunParams),
 		execute: async ({ skill, set }) => {
 			const ref = parseSkillRef(skill);
@@ -246,8 +248,11 @@ function createTaskpRunTool(deps: TaskpRunDeps): AnyTool {
 	return tool as AnyTool;
 }
 
+export type DescriptionOverrides = Readonly<Record<string, string>>;
+
 export type BuildToolsOptions = {
 	readonly taskpRunDeps?: TaskpRunDeps;
+	readonly descriptionOverrides?: DescriptionOverrides;
 };
 
 export function buildTools(
@@ -260,24 +265,89 @@ export function buildTools(
 			if (!options?.taskpRunDeps) {
 				return err(executionError("taskp_run requires taskpRunDeps in BuildToolsOptions"));
 			}
-			tools[name] = createTaskpRunTool(options.taskpRunDeps);
+			const description = options.descriptionOverrides?.taskp_run ?? TASKP_RUN_DEFAULT_DESCRIPTION;
+			tools[name] = createTaskpRunTool(options.taskpRunDeps, description);
 			continue;
 		}
 		const t = staticTools[name];
 		if (t === undefined) {
 			return err(executionError(`Unknown tool: ${name}`));
 		}
-		tools[name] = t;
+		const override = options?.descriptionOverrides?.[name];
+		tools[name] = override ? { ...t, description: override } : t;
 	}
 	return ok(tools);
 }
 
+const TASKP_RUN_DEFAULT_DESCRIPTION =
+	"Run another taskp skill (template mode only). Use to invoke predefined skills with variable inputs.";
+
 /** ツール名からその description を返す。未知のツール名は undefined を返す。 */
 export function getToolDescription(name: string): string | undefined {
 	if (name === "taskp_run") {
-		return "Run another taskp skill (template mode only). Use to invoke predefined skills with variable inputs.";
+		return TASKP_RUN_DEFAULT_DESCRIPTION;
 	}
 	return staticTools[name]?.description;
+}
+
+const TASKP_RUN_BASE_DESCRIPTION =
+	"Run another taskp skill or action. Only template-mode skills can be invoked.";
+
+/**
+ * スキル一覧から taskp_run ツールの description を動的構築する。
+ * agent モードのスキル/アクションは除外し、template モードのみ表示する。
+ */
+export function buildTaskpRunDescription(
+	skills: readonly Skill[],
+	currentSkillName?: string,
+): string {
+	const lines = collectSkillLines(skills, currentSkillName);
+
+	if (lines.length === 0) {
+		return TASKP_RUN_BASE_DESCRIPTION;
+	}
+
+	return `${TASKP_RUN_BASE_DESCRIPTION}\n\nAvailable skills:\n${lines.join("\n")}`;
+}
+
+function collectSkillLines(skills: readonly Skill[], currentSkillName?: string): readonly string[] {
+	const lines: string[] = [];
+
+	for (const skill of skills) {
+		if (skill.metadata.name === currentSkillName) continue;
+
+		const hasActions = skill.metadata.actions && Object.keys(skill.metadata.actions).length > 0;
+
+		if (hasActions) {
+			appendSkillWithActions(lines, skill);
+		} else {
+			appendSimpleSkill(lines, skill);
+		}
+	}
+
+	return lines;
+}
+
+function appendSimpleSkill(lines: string[], skill: Skill): void {
+	if (skill.metadata.mode === "agent") return;
+	lines.push(`- ${skill.metadata.name}: ${skill.metadata.description}`);
+}
+
+function appendSkillWithActions(lines: string[], skill: Skill): void {
+	const actions = skill.metadata.actions as Record<string, Action>;
+	const actionLines: string[] = [];
+
+	for (const [actionName, action] of Object.entries(actions)) {
+		const resolved = resolveActionConfig(action, skill.metadata);
+		if (resolved.mode === "agent") continue;
+		actionLines.push(`  - ${skill.metadata.name}:${actionName}: ${resolved.description}`);
+	}
+
+	if (actionLines.length === 0) return;
+
+	// スキル自体が template でもアクションがあればヘッダーを表示
+	lines.push(`- ${skill.metadata.name}: ${skill.metadata.description}`);
+	lines.push(...actionLines);
 }
 
 export type { AnyTool, TaskpRunDeps, TaskpRunResult, ToolName };

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -5,9 +5,10 @@ export { createAgentLoop } from "./agent-loop.js";
 export type {
 	AnyTool,
 	BuildToolsOptions,
+	DescriptionOverrides,
 	TaskpRunDeps,
 	TaskpRunResult,
 	ToolName,
 } from "./agent-tools.js";
-export { buildTools, TOOL_NAMES } from "./agent-tools.js";
+export { buildTaskpRunDescription, buildTools, TOOL_NAMES } from "./agent-tools.js";
 export type { ExecutionMode } from "./execution-mode.js";

--- a/src/usecase/port/agent-executor.ts
+++ b/src/usecase/port/agent-executor.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { BuildToolsOptions } from "../../core/execution/agent-tools";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
 
@@ -8,6 +9,7 @@ export type AgentExecutorInput = {
 	readonly prompt: string;
 	readonly toolNames: readonly string[];
 	readonly maxSteps: number;
+	readonly buildToolsOptions?: BuildToolsOptions;
 };
 
 export type AgentExecutorResult = {

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,5 +1,6 @@
 import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
+import { buildTaskpRunDescription } from "../core/execution/agent-tools";
 import { getActionSection, parseActionSections, resolveActionConfig } from "../core/skill";
 import type { ContextSource } from "../core/skill/context-source";
 import type { Skill } from "../core/skill/skill";
@@ -123,12 +124,19 @@ export async function runAgentSkill(
 
 	const startTime = Date.now();
 
+	const descriptionOverrides = await buildDescriptionOverrides(
+		toolNames,
+		deps.skillRepository,
+		skill.metadata.name,
+	);
+
 	const executeResult = await deps.agentExecutor.execute({
 		model: input.model,
 		systemPrompt,
 		prompt,
 		toolNames,
 		maxSteps: MAX_STEPS,
+		buildToolsOptions: descriptionOverrides ? { descriptionOverrides } : undefined,
 	});
 
 	const durationMs = Date.now() - startTime;
@@ -230,6 +238,19 @@ function resolveContextSources(
 	}
 
 	return ok(resolved);
+}
+
+async function buildDescriptionOverrides(
+	toolNames: readonly string[],
+	skillRepository: SkillRepository,
+	currentSkillName: string,
+): Promise<Record<string, string> | undefined> {
+	if (!toolNames.includes("taskp_run")) return undefined;
+
+	const { skills } = await skillRepository.listAll();
+	return {
+		taskp_run: buildTaskpRunDescription(skills, currentSkillName),
+	};
 }
 
 function getContextSourceValue(source: ContextSource): string {

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -2,7 +2,12 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildTools, TOOL_NAMES } from "../../../src/core/execution/agent-tools";
+import {
+	buildTaskpRunDescription,
+	buildTools,
+	TOOL_NAMES,
+} from "../../../src/core/execution/agent-tools";
+import type { Skill } from "../../../src/core/skill/skill";
 
 describe("buildTools", () => {
 	it("指定したツール名に対応するツールを返す", () => {
@@ -126,5 +131,166 @@ describe("glob tool", () => {
 			{ toolCallId: "5", messages: [], abortSignal: AbortSignal.timeout(5000) },
 		)) as string[];
 		expect(result).toContain("tests/core/execution/agent-tools.test.ts");
+	});
+});
+
+describe("buildTools with descriptionOverrides", () => {
+	it("指定したツールの description を上書きする", () => {
+		const result = buildTools(["bash"], {
+			descriptionOverrides: { bash: "Custom bash description" },
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.bash.description).toBe("Custom bash description");
+	});
+
+	it("上書き対象外のツールは元の description を維持する", () => {
+		const result = buildTools(["bash", "read"], {
+			descriptionOverrides: { bash: "Overridden" },
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.bash.description).toBe("Overridden");
+		expect(result.value.read.description).toBe("Read the contents of a file");
+	});
+});
+
+function createSkillFixture(overrides: {
+	readonly name: string;
+	readonly description: string;
+	readonly mode?: "template" | "agent";
+	readonly actions?: Record<
+		string,
+		{ readonly description: string; readonly mode?: "template" | "agent" }
+	>;
+}): Skill {
+	const actions = overrides.actions
+		? Object.fromEntries(
+				Object.entries(overrides.actions).map(([key, action]) => [key, { ...action }]),
+			)
+		: undefined;
+
+	return {
+		metadata: {
+			name: overrides.name,
+			description: overrides.description,
+			mode: overrides.mode ?? "template",
+			inputs: [],
+			tools: ["bash", "read", "write"],
+			context: [],
+			actions,
+		},
+		body: {
+			content: "",
+			extractCodeBlocks: () => [],
+			extractActionSection: () => undefined,
+			extractActionCodeBlocks: () => [],
+		},
+		location: `/skills/${overrides.name}/SKILL.md`,
+		scope: "local",
+	};
+}
+
+describe("buildTaskpRunDescription", () => {
+	it("通常のスキル一覧を description に含める", () => {
+		const skills = [
+			createSkillFixture({ name: "deploy", description: "アプリケーションをデプロイする" }),
+			createSkillFixture({ name: "test", description: "テストを実行する" }),
+		];
+
+		const result = buildTaskpRunDescription(skills);
+
+		expect(result).toContain("Available skills:");
+		expect(result).toContain("- deploy: アプリケーションをデプロイする");
+		expect(result).toContain("- test: テストを実行する");
+	});
+
+	it("アクション付きスキルをアクションごとに展開表示する", () => {
+		const skills = [
+			createSkillFixture({
+				name: "task",
+				description: "タスクを管理する",
+				actions: {
+					add: { description: "タスクを追加する" },
+					delete: { description: "タスクを削除する" },
+					list: { description: "タスク一覧を表示する" },
+				},
+			}),
+		];
+
+		const result = buildTaskpRunDescription(skills);
+
+		expect(result).toContain("- task: タスクを管理する");
+		expect(result).toContain("  - task:add: タスクを追加する");
+		expect(result).toContain("  - task:delete: タスクを削除する");
+		expect(result).toContain("  - task:list: タスク一覧を表示する");
+	});
+
+	it("agent モードのスキルを一覧から除外する", () => {
+		const skills = [
+			createSkillFixture({ name: "deploy", description: "デプロイ", mode: "template" }),
+			createSkillFixture({ name: "chat", description: "チャット", mode: "agent" }),
+		];
+
+		const result = buildTaskpRunDescription(skills);
+
+		expect(result).toContain("- deploy: デプロイ");
+		expect(result).not.toContain("chat");
+	});
+
+	it("agent モードのアクションを一覧から除外する", () => {
+		const skills = [
+			createSkillFixture({
+				name: "task",
+				description: "タスクを管理する",
+				actions: {
+					add: { description: "追加する", mode: "template" },
+					chat: { description: "チャットする", mode: "agent" },
+				},
+			}),
+		];
+
+		const result = buildTaskpRunDescription(skills);
+
+		expect(result).toContain("  - task:add: 追加する");
+		expect(result).not.toContain("chat");
+	});
+
+	it("空のスキル一覧ではベース description のみ返す", () => {
+		const result = buildTaskpRunDescription([]);
+
+		expect(result).toBe(
+			"Run another taskp skill or action. Only template-mode skills can be invoked.",
+		);
+		expect(result).not.toContain("Available skills:");
+	});
+
+	it("実行中のスキル自身を一覧から除外する", () => {
+		const skills = [
+			createSkillFixture({ name: "deploy", description: "デプロイ" }),
+			createSkillFixture({ name: "current", description: "現在のスキル" }),
+		];
+
+		const result = buildTaskpRunDescription(skills, "current");
+
+		expect(result).toContain("- deploy: デプロイ");
+		expect(result).not.toContain("current");
+	});
+
+	it("全アクションが agent モードのスキルは表示しない", () => {
+		const skills = [
+			createSkillFixture({
+				name: "agent-only",
+				description: "エージェント専用",
+				actions: {
+					a: { description: "A", mode: "agent" },
+					b: { description: "B", mode: "agent" },
+				},
+			}),
+		];
+
+		const result = buildTaskpRunDescription(skills);
+
+		expect(result).not.toContain("agent-only");
 	});
 });


### PR DESCRIPTION
#### 概要

`taskp_run` ツールの description にスキル一覧を動的注入し、LLM がどのスキルを呼べるかを知れるようにする。

#### 変更内容

- `buildTaskpRunDescription` 関数を `agent-tools.ts` に追加（agent モード除外、自己除外対応）
- `buildTools` に `descriptionOverrides` パラメータを追加し、ツールの description を動的上書き可能に
- `AgentExecutorInput` / `AgentLoopInput` に `descriptionOverrides` を追加
- `run-agent-skill.ts` で `skillRepository` からスキル一覧を取得し description を動的構築
- テスト追加: 通常スキル、アクション展開、agent モード除外、空リスト、自己除外

Closes #245