### PR TITLE
docs: taskp setup コマンドを README.md に反映

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,7 +41,32 @@ bun remove -g taskp
 
 ## クイックスタート
 
-### 1. スキルを作成する
+### 1. プロジェクトを初期化する
+
+```bash
+taskp setup
+```
+
+`.taskp/` ディレクトリとコメントアウトされた `config.toml` が生成されます。必要な行のコメントを外すだけで設定できます：
+
+```toml
+[ai]
+default_provider = "anthropic"
+default_model = "claude-sonnet-4-20250514"
+
+[ai.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+```
+
+JSON Schema と `.taplo.toml` も生成されるため、[Taplo](https://taplo.tamasfe.dev/) 対応エディタで補完が効きます。
+
+グローバル設定（プロジェクト横断）の場合：
+
+```bash
+taskp setup --global
+```
+
+### 2. スキルを作成する
 
 ```bash
 taskp init deploy
@@ -49,7 +74,7 @@ taskp init deploy
 
 `.taskp/skills/deploy/SKILL.md` が生成されます。
 
-### 2. スキルを編集する
+### 3. スキルを編集する
 
 ```markdown
 ---
@@ -81,7 +106,7 @@ npm run deploy:{{environment}}
 \`\`\`
 ```
 
-### 3. スキルを実行する
+### 4. スキルを実行する
 
 ```bash
 taskp run deploy
@@ -90,7 +115,7 @@ taskp run deploy
 # → コマンドが順番に実行される
 ```
 
-### 4. AI エージェントモードで実行する
+### 5. AI エージェントモードで実行する
 
 `mode: agent` に変更すれば、LLM がスキルの内容を解釈して実行します。
 
@@ -98,7 +123,7 @@ taskp run deploy
 taskp run code-review --model anthropic/claude-sonnet-4-20250514
 ```
 
-### 5. マルチアクションスキルを作成する
+### 6. マルチアクションスキルを作成する
 
 `actions` で関連する操作を1つのスキルにまとめられます：
 
@@ -176,6 +201,21 @@ taskp run task:add               # 特定のアクションを実行
 | `--verbose` | `-v` | 詳細ログを表示 |
 | `--no-input` | | 対話的質問を無効化（デフォルト値を使用） |
 | `--set` | `-s` | 変数を直接指定（`--set key=value`） |
+
+### `taskp setup`
+
+プロジェクトの設定を初期化します。
+
+```bash
+taskp setup
+taskp setup --global
+taskp setup --force
+```
+
+| オプション | 短縮 | 説明 |
+|-----------|------|------|
+| `--global` | `-g` | グローバル設定（`~/.taskp/`）を初期化 |
+| `--force` | `-f` | 既存ファイルを上書き |
 
 ### `taskp list`
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,32 @@ bun remove -g taskp
 
 ## Quick Start
 
-### 1. Create a skill
+### 1. Initialize the project
+
+```bash
+taskp setup
+```
+
+This creates the `.taskp/` directory with a commented-out `config.toml`. Uncomment the lines you need:
+
+```toml
+[ai]
+default_provider = "anthropic"
+default_model = "claude-sonnet-4-20250514"
+
+[ai.providers.anthropic]
+api_key_env = "ANTHROPIC_API_KEY"
+```
+
+A JSON Schema and `.taplo.toml` are also generated, enabling autocompletion in editors that support [Taplo](https://taplo.tamasfe.dev/).
+
+For global configuration (shared across projects):
+
+```bash
+taskp setup --global
+```
+
+### 2. Create a skill
 
 ```bash
 taskp init deploy
@@ -49,7 +74,7 @@ taskp init deploy
 
 This generates `.taskp/skills/deploy/SKILL.md`.
 
-### 2. Edit the skill
+### 3. Edit the skill
 
 ```markdown
 ---
@@ -81,7 +106,7 @@ npm run deploy:{{environment}}
 \`\`\`
 ```
 
-### 3. Run the skill
+### 4. Run the skill
 
 ```bash
 taskp run deploy
@@ -90,7 +115,7 @@ taskp run deploy
 # → Commands are executed in order
 ```
 
-### 4. Run in AI agent mode
+### 5. Run in AI agent mode
 
 Change to `mode: agent` and the LLM will interpret and execute the skill's content.
 
@@ -98,7 +123,7 @@ Change to `mode: agent` and the LLM will interpret and execute the skill's conte
 taskp run code-review --model anthropic/claude-sonnet-4-20250514
 ```
 
-### 5. Create a multi-action skill
+### 6. Create a multi-action skill
 
 Group related operations into a single skill with `actions`:
 
@@ -176,6 +201,21 @@ taskp run task:add               # Run a specific action
 | `--verbose` | `-v` | Show detailed logs |
 | `--no-input` | | Disable interactive prompts (use defaults) |
 | `--set` | `-s` | Set variables directly (`--set key=value`) |
+
+### `taskp setup`
+
+Initialize project configuration.
+
+```bash
+taskp setup
+taskp setup --global
+taskp setup --force
+```
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--global` | `-g` | Initialize global configuration (`~/.taskp/`) |
+| `--force` | `-f` | Overwrite existing files |
 
 ### `taskp list`
 


### PR DESCRIPTION
#### 概要

`taskp setup` コマンドのドキュメントを README.md / README.ja.md に追記。

#### 変更内容

- Quick Start セクションに「プロジェクトを初期化する」ステップを追加（step 1）
- コマンド一覧セクションに `taskp setup` の説明・オプション表を追加
- README.ja.md にも同等の内容を反映

Closes #269