### PR TITLE
refactor: agent-executorのcatch-allエラーハンドリングを改善

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -8,6 +8,7 @@ import type {
 	AgentExecutorPort,
 	AgentExecutorResult,
 } from "../usecase/port/agent-executor";
+import { classifyAgentError, toExecutionError } from "./agent-error-handler";
 import type { StreamWriter } from "./stream-writer";
 
 export function createAgentExecutor(writer: StreamWriter): AgentExecutorPort {
@@ -67,11 +68,11 @@ async function executeAgentLoop(
 
 		return ok(agentResult);
 	} catch (error) {
-		return err(
-			executionError(
-				`Agent execution failed: ${error instanceof Error ? error.message : String(error)}`,
-			),
-		);
+		const classified = classifyAgentError(error, input.model.provider);
+		if (classified.category === "fatal") {
+			throw error;
+		}
+		return err(toExecutionError(classified));
 	}
 }
 


### PR DESCRIPTION
#### 概要

executeAgentLoopのcatchブロックが全エラーをExecutionErrorに変換していた問題を修正し、Error/Defectを適切に区別するようにした。

#### 変更内容

- 既存の`classifyAgentError`を使ってcatchしたエラーを分類
- 既知エラー（rate_limit, api_key_missing, network, ollama_*）はResult型で返却
- 未知エラー（fatal）はre-throwしてDefectとして上位で検出可能に

Closes #295