### PR TITLE
fix: remove unsafe ToolSet type cast in agent-executor.ts

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -25,7 +25,7 @@ async function executeAgentLoop(
 	if (!toolsResult.ok) {
 		return toolsResult;
 	}
-	const tools = toolsResult.value as ToolSet;
+	const tools = toolsResult.value;
 
 	try {
 		const result = streamText({


### PR DESCRIPTION
#### 概要

`buildTools` の戻り値 `Record<string, AnyTool>` を `ToolSet` にキャストしていた不安全な型キャストを除去。

#### 変更内容

- `agent-executor.ts` の `as ToolSet` キャストを削除
- `Record<string, AnyTool>` は `ToolSet` と構造的に互換性があり、`agent-loop.ts` と同様にキャスト不要

Closes #279