### PR TITLE
refactor: runHooksの戻り値をResult型に変更しエラーを握りつぶさない

### DIFF
--- a/src/usecase/hook-runner.ts
+++ b/src/usecase/hook-runner.ts
@@ -1,4 +1,6 @@
 import type { HooksConfig } from "../adapter/config-loader";
+import { type ExecutionError, executionError } from "../core/types/errors";
+import { err, ok, type Result } from "../core/types/result";
 import type { HookContext, HookExecutorPort } from "./port/hook-executor";
 
 export type { HooksConfig };
@@ -9,9 +11,9 @@ type RunHooksParams = {
 	readonly context: HookContext;
 };
 
-export async function runHooks(params: RunHooksParams): Promise<void> {
+export async function runHooks(params: RunHooksParams): Promise<Result<void, ExecutionError>> {
 	if (params.hookExecutor === undefined || params.hooksConfig === undefined) {
-		return;
+		return ok(undefined);
 	}
 
 	const commands =
@@ -20,13 +22,14 @@ export async function runHooks(params: RunHooksParams): Promise<void> {
 			: params.hooksConfig.on_failure;
 
 	if (commands === undefined || commands.length === 0) {
-		return;
+		return ok(undefined);
 	}
 
 	try {
 		await params.hookExecutor.execute(commands, params.context);
+		return ok(undefined);
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
-		console.error(`[taskp] hook error: ${message}`);
+		return err(executionError(`Hook failed: ${message}`));
 	}
 }

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ErrorType } from "../../src/core/types/errors";
 import { runHooks } from "../../src/usecase/hook-runner";
 import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 
@@ -18,19 +19,20 @@ function createMockExecutor(): HookExecutorPort & {
 describe("runHooks", () => {
 	it("calls on_success commands when status is success", async () => {
 		const executor = createMockExecutor();
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
 			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.execute).toHaveBeenCalledOnce();
 		expect(executor.calls[0].commands).toEqual(["echo ok"]);
 	});
 
 	it("calls on_failure commands when status is failed", async () => {
 		const executor = createMockExecutor();
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"], on_failure: ["echo fail"] },
 			context: {
@@ -42,68 +44,75 @@ describe("runHooks", () => {
 			},
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.execute).toHaveBeenCalledOnce();
 		expect(executor.calls[0].commands).toEqual(["echo fail"]);
 	});
 
 	it("does not call executor when commands array is empty", async () => {
 		const executor = createMockExecutor();
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: [], on_failure: [] },
 			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.execute).not.toHaveBeenCalled();
 	});
 
 	it("does not call executor when commands are undefined", async () => {
 		const executor = createMockExecutor();
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: {},
 			context: { skillName: "deploy", mode: "agent", status: "success", durationMs: 100 },
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.execute).not.toHaveBeenCalled();
 	});
 
-	it("does nothing when hookExecutor is undefined", async () => {
-		await runHooks({
+	it("returns ok when hookExecutor is undefined", async () => {
+		const result = await runHooks({
 			hookExecutor: undefined,
 			hooksConfig: { on_success: ["echo ok"] },
 			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
 		});
-		// no throw = pass
+
+		expect(result.ok).toBe(true);
 	});
 
-	it("does nothing when hooksConfig is undefined", async () => {
+	it("returns ok when hooksConfig is undefined", async () => {
 		const executor = createMockExecutor();
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: undefined,
 			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.execute).not.toHaveBeenCalled();
 	});
 
-	it("catches and logs executor exceptions without rethrowing", async () => {
+	it("returns err with ExecutionError when executor throws", async () => {
 		const throwingExecutor: HookExecutorPort = {
 			execute: vi.fn(async () => {
 				throw new Error("network error");
 			}),
 		};
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: throwingExecutor,
 			hooksConfig: { on_success: ["echo ok"] },
 			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
 		});
 
-		expect(errorSpy).toHaveBeenCalledWith("[taskp] hook error: network error");
-		vi.restoreAllMocks();
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Execution);
+			expect(result.error.message).toBe("Hook failed: network error");
+		}
 	});
 
 	it("passes context to executor", async () => {
@@ -116,12 +125,13 @@ describe("runHooks", () => {
 			error: "timeout",
 		};
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_failure: ["notify"] },
 			context,
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.calls[0].context).toEqual(context);
 	});
 
@@ -135,12 +145,13 @@ describe("runHooks", () => {
 			durationMs: 100,
 		};
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"] },
 			context,
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.calls[0].context.actionName).toBe("add");
 	});
 
@@ -154,12 +165,13 @@ describe("runHooks", () => {
 			callerSkill: "diagnose",
 		};
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"] },
 			context,
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.calls[0].context.callerSkill).toBe("diagnose");
 	});
 
@@ -172,12 +184,13 @@ describe("runHooks", () => {
 			durationMs: 100,
 		};
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"] },
 			context,
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.calls[0].context.callerSkill).toBeUndefined();
 	});
 
@@ -190,12 +203,13 @@ describe("runHooks", () => {
 			durationMs: 100,
 		};
 
-		await runHooks({
+		const result = await runHooks({
 			hookExecutor: executor,
 			hooksConfig: { on_success: ["echo ok"] },
 			context,
 		});
 
+		expect(result.ok).toBe(true);
 		expect(executor.calls[0].context.actionName).toBeUndefined();
 	});
 });


### PR DESCRIPTION
#### 概要

`runHooks` 関数がエラーを `console.error` で握りつぶしていた問題を修正し、`Result<void, ExecutionError>` を返すように変更。

#### 変更内容

- `runHooks` の戻り値を `Promise<void>` → `Promise<Result<void, ExecutionError>>` に変更
- `console.error` によるサイレントなエラー握りつぶしを廃止し、`err(executionError(...))` を返却
- テストを Result 型の検証に更新（全12テストパス）

Closes #297