### PR TITLE
refactor: buildValidator と buildNumberValidator を共通の buildValidatorFn に統合

### DIFF
--- a/src/adapter/prompt-runner.ts
+++ b/src/adapter/prompt-runner.ts
@@ -176,39 +176,35 @@ async function askPassword(skillInput: SkillInput): Promise<Result<string, Execu
 	}
 }
 
-function buildValidator(
-	skillInput: SkillInput,
-): Result<((value: string) => string | true) | undefined, ExecutionError> {
-	if (!skillInput.validate) return ok(undefined);
+function buildValidatorFn<T>(
+	pattern: string | undefined,
+	format: (value: T) => string | undefined,
+): Result<((value: T) => string | true) | undefined, ExecutionError> {
+	if (!pattern) return ok(undefined);
 
-	const regexResult = compileRegex(skillInput.validate);
+	const regexResult = compileRegex(pattern);
 	if (!regexResult.ok) return regexResult;
 
 	const regex = regexResult.value;
-	return ok((value: string) => {
-		if (!regex.test(value)) {
-			return `Input must match pattern: ${skillInput.validate}`;
-		}
-		return true;
+	return ok((value: T) => {
+		const formatted = format(value);
+		if (formatted === undefined) return true;
+		return regex.test(formatted) ? true : `Input must match pattern: ${pattern}`;
 	});
+}
+
+function buildValidator(
+	skillInput: SkillInput,
+): Result<((value: string) => string | true) | undefined, ExecutionError> {
+	return buildValidatorFn(skillInput.validate, (value: string) => value);
 }
 
 function buildNumberValidator(
 	skillInput: SkillInput,
 ): Result<((value: number | undefined) => string | true) | undefined, ExecutionError> {
-	if (!skillInput.validate) return ok(undefined);
-
-	const regexResult = compileRegex(skillInput.validate);
-	if (!regexResult.ok) return regexResult;
-
-	const regex = regexResult.value;
-	return ok((value: number | undefined) => {
-		if (value === undefined) return true;
-		if (!regex.test(String(value))) {
-			return `Input must match pattern: ${skillInput.validate}`;
-		}
-		return true;
-	});
+	return buildValidatorFn(skillInput.validate, (value: number | undefined) =>
+		value === undefined ? undefined : String(value),
+	);
 }
 
 function compileRegex(pattern: string): Result<RegExp, ExecutionError> {


### PR DESCRIPTION
#### 概要

buildValidator と buildNumberValidator の重複ロジックを共通のジェネリック関数 buildValidatorFn<T> に統合し、DRY 違反を解消。

#### 変更内容

- 共通の `buildValidatorFn<T>(pattern, format)` を追加（正規表現コンパイル→バリデータ関数作成）
- `buildValidator` と `buildNumberValidator` を `buildValidatorFn` の薄いラッパーに変更
- 外部インターフェースへの変更なし

Closes #296