### PR TITLE
refactor: extract hard-coded error messages to dedicated module

### DIFF
--- a/src/adapter/agent-error-handler.ts
+++ b/src/adapter/agent-error-handler.ts
@@ -1,5 +1,6 @@
 import { APICallError } from "@ai-sdk/provider";
 import { type ExecutionError, executionError } from "../core/types/errors";
+import { ErrorMessages } from "./error-messages";
 
 export type AgentErrorCategory =
 	| "rate_limit"
@@ -26,13 +27,13 @@ export function classifyAgentError(error: unknown, provider: string): Classified
 		if (provider === "ollama") {
 			return {
 				category: "ollama_not_running",
-				message: "Ollama is not running. Start it with:\n\n  ollama serve\n",
+				message: ErrorMessages.OLLAMA_NOT_RUNNING,
 				retryable: false,
 			};
 		}
 		return {
 			category: "network",
-			message: "Network error: unable to reach the API server. Check your internet connection.",
+			message: ErrorMessages.NETWORK_ERROR,
 			retryable: true,
 		};
 	}
@@ -58,7 +59,7 @@ function classifyApiCallError(error: APICallError, provider: string): Classified
 	if (status === 429) {
 		return {
 			category: "rate_limit",
-			message: "Rate limited by the API. Retrying with exponential backoff...",
+			message: ErrorMessages.RATE_LIMITED,
 			retryable: true,
 		};
 	}
@@ -67,7 +68,7 @@ function classifyApiCallError(error: APICallError, provider: string): Classified
 		const model = extractOllamaModelFromError(error);
 		return {
 			category: "ollama_model_missing",
-			message: `Model not found. Download it with:\n\n  ollama pull ${model}\n`,
+			message: ErrorMessages.ollamaModelMissing(model),
 			retryable: false,
 		};
 	}
@@ -75,7 +76,7 @@ function classifyApiCallError(error: APICallError, provider: string): Classified
 	if (status !== undefined && status >= 500) {
 		return {
 			category: "network",
-			message: `Server error (${status}). Retrying...`,
+			message: ErrorMessages.serverError(status),
 			retryable: true,
 		};
 	}
@@ -131,9 +132,9 @@ const API_KEY_ENV_VARS: Record<string, string> = {
 function buildApiKeyMessage(provider: string): string {
 	const envVar = API_KEY_ENV_VARS[provider];
 	if (envVar === undefined) {
-		return `API key is invalid or missing for provider "${provider}".`;
+		return ErrorMessages.apiKeyMissingGeneric(provider);
 	}
-	return `API key is invalid or missing. Set the ${envVar} environment variable:\n\n  export ${envVar}=your-api-key\n`;
+	return ErrorMessages.apiKeyMissingWithEnv(envVar);
 }
 
 function extractOllamaModelFromError(error: APICallError): string {

--- a/src/adapter/error-messages.ts
+++ b/src/adapter/error-messages.ts
@@ -1,0 +1,13 @@
+// エラーメッセージを一元管理し、将来の多言語対応を可能にする
+export const ErrorMessages = {
+	OLLAMA_NOT_RUNNING: "Ollama is not running. Start it with:\n\n  ollama serve\n",
+	NETWORK_ERROR: "Network error: unable to reach the API server. Check your internet connection.",
+	RATE_LIMITED: "Rate limited by the API. Retrying with exponential backoff...",
+	ollamaModelMissing: (model: string): string =>
+		`Model not found. Download it with:\n\n  ollama pull ${model}\n`,
+	serverError: (status: number): string => `Server error (${status}). Retrying...`,
+	apiKeyMissingWithEnv: (envVar: string): string =>
+		`API key is invalid or missing. Set the ${envVar} environment variable:\n\n  export ${envVar}=your-api-key\n`,
+	apiKeyMissingGeneric: (provider: string): string =>
+		`API key is invalid or missing for provider "${provider}".`,
+} as const;


### PR DESCRIPTION
#### 概要

agent-error-handler.ts のハードコードされた英語エラーメッセージを専用モジュールに抽出し、将来の多言語対応とメッセージの一元管理を可能にする。

#### 変更内容

- `src/adapter/error-messages.ts` を新規作成し、全エラーメッセージを定数・関数として定義
- `src/adapter/agent-error-handler.ts` からインライン文字列を除去し、`ErrorMessages` を参照するよう変更

Closes #310