### PR TITLE
feat: hooks の TASKP_CALLER_SKILL 対応

### DIFF
--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -28,6 +28,7 @@ function buildEnvVars(context: HookContext): Record<string, string> {
 		TASKP_STATUS: context.status,
 		TASKP_DURATION_MS: String(context.durationMs),
 		TASKP_ERROR: errorValue.slice(0, MAX_ERROR_LENGTH),
+		TASKP_CALLER_SKILL: context.callerSkill ?? "",
 	};
 }
 

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -4,7 +4,9 @@ import type { JSONSchema7, Tool } from "ai";
 import { jsonSchema } from "ai";
 import { execa } from "execa";
 import { toJSONSchema, z } from "zod";
+import type { HooksConfig } from "../../usecase/hook-runner";
 import type { CommandExecutor } from "../../usecase/port/command-executor";
+import type { HookExecutorPort } from "../../usecase/port/hook-executor";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import { type RunOutput, runSkill } from "../../usecase/run-skill";
@@ -155,6 +157,9 @@ type TaskpRunDeps = {
 	readonly commandExecutor: CommandExecutor;
 	readonly promptCollector: PromptCollector;
 	readonly callStack?: readonly string[];
+	readonly callerSkillName?: string;
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooksConfig?: HooksConfig;
 };
 
 function parseSkillRef(ref: string): {
@@ -227,11 +232,14 @@ function createTaskpRunTool(deps: TaskpRunDeps): AnyTool {
 					dryRun: false,
 					force: false,
 					noInput: true,
+					callerSkill: deps.callerSkillName,
 				},
 				{
 					skillRepository: deps.skillRepository,
 					commandExecutor: deps.commandExecutor,
 					promptCollector: deps.promptCollector,
+					hookExecutor: deps.hookExecutor,
+					hooksConfig: deps.hooksConfig,
 				},
 			);
 

--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -5,6 +5,7 @@ export type HookContext = {
 	readonly status: "success" | "failed";
 	readonly durationMs: number;
 	readonly error?: string;
+	readonly callerSkill?: string;
 };
 
 export type HookResult = {

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -22,6 +22,7 @@ export type RunSkillInput = {
 	readonly dryRun: boolean;
 	readonly force: boolean;
 	readonly noInput?: boolean;
+	readonly callerSkill?: string;
 };
 
 export type CommandResult = {
@@ -226,6 +227,7 @@ async function executeAndReport(
 				status: "failed",
 				durationMs,
 				error: domainErrorMessage(commandResults.error),
+				callerSkill: input.callerSkill,
 			},
 		});
 		return commandResults;
@@ -240,6 +242,7 @@ async function executeAndReport(
 			mode: "template",
 			status: "success",
 			durationMs,
+			callerSkill: input.callerSkill,
 		},
 	});
 

--- a/tests/adapter/hook-executor.test.ts
+++ b/tests/adapter/hook-executor.test.ts
@@ -80,6 +80,7 @@ describe("HookExecutor", () => {
 			TASKP_STATUS: "success",
 			TASKP_DURATION_MS: "1234",
 			TASKP_ERROR: "",
+			TASKP_CALLER_SKILL: "",
 		});
 	});
 
@@ -191,6 +192,30 @@ describe("HookExecutor", () => {
 
 		expect(results).toEqual([]);
 		expect(executor.executedCommands).toHaveLength(0);
+	});
+
+	it("injects TASKP_CALLER_SKILL when callerSkill is present", async () => {
+		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
+		const hookExecutor = createHookExecutor(executor);
+		const contextWithCaller: HookContext = {
+			...successContext,
+			callerSkill: "diagnose",
+		};
+
+		await hookExecutor.execute(["echo test"], contextWithCaller);
+
+		const env = executor.executedCommands[0].options?.env;
+		expect(env?.TASKP_CALLER_SKILL).toBe("diagnose");
+	});
+
+	it("sets TASKP_CALLER_SKILL to empty string when callerSkill is undefined", async () => {
+		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
+		const hookExecutor = createHookExecutor(executor);
+
+		await hookExecutor.execute(["echo test"], successContext);
+
+		const env = executor.executedCommands[0].options?.env;
+		expect(env?.TASKP_CALLER_SKILL).toBe("");
 	});
 
 	it("sets timeout to 30 seconds", async () => {

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -144,6 +144,43 @@ describe("runHooks", () => {
 		expect(executor.calls[0].context.actionName).toBe("add");
 	});
 
+	it("passes callerSkill in context when present", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "build",
+			mode: "template",
+			status: "success",
+			durationMs: 100,
+			callerSkill: "diagnose",
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"] },
+			context,
+		});
+
+		expect(executor.calls[0].context.callerSkill).toBe("diagnose");
+	});
+
+	it("omits callerSkill in context for direct execution", async () => {
+		const executor = createMockExecutor();
+		const context: HookContext = {
+			skillName: "deploy",
+			mode: "template",
+			status: "success",
+			durationMs: 100,
+		};
+
+		await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok"] },
+			context,
+		});
+
+		expect(executor.calls[0].context.callerSkill).toBeUndefined();
+	});
+
 	it("omits actionName in context for single skill execution", async () => {
 		const executor = createMockExecutor();
 		const context: HookContext = {


### PR DESCRIPTION
#### 概要

`taskp_run` 経由で呼び出されたスキルのフックに、呼び出し元スキル名を `TASKP_CALLER_SKILL` 環境変数として注入する。

#### 変更内容

- `HookContext` に `callerSkill` フィールドを追加
- `hook-executor` で `TASKP_CALLER_SKILL` 環境変数を注入（直接実行時は空文字）
- `RunSkillInput` に `callerSkill` を追加し、hooks context へ伝播
- `TaskpRunDeps` に `callerSkillName`, `hookExecutor`, `hooksConfig` を追加
- `taskp_run` ツールの `runSkill` 呼び出しで `callerSkill` と hooks deps を渡す

Closes #246