### PR TITLE
docs: README にアクション機能・provider/model 統一・taskp_run を反映

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,7 @@
 
 - **マークダウンでスキル定義** — 人間が読み書きしやすく、Git 管理も容易
 - **2つの実行モード** — テンプレート展開（LLM 不要）と AI エージェント実行
+- **マルチアクション** — 関連する操作（追加/削除/一覧）を1つのスキルにまとめられる
 - **マルチプロバイダ対応** — Anthropic / OpenAI / Google / Ollama をサポート
 - **MCP サーバー** — Claude Code や pi などの AI ツールからも利用可能
 
@@ -97,6 +98,61 @@ taskp run deploy
 taskp run code-review --model anthropic/claude-sonnet-4-20250514
 ```
 
+### 5. マルチアクションスキルを作成する
+
+`actions` で関連する操作を1つのスキルにまとめられます：
+
+```markdown
+---
+name: task
+description: タスクを管理する
+mode: template
+actions:
+  add:
+    description: タスクを追加する
+    inputs:
+      - name: title
+        type: text
+        message: "タスク名は？"
+  list:
+    description: タスク一覧を表示する
+  delete:
+    description: タスクを削除する
+    mode: agent
+    tools: [bash]
+    inputs:
+      - name: id
+        type: text
+        message: "タスクIDは？"
+---
+
+# タスク管理
+
+## action:add
+
+｀｀｀bash
+echo "タスク追加: {{title}}"
+｀｀｀
+
+## action:list
+
+｀｀｀bash
+echo "タスク一覧..."
+｀｀｀
+
+## action:delete
+
+タスク {{id}} を確認してから削除してください。
+```
+
+```bash
+taskp run task:add                 # 特定のアクションを実行
+taskp run task:add --set title="買い物"
+taskp tui                          # TUI でアクションを選択
+```
+
+各アクションは独自の `mode`、`model`、`inputs`、`tools`、`context` を持てます。1つのスキル内で template と agent モードを混在できます。
+
 ## コマンド一覧
 
 ### `taskp run <skill>`
@@ -109,12 +165,12 @@ taskp run deploy --model ollama/qwen2.5-coder:32b
 taskp run deploy --dry-run
 taskp run deploy --set environment=production --set branch=main
 taskp run deploy --no-input
+taskp run task:add               # 特定のアクションを実行
 ```
 
 | オプション | 短縮 | 説明 |
 |-----------|------|------|
-| `--model` | `-m` | 使用する LLM モデル |
-| `--provider` | `-p` | LLM プロバイダ |
+| `--model` | `-m` | 使用する LLM モデル（`provider/model` 形式対応） |
 | `--dry-run` | | 実行計画を表示するが実行しない |
 | `--force` | `-f` | エラー時も続行する（template モード） |
 | `--verbose` | `-v` | 詳細ログを表示 |
@@ -139,6 +195,7 @@ taskp list --local
 taskp init my-task
 taskp init my-task --global
 taskp init my-task --mode agent
+taskp init my-task --actions add,delete,list
 ```
 
 ### `taskp show <skill>`
@@ -147,6 +204,7 @@ taskp init my-task --mode agent
 
 ```bash
 taskp show deploy
+taskp show task:add              # アクション詳細を表示
 ```
 
 ### `taskp tui`
@@ -210,7 +268,7 @@ inputs:                 # 入力定義
   - name: target
     type: text
     message: "対象は？"
-model: anthropic/claude-sonnet-4-20250514  # agent モード用（省略可）
+model: anthropic/claude-sonnet-4-20250514  # agent モード用（provider/model 形式）
 tools:                  # agent モードで使用するツール（省略可）
   - bash
   - read
@@ -220,7 +278,45 @@ context:                # 自動的にコンテキストに含めるソース（
     path: "src/{{target}}"
   - type: command
     run: "git diff --cached"
+actions:                # マルチアクション定義（省略可）
+  build:
+    description: プロジェクトをビルドする
+    inputs:
+      - name: target
+        type: text
+        message: "ビルド対象は？"
+  test:
+    description: テストを実行する
+    mode: agent
+    tools: [bash, read]
 ---
+```
+
+### アクション
+
+`actions` フィールドで1つのスキルに複数のアクションを定義できます。各アクションは `mode`、`model`、`inputs`、`tools`、`context`、`timeout` を個別に上書き可能で、未指定のフィールドはスキルレベルの値を継承します。
+
+`actions` が定義されている場合、スキルレベルの `inputs` は無視されます。
+
+アクションの実行手順は本文中の `## action:<name>` セクションで定義します：
+
+```markdown
+## action:build
+
+｀｀｀bash
+npm run build --target={{target}}
+｀｀｀
+
+## action:test
+
+テストカバレッジを分析し、改善点を提案してください。
+```
+
+コロン区切りでアクションを実行：
+
+```bash
+taskp run my-skill:build
+taskp run my-skill:test --model anthropic/claude-sonnet-4-20250514
 ```
 
 ### 入力タイプ
@@ -237,6 +333,26 @@ context:                # 自動的にコンテキストに含めるソース（
 ### 変数展開
 
 本文中で `{{変数名}}` を使って入力値を展開できます。
+
+### 組み込みツール: `taskp_run`
+
+agent モードで LLM が他の template モードスキルを呼び出せます：
+
+```yaml
+---
+name: diagnose
+mode: agent
+tools:
+  - bash
+  - read
+  - taskp_run    # スキル間連携を有効化
+---
+```
+
+制約:
+- template モードのスキルのみ呼び出し可能（agent のネストは不可）
+- 再帰呼び出しは検出・ブロック
+- 最大ネスト深度: 3
 
 ## カスタムシステムプロンプト
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A CLI tool that runs skills (task procedures) defined in Markdown — collecting
 
 - **Skills defined in Markdown** — Human-readable, easy to write, and Git-friendly
 - **Two execution modes** — Template rendering (no LLM required) and AI agent execution
+- **Multi-action skills** — Group related operations (add/delete/list) into a single skill
 - **Multi-provider support** — Anthropic / OpenAI / Google / Ollama
 - **MCP server** — Usable from AI tools like Claude Code and pi
 
@@ -97,6 +98,61 @@ Change to `mode: agent` and the LLM will interpret and execute the skill's conte
 taskp run code-review --model anthropic/claude-sonnet-4-20250514
 ```
 
+### 5. Create a multi-action skill
+
+Group related operations into a single skill with `actions`:
+
+```markdown
+---
+name: task
+description: Manage tasks
+mode: template
+actions:
+  add:
+    description: Add a task
+    inputs:
+      - name: title
+        type: text
+        message: "Task title?"
+  list:
+    description: List tasks
+  delete:
+    description: Delete a task
+    mode: agent
+    tools: [bash]
+    inputs:
+      - name: id
+        type: text
+        message: "Task ID?"
+---
+
+# Task Management
+
+## action:add
+
+｀｀｀bash
+echo "Adding task: {{title}}"
+｀｀｀
+
+## action:list
+
+｀｀｀bash
+echo "Listing tasks..."
+｀｀｀
+
+## action:delete
+
+Find and delete task {{id}}, confirming with the user first.
+```
+
+```bash
+taskp run task:add                 # Run a specific action
+taskp run task:add --set title="Buy milk"
+taskp tui                          # Select actions interactively
+```
+
+Each action can have its own `mode`, `model`, `inputs`, `tools`, and `context` — mixing template and agent mode within a single skill.
+
 ## Commands
 
 ### `taskp run <skill>`
@@ -109,12 +165,12 @@ taskp run deploy --model ollama/qwen2.5-coder:32b
 taskp run deploy --dry-run
 taskp run deploy --set environment=production --set branch=main
 taskp run deploy --no-input
+taskp run task:add               # Run a specific action
 ```
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--model` | `-m` | LLM model to use |
-| `--provider` | `-p` | LLM provider |
+| `--model` | `-m` | LLM model (`provider/model` format supported) |
 | `--dry-run` | | Show execution plan without running |
 | `--force` | `-f` | Continue on error (template mode) |
 | `--verbose` | `-v` | Show detailed logs |
@@ -139,6 +195,7 @@ Generate a skill scaffold.
 taskp init my-task
 taskp init my-task --global
 taskp init my-task --mode agent
+taskp init my-task --actions add,delete,list
 ```
 
 ### `taskp show <skill>`
@@ -147,6 +204,7 @@ Show skill details.
 
 ```bash
 taskp show deploy
+taskp show task:add              # Show action details
 ```
 
 ### `taskp tui`
@@ -210,7 +268,7 @@ inputs:                 # Input definitions
   - name: target
     type: text
     message: "Target?"
-model: anthropic/claude-sonnet-4-20250514  # For agent mode (optional)
+model: anthropic/claude-sonnet-4-20250514  # For agent mode (provider/model format)
 tools:                  # Tools for agent mode (optional)
   - bash
   - read
@@ -220,7 +278,45 @@ context:                # Sources auto-included in context (optional)
     path: "src/{{target}}"
   - type: command
     run: "git diff --cached"
+actions:                # Multi-action definitions (optional)
+  build:
+    description: Build the project
+    inputs:
+      - name: target
+        type: text
+        message: "Build target?"
+  test:
+    description: Run tests
+    mode: agent
+    tools: [bash, read]
 ---
+```
+
+### Actions
+
+A skill can define multiple actions via the `actions` field. Each action can override `mode`, `model`, `inputs`, `tools`, `context`, and `timeout` — unspecified fields inherit from the skill level.
+
+When `actions` is defined, the skill-level `inputs` is ignored.
+
+Action bodies are defined in the Markdown body using `## action:<name>` sections:
+
+```markdown
+## action:build
+
+｀｀｀bash
+npm run build --target={{target}}
+｀｀｀
+
+## action:test
+
+Analyze test coverage and suggest improvements.
+```
+
+Run actions with colon syntax:
+
+```bash
+taskp run my-skill:build
+taskp run my-skill:test --model anthropic/claude-sonnet-4-20250514
 ```
 
 ### Input Types
@@ -237,6 +333,26 @@ context:                # Sources auto-included in context (optional)
 ### Variable Expansion
 
 Use `{{variable_name}}` in the body to expand input values.
+
+### Built-in Tool: `taskp_run`
+
+In agent mode, the LLM can invoke other template-mode skills using the `taskp_run` tool:
+
+```yaml
+---
+name: diagnose
+mode: agent
+tools:
+  - bash
+  - read
+  - taskp_run    # Enable cross-skill invocation
+---
+```
+
+Constraints:
+- Only template-mode skills can be called (no agent nesting)
+- Recursive calls are detected and blocked
+- Maximum nesting depth: 3
 
 ## Custom System Prompt
 


### PR DESCRIPTION
## 概要

v0.1.6 の新機能を README.md / README.ja.md に反映。

## 追加内容

- **Features**: マルチアクション機能を追加
- **Quick Start**: マルチアクションスキルの作成例（ステップ5）
- **コマンド**: `skill:action` 形式、`--actions` オプション、`--provider` 削除
- **フロントマター**: `actions` フィールドの説明
- **Actions セクション**: 継承ルール、`## action:<name>` 構文、実行方法
- **taskp_run セクション**: 組み込みツールの説明と制約
- **provider/model**: `--model` の説明を `provider/model` 形式に更新