### PR TITLE
refactor: ContextSource の switch パターン重複を統合

### DIFF
--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -248,28 +248,17 @@ async function buildDescriptionOverrides(
 	};
 }
 
+const VALUE_FIELD: Record<ContextSource["type"], string> = {
+	file: "path",
+	glob: "pattern",
+	command: "run",
+	url: "url",
+} as const;
+
 function getContextSourceValue(source: ContextSource): string {
-	switch (source.type) {
-		case "file":
-			return source.path;
-		case "glob":
-			return source.pattern;
-		case "command":
-			return source.run;
-		case "url":
-			return source.url;
-	}
+	return source[VALUE_FIELD[source.type] as keyof typeof source] as string;
 }
 
 function withResolvedValue(source: ContextSource, value: string): ContextSource {
-	switch (source.type) {
-		case "file":
-			return { ...source, path: value };
-		case "glob":
-			return { ...source, pattern: value };
-		case "command":
-			return { ...source, run: value };
-		case "url":
-			return { ...source, url: value };
-	}
+	return { ...source, [VALUE_FIELD[source.type]]: value } as ContextSource;
 }


### PR DESCRIPTION
#### 概要

getContextSourceValue と withResolvedValue の重複した switch パターンを VALUE_FIELD マップに統合し、DRY 原則に準拠させた。

#### 変更内容

- `VALUE_FIELD` マップを追加し、ContextSource type → フィールド名のマッピングを一元化
- `getContextSourceValue` と `withResolvedValue` をマップベースの実装にリファクタリング
- 新しい ContextSource タイプ追加時の変更箇所を 2 箇所から 1 箇所に削減

Closes #278