### PR TITLE
refactor: レビュー指摘の Important 5件を修正

### DIFF
--- a/src/core/skill/action-section-parser.ts
+++ b/src/core/skill/action-section-parser.ts
@@ -3,8 +3,6 @@ import type { Heading, Root, RootContent } from "mdast";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import type { Result } from "../types/result";
-import { ok } from "../types/result";
 import type { CodeBlock } from "./skill-body";
 
 const ACTION_PREFIX = "action:";
@@ -15,7 +13,7 @@ export type ActionSection = {
 	readonly codeBlocks: readonly CodeBlock[];
 };
 
-export function parseActionSections(markdown: string): Result<readonly ActionSection[], never> {
+export function parseActionSections(markdown: string): readonly ActionSection[] {
 	const { content } = matter(markdown);
 	const tree = unified().use(remarkParse).parse(content);
 
@@ -53,7 +51,7 @@ export function parseActionSections(markdown: string): Result<readonly ActionSec
 		sections.push(buildSection(currentName, currentNodes));
 	}
 
-	return ok(sections);
+	return sections;
 }
 
 export function getActionSection(

--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -25,9 +25,7 @@ export function createSkillBody(rawMarkdown: string): SkillBody {
 	let cachedSections: readonly ActionSection[] | null = null;
 	const getSections = (): readonly ActionSection[] => {
 		if (cachedSections === null) {
-			const result = parseActionSections(rawMarkdown);
-			if (!result.ok) return [];
-			cachedSections = result.value;
+			cachedSections = parseActionSections(rawMarkdown);
 		}
 		return cachedSections;
 	};

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -3,8 +3,6 @@ import type { ParseError } from "../types/errors";
 import { parseError } from "../types/errors";
 import type { Result } from "../types/result";
 import { err, ok } from "../types/result";
-import type { Action } from "./action";
-import type { ActionSection } from "./action-section-parser";
 import { parseActionSections } from "./action-section-parser";
 import type { SkillBody } from "./skill-body";
 import { createSkillBody } from "./skill-body";
@@ -62,13 +60,13 @@ export function parseSkill(
 }
 
 function validateActionSections(raw: string, metadata: SkillMetadata): Result<void, ParseError> {
-	const actions = metadata.actions as Record<string, Action>;
-	const sectionsResult = parseActionSections(raw);
-	if (!sectionsResult.ok) return err(parseError("Failed to parse action sections"));
-	const sections: readonly ActionSection[] = sectionsResult.value;
+	const actions = metadata.actions;
+	if (!actions) return ok(undefined);
+
+	const sections = parseActionSections(raw);
 
 	const actionKeys = new Set(Object.keys(actions));
-	const sectionNames = new Set(sections.map((section: ActionSection) => section.name));
+	const sectionNames = new Set(sections.map((section) => section.name));
 
 	for (const key of actionKeys) {
 		if (!sectionNames.has(key)) {
@@ -90,10 +88,10 @@ function validateActionSections(raw: string, metadata: SkillMetadata): Result<vo
 		}
 	}
 
-	for (const [key, action] of Object.entries(actions) as [string, Action][]) {
+	for (const [key, action] of Object.entries(actions)) {
 		const effectiveMode = action.mode ?? metadata.mode ?? "template";
 		if (effectiveMode === "template") {
-			const section = sections.find((s: ActionSection) => s.name === key);
+			const section = sections.find((s) => s.name === key);
 			if (section && section.codeBlocks.length === 0) {
 				return err(
 					parseError(

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,7 +1,7 @@
 import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
-import { getActionSection, parseActionSections, resolveActionConfig } from "../core/skill";
+import { resolveActionConfig } from "../core/skill";
 import type { ContextSource } from "../core/skill/context-source";
 import type { Skill } from "../core/skill/skill";
 import type { SkillInput } from "../core/skill/skill-input";
@@ -195,13 +195,8 @@ function resolveActionForAgent(
 
 	const config = resolveActionConfig(actions[actionName], skill.metadata);
 
-	const sectionsResult = parseActionSections(skill.body.content);
-	if (!sectionsResult.ok) {
-		return sectionsResult;
-	}
-
-	const section = getActionSection(sectionsResult.value, actionName);
-	if (!section) {
+	const sectionContent = skill.body.extractActionSection(actionName);
+	if (!sectionContent) {
 		return err(
 			executionError(
 				`Action section "## action:${actionName}" not found in skill "${skill.metadata.name}"`,
@@ -213,7 +208,7 @@ function resolveActionForAgent(
 		inputs: config.inputs,
 		tools: config.tools,
 		context: config.context,
-		sectionContent: section.content,
+		sectionContent,
 	});
 }
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,6 +1,5 @@
 import { dirname } from "node:path";
 import { resolveActionConfig } from "../core/skill/action";
-import { getActionSection, parseActionSections } from "../core/skill/action-section-parser";
 import type { Skill } from "../core/skill/skill";
 import type { CodeBlock } from "../core/skill/skill-body";
 import { type DomainError, domainErrorMessage, executionError } from "../core/types/errors";
@@ -110,23 +109,18 @@ async function runWithAction(
 		timestamp: new Date().toISOString(),
 	};
 
-	const sectionsResult = parseActionSections(skill.body.content);
-	if (!sectionsResult.ok) {
-		return sectionsResult;
-	}
-
-	const section = getActionSection(sectionsResult.value, input.action);
-	if (!section) {
+	const sectionContent = skill.body.extractActionSection(input.action);
+	if (!sectionContent) {
 		return err(executionError(`Action section "action:${input.action}" not found in skill body.`));
 	}
 
-	const renderResult = renderTemplate(section.content, variables, reserved);
+	const renderResult = renderTemplate(sectionContent, variables, reserved);
 	if (!renderResult.ok) {
 		return renderResult;
 	}
 
 	const rendered = renderResult.value;
-	const codeBlocks = section.codeBlocks;
+	const codeBlocks = skill.body.extractActionCodeBlocks(input.action, "bash");
 
 	if (input.dryRun) {
 		return ok({

--- a/tests/core/skill/action-section-parser.test.ts
+++ b/tests/core/skill/action-section-parser.test.ts
@@ -25,12 +25,10 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(2);
-		expect(result.value[0].name).toBe("add");
-		expect(result.value[1].name).toBe("delete");
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("add");
+		expect(result[1].name).toBe("delete");
 	});
 
 	it("セクション範囲は次の H2 見出しまで", () => {
@@ -45,23 +43,19 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value[0].content).toContain("最初のセクション");
-		expect(result.value[0].content).not.toContain("次のセクション");
+		expect(result[0].content).toContain("最初のセクション");
+		expect(result[0].content).not.toContain("次のセクション");
 	});
 
 	it("セクション範囲はファイル末尾まで", () => {
 		const markdown = ["## action:only", "", "唯一のセクション", "", "追加テキスト"].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(1);
-		expect(result.value[0].content).toContain("唯一のセクション");
-		expect(result.value[0].content).toContain("追加テキスト");
+		expect(result).toHaveLength(1);
+		expect(result[0].content).toContain("唯一のセクション");
+		expect(result[0].content).toContain("追加テキスト");
 	});
 
 	it("セクション外のテキスト（冒頭の説明文）は除外される", () => {
@@ -76,12 +70,10 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(1);
-		expect(result.value[0].name).toBe("deploy");
-		expect(result.value[0].content).not.toContain("冒頭の説明文");
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("deploy");
+		expect(result[0].content).not.toContain("冒頭の説明文");
 	});
 
 	it("コードブロックがアクション単位で抽出される", () => {
@@ -104,15 +96,13 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value[0].codeBlocks).toHaveLength(2);
-		expect(result.value[0].codeBlocks[0].code).toBe("npm run build");
-		expect(result.value[0].codeBlocks[1].code).toBe("npm run test");
+		expect(result[0].codeBlocks).toHaveLength(2);
+		expect(result[0].codeBlocks[0].code).toBe("npm run build");
+		expect(result[0].codeBlocks[1].code).toBe("npm run test");
 
-		expect(result.value[1].codeBlocks).toHaveLength(1);
-		expect(result.value[1].codeBlocks[0].code).toBe("npm run deploy");
+		expect(result[1].codeBlocks).toHaveLength(1);
+		expect(result[1].codeBlocks[0].code).toBe("npm run deploy");
 	});
 
 	it("action: プレフィックスのない H2 は無視される", () => {
@@ -131,25 +121,21 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(1);
-		expect(result.value[0].name).toBe("run");
-		expect(result.value[0].content).not.toContain("注意テキスト");
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("run");
+		expect(result[0].content).not.toContain("注意テキスト");
 	});
 
 	it("空のアクションセクション", () => {
 		const markdown = ["## action:empty", "", "## action:next", "", "次のセクション"].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(2);
-		expect(result.value[0].name).toBe("empty");
-		expect(result.value[0].codeBlocks).toHaveLength(0);
-		expect(result.value[1].name).toBe("next");
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("empty");
+		expect(result[0].codeBlocks).toHaveLength(0);
+		expect(result[1].name).toBe("next");
 	});
 
 	it("bash 以外のコードブロックは codeBlocks に含まれない", () => {
@@ -166,11 +152,9 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value[0].codeBlocks).toHaveLength(1);
-		expect(result.value[0].codeBlocks[0].code).toBe("echo hello");
+		expect(result[0].codeBlocks).toHaveLength(1);
+		expect(result[0].codeBlocks[0].code).toBe("echo hello");
 	});
 
 	it("frontmatter がある場合も正しくパースできる", () => {
@@ -186,11 +170,9 @@ describe("parseActionSections", () => {
 		].join("\n");
 
 		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
 
-		expect(result.value).toHaveLength(1);
-		expect(result.value[0].name).toBe("run");
+		expect(result).toHaveLength(1);
+		expect(result[0].name).toBe("run");
 	});
 });
 
@@ -200,11 +182,9 @@ describe("getActionSection", () => {
 			"\n",
 		);
 
-		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
+		const sections = parseActionSections(markdown);
 
-		const section = getActionSection(result.value, "delete");
+		const section = getActionSection(sections, "delete");
 		expect(section).toBeDefined();
 		expect(section?.name).toBe("delete");
 	});
@@ -212,10 +192,8 @@ describe("getActionSection", () => {
 	it("存在しない名前の場合は undefined を返す", () => {
 		const markdown = "## action:add\n\n追加手順";
 
-		const result = parseActionSections(markdown);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
+		const sections = parseActionSections(markdown);
 
-		expect(getActionSection(result.value, "nonexistent")).toBeUndefined();
+		expect(getActionSection(sections, "nonexistent")).toBeUndefined();
 	});
 });

--- a/tests/integration/list-command.test.ts
+++ b/tests/integration/list-command.test.ts
@@ -142,6 +142,6 @@ describe("taskp list E2E", () => {
 
 		expect(skills).toHaveLength(1);
 		expect(skills[0].metadata.actions).toBeDefined();
-		expect(Object.keys(skills[0].metadata.actions!)).toEqual(["add", "delete", "list"]);
+		expect(Object.keys(skills[0].metadata.actions ?? {})).toEqual(["add", "delete", "list"]);
 	});
 });

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -341,7 +341,13 @@ describe("runAgentSkill", () => {
 					content:
 						"Global instructions.\n\n## action:review\n\nReview the code in {{target}}.\n\n## action:analyze\n\nAnalyze the codebase.\n",
 					extractCodeBlocks: () => [],
-					extractActionSection: () => undefined,
+					extractActionSection: (name: string) => {
+						const sections: Record<string, string> = {
+							review: "## action:review\n\nReview the code in {{target}}.",
+							analyze: "## action:analyze\n\nAnalyze the codebase.",
+						};
+						return sections[name];
+					},
 					extractActionCodeBlocks: () => [],
 				},
 				location: "/tmp/test",

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -146,8 +146,8 @@ describe("showSkill", () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.actions).toHaveLength(2);
-		expect(result.value.actions![0].name).toBe("add");
-		expect(result.value.actions![0].description).toBe("タスクを追加");
+		expect(result.value.actions?.[0].name).toBe("add");
+		expect(result.value.actions?.[0].description).toBe("タスクを追加");
 		expect(result.value.actionDetail).toBeUndefined();
 	});
 
@@ -168,8 +168,8 @@ describe("showSkill", () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.actionDetail).toBeDefined();
-		expect(result.value.actionDetail!.name).toBe("add");
-		expect(result.value.actionDetail!.mode).toBe("agent");
+		expect(result.value.actionDetail?.name).toBe("add");
+		expect(result.value.actionDetail?.mode).toBe("agent");
 		expect(result.value.inputs).toHaveLength(1);
 		expect(result.value.inputs[0].name).toBe("title");
 	});


### PR DESCRIPTION
## 概要

コードレビューで指摘された Important 5件を修正。

## 修正内容

### 1. アクションセクションの二重パース解消（run-skill.ts）

`parseActionSections()` を直接呼んでいたのを `skill.body.extractActionSection()` / `skill.body.extractActionCodeBlocks()` に置換。`SkillBody` 内のキャッシュを活用し、remark AST の不要な再パースを排除。

### 2. アクションセクションの二重パース解消（run-agent-skill.ts）

同上。`resolveActionForAgent` 内の `parseActionSections` 直接呼び出しを `skill.body.extractActionSection` に置換。

### 3. `parseActionSections` の戻り値を素の配列に変更

`Result<readonly ActionSection[], never>` → `readonly ActionSection[]`。エラーを返せない `Result` で包む意味がないため、シンプルな配列に変更。テストからも `.ok` / `.value` アクセスを除去。

### 4. 不要な `as` キャストの除去（skill.ts）

`validateActionSections` 内の `metadata.actions as Record<string, Action>` と `Object.entries(actions) as [string, Action][]` を除去。if ガード後は型推論で十分。

### 5. lint warning の修正（non-null assertion → optional chain）

- `tests/integration/list-command.test.ts`: `actions!` → `actions ?? {}`
- `tests/usecase/show-skill.test.ts`: `actions![0]` → `actions?.[0]`、`actionDetail!` → `actionDetail?.`

## テスト結果

- ✅ 542 tests passed
- ✅ tsc --noEmit: no errors
- ✅ biome check: 0 warnings