### PR TITLE
refactor: parseSkillRef 関数の重複定義を統一

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import type { Action } from "./core/skill/action";
 import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
 import type { Skill, SkillScope } from "./core/skill/skill";
+import { parseSkillRef } from "./core/skill/skill-ref";
 import { type DomainError, domainErrorMessage, ErrorType, EXIT_CODE } from "./core/types/errors";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
@@ -29,29 +30,6 @@ import type { SetupOutput } from "./usecase/setup-project";
 import { setupProject } from "./usecase/setup-project";
 import type { ShowOutput } from "./usecase/show-skill";
 import { showSkill } from "./usecase/show-skill";
-
-type SkillRef = {
-	readonly name: string;
-	readonly action: string | undefined;
-};
-
-export function parseSkillRef(ref: string): SkillRef {
-	const parts = ref.split(":");
-	if (parts.length === 1) {
-		return { name: parts[0], action: undefined };
-	}
-	if (parts.length === 2) {
-		return { name: parts[0], action: parts[1] };
-	}
-	throw new InvalidSkillRefError(ref);
-}
-
-class InvalidSkillRefError extends Error {
-	constructor(ref: string) {
-		super(`Invalid skill reference "${ref}": expected "skill" or "skill:action"`);
-		this.name = "InvalidSkillRefError";
-	}
-}
 
 // --set key=value 形式の引数を Record に変換する。
 // "=" を含む値をサポートするため、最初の "=" のみで分割する
@@ -178,15 +156,12 @@ const cli = Cli.create("taskp", {
 			set: "s",
 		},
 		async run(c) {
-			let ref: SkillRef;
-			try {
-				ref = parseSkillRef(c.args.skill);
-			} catch {
-				console.error(
-					`Error: Invalid skill reference "${c.args.skill}": expected "skill" or "skill:action"`,
-				);
-				process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
+			const refResult = parseSkillRef(c.args.skill);
+			if (!refResult.ok) {
+				console.error(`Error: ${refResult.error.message}`);
+				process.exit(EXIT_CODE[ErrorType.Parse]);
 			}
+			const ref = refResult.value;
 
 			const presets = parsePresets(c.options.set ?? []);
 			const skillRepository = createDefaultSkillLoader(process.cwd());
@@ -322,15 +297,12 @@ const cli = Cli.create("taskp", {
 			skill: z.string().describe("Skill name or skill:action to show"),
 		}),
 		async run(c) {
-			let ref: SkillRef;
-			try {
-				ref = parseSkillRef(c.args.skill);
-			} catch {
-				console.error(
-					`Error: Invalid skill reference "${c.args.skill}": expected "skill" or "skill:action"`,
-				);
-				process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
+			const refResult = parseSkillRef(c.args.skill);
+			if (!refResult.ok) {
+				console.error(`Error: ${refResult.error.message}`);
+				process.exit(EXIT_CODE[ErrorType.Parse]);
 			}
+			const ref = refResult.value;
 
 			const repository = createDefaultSkillLoader(process.cwd());
 			const result = await showSkill(ref.name, repository, ref.action);

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -13,6 +13,7 @@ import { type RunOutput, runSkill } from "../../usecase/run-skill";
 import type { Action } from "../skill/action";
 import { resolveActionConfig } from "../skill/action";
 import type { Skill } from "../skill/skill";
+import { parseSkillRef } from "../skill/skill-ref";
 import { domainErrorMessage, type ExecutionError, executionError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
 
@@ -165,17 +166,6 @@ type TaskpRunDeps = {
 	readonly hooksConfig?: HooksConfig;
 };
 
-function parseSkillRef(ref: string): {
-	readonly name: string;
-	readonly action: string | undefined;
-} {
-	const colonIndex = ref.indexOf(":");
-	if (colonIndex === -1) {
-		return { name: ref, action: undefined };
-	}
-	return { name: ref.slice(0, colonIndex), action: ref.slice(colonIndex + 1) };
-}
-
 function buildTaskpRunOutput(runOutput: RunOutput): string {
 	const parts: string[] = [runOutput.rendered];
 	for (const cmd of runOutput.commands) {
@@ -192,7 +182,11 @@ function createTaskpRunTool(deps: TaskpRunDeps, description: string): AnyTool {
 		description,
 		inputSchema: zodToJsonSchema(taskpRunParams),
 		execute: async ({ skill, set }) => {
-			const ref = parseSkillRef(skill);
+			const refResult = parseSkillRef(skill);
+			if (!refResult.ok) {
+				return { status: "failed" as const, output: "", error: refResult.error.message };
+			}
+			const ref = refResult.value;
 			const skillId = ref.action ? `${ref.name}:${ref.action}` : ref.name;
 
 			if (callStack.includes(skillId)) {

--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -13,3 +13,5 @@ export type { InputType, SkillInput } from "./skill-input";
 export { parseSkillInput } from "./skill-input";
 export type { SkillMetadata, SkillMode } from "./skill-metadata";
 export { parseSkillMetadata } from "./skill-metadata";
+export type { SkillRef } from "./skill-ref";
+export { parseSkillRef } from "./skill-ref";

--- a/src/core/skill/skill-ref.ts
+++ b/src/core/skill/skill-ref.ts
@@ -1,0 +1,19 @@
+import { type ParseError, parseError } from "../types/errors";
+import { err, ok, type Result } from "../types/result";
+
+export type SkillRef = {
+	readonly name: string;
+	readonly action: string | undefined;
+};
+
+export function parseSkillRef(ref: string): Result<SkillRef, ParseError> {
+	const colonIndex = ref.indexOf(":");
+	if (colonIndex === -1) {
+		return ok({ name: ref, action: undefined });
+	}
+	const rest = ref.slice(colonIndex + 1);
+	if (rest.includes(":")) {
+		return err(parseError(`Invalid skill reference "${ref}": expected "skill" or "skill:action"`));
+	}
+	return ok({ name: ref.slice(0, colonIndex), action: rest });
+}

--- a/tests/e2e/run-command.test.ts
+++ b/tests/e2e/run-command.test.ts
@@ -159,7 +159,7 @@ describe("taskp run (E2E)", () => {
 			reject: false,
 		});
 
-		expect(result.exitCode).toBe(2);
+		expect(result.exitCode).toBe(3);
 		expect(result.stderr).toContain("Invalid skill reference");
 	});
 

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execaCommand } from "execa";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { parseSkillRef } from "../../src/cli";
+import { parseSkillRef } from "../../src/core/skill/skill-ref";
 
 const CLI_PATH = join(import.meta.dirname, "../../src/cli.ts");
 
@@ -13,15 +13,21 @@ function run(args: string, cwd: string) {
 
 describe("parseSkillRef", () => {
 	it("parses skill name without action", () => {
-		expect(parseSkillRef("task")).toEqual({ name: "task", action: undefined });
+		const result = parseSkillRef("task");
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.value).toEqual({ name: "task", action: undefined });
 	});
 
 	it("parses skill:action format", () => {
-		expect(parseSkillRef("task:add")).toEqual({ name: "task", action: "add" });
+		const result = parseSkillRef("task:add");
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.value).toEqual({ name: "task", action: "add" });
 	});
 
-	it("throws on skill:action:extra format", () => {
-		expect(() => parseSkillRef("task:add:extra")).toThrow("Invalid skill reference");
+	it("returns error on skill:action:extra format", () => {
+		const result = parseSkillRef("task:add:extra");
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.error.message).toContain("Invalid skill reference");
 	});
 });
 


### PR DESCRIPTION
#### 概要

parseSkillRef 関数が cli.ts と agent-tools.ts で重複定義されていたものを、共通モジュールに統一しました。

#### 変更内容

- `src/core/skill/skill-ref.ts` に共通の `parseSkillRef` を新規作成（`Result<SkillRef, ParseError>` を返す）
- `src/cli.ts` の重複定義を削除し、共通モジュールからインポート
- `src/core/execution/agent-tools.ts` の重複定義を削除し、共通モジュールからインポート
- `src/core/skill/index.ts` にバレルエクスポートを追加
- テストを更新（Result 型対応、終了コードを Parse エラーに修正）

Closes #280