### PR TITLE
refactor: replace formatToolArgs switch-case with metadata-driven PRIMARY_ARG_KEYS

### DIFF
--- a/src/adapter/stream-writer.ts
+++ b/src/adapter/stream-writer.ts
@@ -1,3 +1,5 @@
+import { getPrimaryArgKey } from "../core/execution/agent-tools";
+
 export type StreamWriterOptions = {
 	readonly verbose: boolean;
 	readonly output: NodeJS.WritableStream;
@@ -22,7 +24,6 @@ export function createStreamWriter(options: StreamWriterOptions): StreamWriter {
 		},
 
 		writeToolResult(toolName: string, result: unknown): void {
-			// ツール結果は冗長になりがちなので、--verbose 時のみ表示
 			if (!options.verbose) return;
 			const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
 			options.output.write(`[result: ${toolName}]\n${text}\n`);
@@ -35,20 +36,8 @@ export function createStreamWriter(options: StreamWriterOptions): StreamWriter {
 	};
 }
 
-// ツールごとに最も重要な引数だけを表示して、ログの可読性を保つ
 function formatToolArgs(toolName: string, args: Record<string, unknown>): string {
-	switch (toolName) {
-		case "bash":
-			return String(args.command);
-		case "read":
-			return String(args.path);
-		case "write":
-			return String(args.path);
-		case "glob":
-			return String(args.pattern);
-		case "ask_user":
-			return String(args.question);
-		default:
-			return JSON.stringify(args);
-	}
+	const key = getPrimaryArgKey(toolName);
+	if (key) return String(args[key]);
+	return JSON.stringify(args);
 }

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -352,5 +352,23 @@ function appendSkillWithActions(lines: string[], skill: Skill): void {
 	lines.push(...actionLines);
 }
 
+/**
+ * ツールごとの「最も重要な引数キー」。
+ * 表示層がツール名で switch-case する代わりに、このマップを参照する。
+ */
+const PRIMARY_ARG_KEYS: Readonly<Record<ToolName, string | undefined>> = {
+	bash: "command",
+	read: "path",
+	write: "path",
+	glob: "pattern",
+	ask_user: "question",
+	taskp_run: "skill",
+};
+
+/** ツール名に対応する primaryArgKey を返す。未知のツール名は undefined。 */
+export function getPrimaryArgKey(toolName: string): string | undefined {
+	return PRIMARY_ARG_KEYS[toolName as ToolName];
+}
+
 export type { AnyTool, TaskpRunDeps, TaskpRunResult, ToolName };
 export { TOOL_NAMES };

--- a/src/tui/components/tool-args-formatter.ts
+++ b/src/tui/components/tool-args-formatter.ts
@@ -1,18 +1,11 @@
+import { getPrimaryArgKey } from "../../core/execution/agent-tools";
+
 const TRUNCATE_LENGTH = 60;
 
 export function formatToolArgs(toolName: string, args: Record<string, unknown>): string {
-	switch (toolName) {
-		case "bash":
-			return truncate(String(args.command), TRUNCATE_LENGTH);
-		case "read":
-			return String(args.path);
-		case "write":
-			return String(args.path);
-		case "glob":
-			return String(args.pattern);
-		default:
-			return truncate(JSON.stringify(args), TRUNCATE_LENGTH);
-	}
+	const key = getPrimaryArgKey(toolName);
+	if (key) return truncate(String(args[key]), TRUNCATE_LENGTH);
+	return truncate(JSON.stringify(args), TRUNCATE_LENGTH);
 }
 
 function truncate(text: string, maxLength: number): string {

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildTaskpRunDescription,
 	buildTools,
+	getPrimaryArgKey,
 	TOOL_NAMES,
 } from "../../../src/core/execution/agent-tools";
 import type { Skill } from "../../../src/core/skill/skill";
@@ -292,5 +293,21 @@ describe("buildTaskpRunDescription", () => {
 		const result = buildTaskpRunDescription(skills);
 
 		expect(result).not.toContain("agent-only");
+	});
+});
+
+describe("getPrimaryArgKey", () => {
+	it("returns the primary arg key for known tools", () => {
+		expect(getPrimaryArgKey("bash")).toBe("command");
+		expect(getPrimaryArgKey("read")).toBe("path");
+		expect(getPrimaryArgKey("write")).toBe("path");
+		expect(getPrimaryArgKey("glob")).toBe("pattern");
+		expect(getPrimaryArgKey("ask_user")).toBe("question");
+		expect(getPrimaryArgKey("taskp_run")).toBe("skill");
+	});
+
+	it("returns undefined for unknown tools", () => {
+		expect(getPrimaryArgKey("custom")).toBeUndefined();
+		expect(getPrimaryArgKey("")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
#### 概要

formatToolArgs の switch-case を PRIMARY_ARG_KEYS マップに置き換え、OCP 違反を解消。

#### 変更内容

- `agent-tools.ts` に `PRIMARY_ARG_KEYS` マップと `getPrimaryArgKey()` 関数を追加
- `stream-writer.ts` と `tool-args-formatter.ts` の `formatToolArgs` をメタデータ参照方式にリファクタ
- `getPrimaryArgKey` のユニットテストを追加

Closes #293