### PR TITLE
fix: taskbook スキルの priority choices を数字のみに修正

### DIFF
--- a/.taskp/skills/taskbook/SKILL.md
+++ b/.taskp/skills/taskbook/SKILL.md
@@ -23,9 +23,9 @@ actions:
         required: false
       - name: priority
         type: select
-        message: "優先度は？"
-        choices: ["1:通常", "2:中", "3:高"]
-        default: "1:通常"
+        message: "優先度は？（1=通常, 2=中, 3=高）"
+        choices: ["1", "2", "3"]
+        default: "1"
   add-note:
     description: ノートを追加する（AIが内容を簡潔にまとめる）
     mode: agent
@@ -73,8 +73,8 @@ actions:
         message: "対象のIDは？"
       - name: priority
         type: select
-        message: "優先度は？"
-        choices: ["1:通常", "2:中", "3:高"]
+        message: "優先度は？（1=通常, 2=中, 3=高）"
+        choices: ["1", "2", "3"]
   move:
     description: アイテムを別ボードへ移動する
     inputs:
@@ -167,7 +167,7 @@ tb -a
 
 1. ユーザー入力（複数行の場合あり）を読んで、**日本語で1行のタスク説明**にまとめる
 2. 元の意図を損なわず、具体的で行動可能な表現にする
-3. 優先度は `{{priority}}` の先頭の数字（1, 2, 3）を使う
+3. 優先度は `{{priority}}`（1, 2, 3）をそのまま使う
 4. コマンド実行後に `tb` で最新状態を表示する
 
 ### ユーザー入力


### PR DESCRIPTION
## 問題

`taskp run taskbook:priority` で `tb -p '@1' '3:高'` のように不正な引数が渡されてエラーになっていた。

## 原因

choices が `["1:通常", "2:中", "3:高"]` になっており、選択値がそのままコマンド引数に展開されていた。

## 修正

- `priority` アクション: choices を `["1", "2", "3"]` に変更、説明は message に含める
- `add-task` アクション: 同上（agent モードだが統一のため）