### PR TITLE
fix: preserve user input on FormController focus retreat

### DIFF
--- a/src/tui/screens/input-form.ts
+++ b/src/tui/screens/input-form.ts
@@ -60,7 +60,6 @@ class FormController {
 	retreatFocus(): void {
 		if (this.focusIndex <= 0) return;
 		this.focusIndex--;
-		delete this.values[this.elements[this.focusIndex].input.name];
 		this.applyFocus();
 	}
 
@@ -75,9 +74,10 @@ class FormController {
 	applyFocus(): void {
 		for (let i = 0; i < this.elements.length; i++) {
 			const el = this.elements[i];
-			if (el.input.name in this.values) continue;
 			if (i === this.focusIndex) {
 				el.label.content = t`${green("?")} ${el.input.message}`;
+			} else if (el.input.name in this.values) {
+				continue;
 			} else {
 				el.label.content = t`${dim("○")} ${el.input.message}`;
 			}


### PR DESCRIPTION
#### 概要

FormController.retreatFocus() でフォーカスを後退させる際にユーザー入力値が削除される問題を修正。

#### 変更内容

- `retreatFocus()` から `delete this.values[...]` を削除し、後退時のデータ消失を防止
- `applyFocus()` の条件順序を変更し、フォーカス中の要素が値を持っていても "?" インジケータを表示するよう修正

Closes #308