### PR TITLE
feat: taskp setup コマンド — プロジェクト初期化

### DIFF
--- a/src/adapter/project-initializer.ts
+++ b/src/adapter/project-initializer.ts
@@ -1,0 +1,174 @@
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { z } from "zod";
+import type { Result } from "../core/types/result";
+import type {
+	ProjectInitializer,
+	SetupLocation,
+	SetupResult,
+} from "../usecase/port/project-initializer";
+import { configSchema } from "./config-loader";
+import { tryCatch } from "./error-handler-utils";
+
+const TASKP_DIR = ".taskp";
+const CONFIG_FILE = "config.toml";
+const SCHEMA_FILE = "config.schema.json";
+const SKILLS_DIR = "skills";
+const TAPLO_FILE = ".taplo.toml";
+
+const CONFIG_TEMPLATE = `# taskp — 設定ファイル
+
+[ai]
+# default_provider = "anthropic"
+# default_model = "claude-sonnet-4-20250514"
+
+# [ai.providers.anthropic]
+# api_key_env = "ANTHROPIC_API_KEY"
+
+# [ai.providers.ollama]
+# base_url = "http://localhost:11434/v1"
+# default_model = "qwen2.5-coder:32b"
+
+# [cli]
+# command_timeout_ms = 30000
+
+# [hooks]
+# on_success = []
+# on_failure = []
+`;
+
+const GLOBAL_CONFIG_TEMPLATE = `# taskp — グローバル設定ファイル
+
+[ai]
+# default_provider = "anthropic"
+# default_model = "claude-sonnet-4-20250514"
+
+# [ai.providers.anthropic]
+# api_key_env = "ANTHROPIC_API_KEY"
+
+# [ai.providers.ollama]
+# base_url = "http://localhost:11434/v1"
+# default_model = "qwen2.5-coder:32b"
+`;
+
+const TAPLO_CONTENT = `[[rule]]
+include = [".taskp/config.toml"]
+
+[rule.schema]
+path = ".taskp/config.schema.json"
+`;
+
+function generateJsonSchema(): string {
+	const jsonSchema = z.toJSONSchema(configSchema, {
+		target: "draft-2020-12",
+	});
+	return `${JSON.stringify(jsonSchema, null, 2)}\n`;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		await stat(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+type FileEntry = {
+	readonly path: string;
+	readonly content: string;
+};
+
+type DirEntry = {
+	readonly path: string;
+};
+
+async function writeFileIfNeeded(
+	entry: FileEntry,
+	force: boolean,
+	baseDir: string,
+	created: string[],
+	skipped: string[],
+): Promise<void> {
+	const displayPath = relative(baseDir, entry.path);
+	if (!force && (await fileExists(entry.path))) {
+		skipped.push(displayPath);
+		return;
+	}
+	await writeFile(entry.path, entry.content, "utf-8");
+	created.push(displayPath);
+}
+
+async function createDirIfNeeded(
+	entry: DirEntry,
+	baseDir: string,
+	created: string[],
+): Promise<void> {
+	const existed = await fileExists(entry.path);
+	await mkdir(entry.path, { recursive: true });
+	if (!existed) {
+		created.push(relative(baseDir, entry.path));
+	}
+}
+
+type ProjectInitializerDeps = {
+	readonly baseDir: string;
+	readonly location: SetupLocation;
+};
+
+export function createProjectInitializer(deps: ProjectInitializerDeps): ProjectInitializer {
+	const isGlobal = deps.location === "global";
+	const taskpDir = join(deps.baseDir, TASKP_DIR);
+	const skillsDir = join(taskpDir, SKILLS_DIR);
+
+	return {
+		setup: async (options: { readonly force: boolean }): Promise<Result<SetupResult, Error>> => {
+			return tryCatch(
+				async () => {
+					const created: string[] = [];
+					const skipped: string[] = [];
+
+					await createDirIfNeeded({ path: taskpDir }, deps.baseDir, created);
+					await createDirIfNeeded({ path: skillsDir }, deps.baseDir, created);
+
+					const configPath = join(taskpDir, CONFIG_FILE);
+					const configContent = isGlobal ? GLOBAL_CONFIG_TEMPLATE : CONFIG_TEMPLATE;
+					await writeFileIfNeeded(
+						{ path: configPath, content: configContent },
+						options.force,
+						deps.baseDir,
+						created,
+						skipped,
+					);
+
+					if (!isGlobal) {
+						const schemaPath = join(taskpDir, SCHEMA_FILE);
+						await writeFileIfNeeded(
+							{ path: schemaPath, content: generateJsonSchema() },
+							options.force,
+							deps.baseDir,
+							created,
+							skipped,
+						);
+
+						const taploPath = join(deps.baseDir, TAPLO_FILE);
+						await writeFileIfNeeded(
+							{ path: taploPath, content: TAPLO_CONTENT },
+							options.force,
+							deps.baseDir,
+							created,
+							skipped,
+						);
+					}
+
+					return {
+						location: deps.location,
+						created,
+						skipped,
+					};
+				},
+				(e) => new Error(`Failed to setup project: ${e.message}`),
+			);
+		},
+	};
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { createContextCollector } from "./adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "./adapter/context-collector-deps";
 import { createHookExecutor } from "./adapter/hook-executor";
 import { createCliProgressWriter } from "./adapter/progress-formatter";
+import { createProjectInitializer } from "./adapter/project-initializer";
 import { createPromptRunner } from "./adapter/prompt-runner";
 import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
@@ -24,6 +25,8 @@ import { createListSkillsUseCase } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
 import type { RunOutput } from "./usecase/run-skill";
 import { runSkill } from "./usecase/run-skill";
+import type { SetupOutput } from "./usecase/setup-project";
+import { setupProject } from "./usecase/setup-project";
 import type { ShowOutput } from "./usecase/show-skill";
 import { showSkill } from "./usecase/show-skill";
 
@@ -96,6 +99,29 @@ function formatRunOutput(output: RunOutput): string {
 
 function formatInitOutput(output: InitOutput): string {
 	return `Created ${output.mode} skill "${output.name}" at ${output.path}`;
+}
+
+function formatSetupOutput(output: SetupOutput): string {
+	const lines: string[] = [];
+	lines.push(`Setup ${output.location} configuration:`);
+
+	if (output.created.length > 0) {
+		lines.push("");
+		lines.push("Created:");
+		for (const path of output.created) {
+			lines.push(`  ${path}`);
+		}
+	}
+
+	if (output.skipped.length > 0) {
+		lines.push("");
+		lines.push("Skipped (already exists):");
+		for (const path of output.skipped) {
+			lines.push(`  ${path}`);
+		}
+	}
+
+	return lines.join("\n");
 }
 
 function formatError(error: DomainError): string {
@@ -315,6 +341,38 @@ const cli = Cli.create("taskp", {
 			}
 
 			console.log(formatShowOutput(result.value));
+		},
+	})
+	.command("setup", {
+		description: "Initialize project configuration",
+		options: z.object({
+			global: z.boolean().optional().describe("Initialize global configuration"),
+			force: z.boolean().optional().describe("Overwrite existing files"),
+		}),
+		alias: {
+			global: "g",
+			force: "f",
+		},
+		async run(c) {
+			const isGlobal = c.options.global ?? false;
+			const baseDir = isGlobal ? homedir() : process.cwd();
+
+			const projectInitializer = createProjectInitializer({
+				baseDir,
+				location: isGlobal ? "global" : "project",
+			});
+
+			const result = await setupProject(
+				{ projectInitializer },
+				{ global: isGlobal, force: c.options.force ?? false },
+			);
+
+			if (!result.ok) {
+				console.error(formatError(result.error));
+				process.exit(EXIT_CODE[result.error.type]);
+			}
+
+			console.log(formatSetupOutput(result.value));
 		},
 	})
 	.command("tui", {

--- a/src/usecase/port/project-initializer.ts
+++ b/src/usecase/port/project-initializer.ts
@@ -1,0 +1,13 @@
+import type { Result } from "../../core/types/result";
+
+export type SetupLocation = "project" | "global";
+
+export type SetupResult = {
+	readonly location: SetupLocation;
+	readonly created: readonly string[];
+	readonly skipped: readonly string[];
+};
+
+export type ProjectInitializer = {
+	readonly setup: (options: { readonly force: boolean }) => Promise<Result<SetupResult, Error>>;
+};

--- a/src/usecase/setup-project.ts
+++ b/src/usecase/setup-project.ts
@@ -1,0 +1,31 @@
+import type { DomainError } from "../core/types/errors";
+import { configError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { err } from "../core/types/result";
+import type { ProjectInitializer, SetupResult } from "./port/project-initializer";
+
+export type SetupOutput = SetupResult;
+
+export type SetupProjectInput = {
+	readonly global: boolean;
+	readonly force: boolean;
+};
+
+type Deps = {
+	readonly projectInitializer: ProjectInitializer;
+};
+
+export async function setupProject(
+	deps: Deps,
+	input: SetupProjectInput,
+): Promise<Result<SetupOutput, DomainError>> {
+	const result = await deps.projectInitializer.setup({
+		force: input.force,
+	});
+
+	if (!result.ok) {
+		return err(configError(result.error.message));
+	}
+
+	return result;
+}

--- a/tests/integration/adapter-integration.test.ts
+++ b/tests/integration/adapter-integration.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createConfigLoader } from "../../src/adapter/config-loader";
+import { createProjectInitializer } from "../../src/adapter/project-initializer";
 import { createSkillLoader } from "../../src/adapter/skill-loader";
 import { type ReservedVars, renderTemplate } from "../../src/core/variable/template-renderer";
 
@@ -282,6 +283,91 @@ describe("Adapter Integration", () => {
 			if (result.ok) return;
 			expect(result.error.type).toBe("CONFIG_ERROR");
 			expect(result.error.message).toContain("Invalid config");
+		});
+	});
+
+	describe("ProjectInitializer", () => {
+		it("プロジェクト初期化で必要なファイルを生成する", async () => {
+			const initializer = createProjectInitializer({
+				baseDir: localRoot,
+				location: "project",
+			});
+
+			const result = await initializer.setup({ force: false });
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			expect(existsSync(join(localRoot, ".taskp", "config.toml"))).toBe(true);
+			expect(existsSync(join(localRoot, ".taskp", "config.schema.json"))).toBe(true);
+			expect(existsSync(join(localRoot, ".taskp", "skills"))).toBe(true);
+			expect(existsSync(join(localRoot, ".taplo.toml"))).toBe(true);
+
+			const configContent = readFileSync(join(localRoot, ".taskp", "config.toml"), "utf-8");
+			expect(configContent).toContain("# default_provider");
+
+			const schemaContent = readFileSync(join(localRoot, ".taskp", "config.schema.json"), "utf-8");
+			const schema = JSON.parse(schemaContent);
+			expect(schema.properties).toHaveProperty("ai");
+		});
+
+		it("グローバル初期化ではスキーマと taplo を生成しない", async () => {
+			const initializer = createProjectInitializer({
+				baseDir: globalRoot,
+				location: "global",
+			});
+
+			const result = await initializer.setup({ force: false });
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			expect(existsSync(join(globalRoot, ".taskp", "config.toml"))).toBe(true);
+			expect(existsSync(join(globalRoot, ".taskp", "skills"))).toBe(true);
+			expect(existsSync(join(globalRoot, ".taskp", "config.schema.json"))).toBe(false);
+			expect(existsSync(join(globalRoot, ".taplo.toml"))).toBe(false);
+		});
+
+		it("既存ファイルをスキップする（force なし）", async () => {
+			const configDir = join(localRoot, ".taskp");
+			mkdirSync(configDir, { recursive: true });
+			writeFileSync(join(configDir, "config.toml"), "existing content");
+
+			const initializer = createProjectInitializer({
+				baseDir: localRoot,
+				location: "project",
+			});
+
+			const result = await initializer.setup({ force: false });
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			expect(result.value.skipped).toContain(".taskp/config.toml");
+
+			const content = readFileSync(join(configDir, "config.toml"), "utf-8");
+			expect(content).toBe("existing content");
+		});
+
+		it("force オプションで既存ファイルを上書きする", async () => {
+			const configDir = join(localRoot, ".taskp");
+			mkdirSync(configDir, { recursive: true });
+			writeFileSync(join(configDir, "config.toml"), "old content");
+
+			const initializer = createProjectInitializer({
+				baseDir: localRoot,
+				location: "project",
+			});
+
+			const result = await initializer.setup({ force: true });
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			expect(result.value.created).toContain(".taskp/config.toml");
+
+			const content = readFileSync(join(configDir, "config.toml"), "utf-8");
+			expect(content).toContain("# default_provider");
 		});
 	});
 });

--- a/tests/usecase/setup-project.test.ts
+++ b/tests/usecase/setup-project.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { ErrorType } from "../../src/core/types/errors";
+import { err, ok } from "../../src/core/types/result";
+import type { ProjectInitializer, SetupLocation } from "../../src/usecase/port/project-initializer";
+import { setupProject } from "../../src/usecase/setup-project";
+
+function stubInitializer(result: {
+	location: SetupLocation;
+	created: string[];
+	skipped: string[];
+}): ProjectInitializer {
+	return {
+		setup: () => Promise.resolve(ok(result)),
+	};
+}
+
+function failingInitializer(message: string): ProjectInitializer {
+	return {
+		setup: () => Promise.resolve(err(new Error(message))),
+	};
+}
+
+describe("setupProject", () => {
+	it("returns created files for project setup", async () => {
+		const initializer = stubInitializer({
+			location: "project",
+			created: [".taskp/config.toml", ".taskp/config.schema.json", ".taskp/skills", ".taplo.toml"],
+			skipped: [],
+		});
+
+		const result = await setupProject(
+			{ projectInitializer: initializer },
+			{ global: false, force: false },
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.location).toBe("project");
+			expect(result.value.created).toContain(".taskp/config.toml");
+			expect(result.value.skipped).toHaveLength(0);
+		}
+	});
+
+	it("returns created files for global setup", async () => {
+		const initializer = stubInitializer({
+			location: "global",
+			created: ["~/.taskp/config.toml", "~/.taskp/skills"],
+			skipped: [],
+		});
+
+		const result = await setupProject(
+			{ projectInitializer: initializer },
+			{ global: true, force: false },
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.location).toBe("global");
+			expect(result.value.created).toHaveLength(2);
+		}
+	});
+
+	it("returns skipped files when they already exist", async () => {
+		const initializer = stubInitializer({
+			location: "project",
+			created: [],
+			skipped: [".taskp/config.toml", ".taplo.toml"],
+		});
+
+		const result = await setupProject(
+			{ projectInitializer: initializer },
+			{ global: false, force: false },
+		);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.created).toHaveLength(0);
+			expect(result.value.skipped).toContain(".taskp/config.toml");
+		}
+	});
+
+	it("passes force option to initializer", async () => {
+		let capturedForce: boolean | undefined;
+		const initializer: ProjectInitializer = {
+			setup: (options) => {
+				capturedForce = options.force;
+				return Promise.resolve(ok({ location: "project" as const, created: [], skipped: [] }));
+			},
+		};
+
+		await setupProject({ projectInitializer: initializer }, { global: false, force: true });
+
+		expect(capturedForce).toBe(true);
+	});
+
+	it("returns config error when initializer fails", async () => {
+		const initializer = failingInitializer("Permission denied");
+
+		const result = await setupProject(
+			{ projectInitializer: initializer },
+			{ global: false, force: false },
+		);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Config);
+			expect((result.error as { message: string }).message).toContain("Permission denied");
+		}
+	});
+});


### PR DESCRIPTION
#### 概要

`taskp setup` コマンドを追加し、プロジェクトの初期設定（`.taskp/` ディレクトリ、`config.toml`、`config.schema.json`、`.taplo.toml`、`skills/`）を一括で行えるようにする。

#### 変更内容

- `src/usecase/port/project-initializer.ts` — ProjectInitializer ポートインターフェース
- `src/adapter/project-initializer.ts` — ファイル生成アダプタ実装
- `src/usecase/setup-project.ts` — setup ユースケース
- `src/cli.ts` — `setup` コマンド登録（`--global/-g`、`--force/-f` オプション）
- `tests/usecase/setup-project.test.ts` — ユースケーステスト（5件）
- `tests/integration/adapter-integration.test.ts` — 統合テスト（4件追加）

Closes #268