### PR TITLE
refactor: extract helper functions from createTaskpRunTool

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -175,76 +175,84 @@ function buildTaskpRunOutput(runOutput: RunOutput): string {
 	return parts.join("\n");
 }
 
+function validateTaskpRunCall(skillId: string, callStack: readonly string[]): Result<void, string> {
+	if (callStack.includes(skillId)) {
+		return err(`Recursive call detected: ${skillId}`);
+	}
+	if (callStack.length >= MAX_NESTING_DEPTH) {
+		return err(`Maximum nesting depth (${MAX_NESTING_DEPTH}) exceeded`);
+	}
+	return ok(undefined);
+}
+
+function resolveSkillMode(skill: Skill, actionName?: string): "template" | "agent" {
+	if (!actionName) return skill.metadata.mode;
+	return skill.metadata.actions?.[actionName]?.mode ?? skill.metadata.mode;
+}
+
+function failedResult(error: string): TaskpRunResult {
+	return { status: "failed", output: "", error };
+}
+
+async function executeTaskpRun(
+	deps: TaskpRunDeps,
+	callStack: readonly string[],
+	skill: string,
+	set?: Readonly<Record<string, string>>,
+): Promise<TaskpRunResult> {
+	const refResult = parseSkillRef(skill);
+	if (!refResult.ok) return failedResult(refResult.error.message);
+
+	const ref = refResult.value;
+	const skillId = ref.action ? `${ref.name}:${ref.action}` : ref.name;
+
+	const validation = validateTaskpRunCall(skillId, callStack);
+	if (!validation.ok) return failedResult(validation.error);
+
+	const findResult = await deps.skillRepository.findByName(ref.name);
+	if (!findResult.ok) return failedResult(`Skill not found: ${ref.name}`);
+
+	const foundSkill = findResult.value;
+	const effectiveMode = resolveSkillMode(foundSkill, ref.action);
+
+	if (effectiveMode === "agent") {
+		return failedResult(
+			`Cannot call agent mode skill: ${skillId}. Only template mode skills are allowed.`,
+		);
+	}
+
+	const result = await runSkill(
+		{
+			name: ref.name,
+			action: ref.action,
+			presets: (set ?? {}) as Readonly<Record<string, string>>,
+			dryRun: false,
+			force: false,
+			noInput: true,
+			callerSkill: deps.callerSkillName,
+		},
+		{
+			skillRepository: deps.skillRepository,
+			commandExecutor: deps.commandExecutor,
+			promptCollector: deps.promptCollector,
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
+		},
+	);
+
+	if (!result.ok) return failedResult(domainErrorMessage(result.error));
+
+	return { status: "success", output: buildTaskpRunOutput(result.value) };
+}
+
 function createTaskpRunTool(deps: TaskpRunDeps, description: string): AnyTool {
 	const callStack = deps.callStack ?? [];
 
 	const tool: Tool<TaskpRunInput, TaskpRunResult> = {
 		description,
 		inputSchema: zodToJsonSchema(taskpRunParams),
-		execute: async ({ skill, set }) => {
-			const refResult = parseSkillRef(skill);
-			if (!refResult.ok) {
-				return { status: "failed" as const, output: "", error: refResult.error.message };
-			}
-			const ref = refResult.value;
-			const skillId = ref.action ? `${ref.name}:${ref.action}` : ref.name;
-
-			if (callStack.includes(skillId)) {
-				return { status: "failed", output: "", error: `Recursive call detected: ${skillId}` };
-			}
-
-			if (callStack.length >= MAX_NESTING_DEPTH) {
-				return {
-					status: "failed",
-					output: "",
-					error: `Maximum nesting depth (${MAX_NESTING_DEPTH}) exceeded`,
-				};
-			}
-
-			const findResult = await deps.skillRepository.findByName(ref.name);
-			if (!findResult.ok) {
-				return { status: "failed", output: "", error: `Skill not found: ${ref.name}` };
-			}
-
-			const foundSkill = findResult.value;
-
-			const effectiveMode = ref.action
-				? (foundSkill.metadata.actions?.[ref.action]?.mode ?? foundSkill.metadata.mode)
-				: foundSkill.metadata.mode;
-
-			if (effectiveMode === "agent") {
-				return {
-					status: "failed",
-					output: "",
-					error: `Cannot call agent mode skill: ${skillId}. Only template mode skills are allowed.`,
-				};
-			}
-
-			const result = await runSkill(
-				{
-					name: ref.name,
-					action: ref.action,
-					presets: (set ?? {}) as Readonly<Record<string, string>>,
-					dryRun: false,
-					force: false,
-					noInput: true,
-					callerSkill: deps.callerSkillName,
-				},
-				{
-					skillRepository: deps.skillRepository,
-					commandExecutor: deps.commandExecutor,
-					promptCollector: deps.promptCollector,
-					hookExecutor: deps.hookExecutor,
-					hooksConfig: deps.hooksConfig,
-				},
-			);
-
-			if (!result.ok) {
-				return { status: "failed", output: "", error: domainErrorMessage(result.error) };
-			}
-
-			return { status: "success", output: buildTaskpRunOutput(result.value) };
-		},
+		execute: async ({ skill, set }) =>
+			executeTaskpRun(deps, callStack, skill, set as Readonly<Record<string, string>>),
 	};
 
 	return tool as AnyTool;
@@ -371,4 +379,4 @@ export function getPrimaryArgKey(toolName: string): string | undefined {
 }
 
 export type { AnyTool, TaskpRunDeps, TaskpRunResult, ToolName };
-export { TOOL_NAMES };
+export { MAX_NESTING_DEPTH, TOOL_NAMES, resolveSkillMode, validateTaskpRunCall };

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -3,10 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	MAX_NESTING_DEPTH,
 	buildTaskpRunDescription,
 	buildTools,
 	getPrimaryArgKey,
+	resolveSkillMode,
 	TOOL_NAMES,
+	validateTaskpRunCall,
 } from "../../../src/core/execution/agent-tools";
 import type { Skill } from "../../../src/core/skill/skill";
 
@@ -309,5 +312,71 @@ describe("getPrimaryArgKey", () => {
 	it("returns undefined for unknown tools", () => {
 		expect(getPrimaryArgKey("custom")).toBeUndefined();
 		expect(getPrimaryArgKey("")).toBeUndefined();
+	});
+});
+
+describe("validateTaskpRunCall", () => {
+	it("再帰呼び出しを検出してエラーを返す", () => {
+		const result = validateTaskpRunCall("deploy", ["deploy"]);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe("Recursive call detected: deploy");
+	});
+
+	it("アクション付きスキルIDの再帰を検出する", () => {
+		const result = validateTaskpRunCall("task:add", ["task:add"]);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toBe("Recursive call detected: task:add");
+	});
+
+	it("最大ネスト深度を超えた場合エラーを返す", () => {
+		const callStack = Array.from({ length: MAX_NESTING_DEPTH }, (_, i) => `skill-${i}`);
+		const result = validateTaskpRunCall("new-skill", callStack);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toContain("Maximum nesting depth");
+	});
+
+	it("有効な呼び出しで ok を返す", () => {
+		const result = validateTaskpRunCall("deploy", ["test"]);
+		expect(result.ok).toBe(true);
+	});
+
+	it("空のコールスタックで ok を返す", () => {
+		const result = validateTaskpRunCall("deploy", []);
+		expect(result.ok).toBe(true);
+	});
+});
+
+describe("resolveSkillMode", () => {
+	it("アクション未指定でスキルのモードを返す", () => {
+		const skill = createSkillFixture({ name: "s", description: "d", mode: "template" });
+		expect(resolveSkillMode(skill)).toBe("template");
+	});
+
+	it("アクション指定でアクションのモードを返す", () => {
+		const skill = createSkillFixture({
+			name: "s",
+			description: "d",
+			mode: "template",
+			actions: { run: { description: "run", mode: "agent" } },
+		});
+		expect(resolveSkillMode(skill, "run")).toBe("agent");
+	});
+
+	it("アクションにモード未定義の場合スキルのモードにフォールバックする", () => {
+		const skill = createSkillFixture({
+			name: "s",
+			description: "d",
+			mode: "agent",
+			actions: { run: { description: "run" } },
+		});
+		expect(resolveSkillMode(skill, "run")).toBe("agent");
+	});
+
+	it("存在しないアクション名でスキルのモードを返す", () => {
+		const skill = createSkillFixture({ name: "s", description: "d", mode: "template" });
+		expect(resolveSkillMode(skill, "nonexistent")).toBe("template");
 	});
 });


### PR DESCRIPTION
#### 概要

createTaskpRunTool 関数を単一責任の小さなヘルパー関数に分割し、凝集度とテスタビリティを向上。

#### 変更内容

- `validateTaskpRunCall`: 再帰検出・ネスト深度チェックを担当する純粋関数を抽出
- `resolveSkillMode`: スキル/アクションのモード解決ロジックを抽出
- `failedResult`: 失敗レスポンス生成の DRY ヘルパーを追加
- `executeTaskpRun`: 実行フローのオーケストレーション関数を抽出
- `createTaskpRunTool` を薄いラッパーに簡素化（~10行）
- 抽出した関数の単体テスト9件を追加

Closes #309