### PR TITLE
refactor: ContextSource の switch パターン重複を VALUE_FIELD マッピングに統合

### DIFF
--- a/src/core/skill/context-source.ts
+++ b/src/core/skill/context-source.ts
@@ -29,6 +29,21 @@ export const contextSourceSchema = z.discriminatedUnion("type", [
 
 export type ContextSource = z.infer<typeof contextSourceSchema>;
 
+const VALUE_FIELD: Record<ContextSource["type"], string> = {
+	file: "path",
+	glob: "pattern",
+	command: "run",
+	url: "url",
+};
+
+export function getContextSourceValue(source: ContextSource): string {
+	return (source as Record<string, string>)[VALUE_FIELD[source.type]];
+}
+
+export function withResolvedValue(source: ContextSource, value: string): ContextSource {
+	return { ...source, [VALUE_FIELD[source.type]]: value } as ContextSource;
+}
+
 export function parseContextSource(input: unknown): ContextSource {
 	return contextSourceSchema.parse(input);
 }

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -2,7 +2,11 @@ import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
 import { resolveActionConfig } from "../core/skill";
-import type { ContextSource } from "../core/skill/context-source";
+import {
+	type ContextSource,
+	getContextSourceValue,
+	withResolvedValue,
+} from "../core/skill/context-source";
 import type { Skill } from "../core/skill/skill";
 import type { SkillInput } from "../core/skill/skill-input";
 import { type DomainError, domainErrorMessage, executionError } from "../core/types/errors";
@@ -246,19 +250,4 @@ async function buildDescriptionOverrides(
 	return {
 		taskp_run: buildTaskpRunDescription(skills, currentSkillName),
 	};
-}
-
-const VALUE_FIELD: Record<ContextSource["type"], string> = {
-	file: "path",
-	glob: "pattern",
-	command: "run",
-	url: "url",
-} as const;
-
-function getContextSourceValue(source: ContextSource): string {
-	return source[VALUE_FIELD[source.type] as keyof typeof source] as string;
-}
-
-function withResolvedValue(source: ContextSource, value: string): ContextSource {
-	return { ...source, [VALUE_FIELD[source.type]]: value } as ContextSource;
 }

--- a/tests/unit/skill/context-source.test.ts
+++ b/tests/unit/skill/context-source.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseContextSource } from "../../../src/core/skill/context-source";
+import {
+	getContextSourceValue,
+	parseContextSource,
+	withResolvedValue,
+} from "../../../src/core/skill/context-source";
 
 describe("parseContextSource", () => {
 	it("parses file type", () => {
@@ -60,7 +64,60 @@ describe("parseContextSource", () => {
 	it("throws on missing type", () => {
 		expect(() => parseContextSource({ path: "src/foo" })).toThrow();
 	});
+});
 
+describe("getContextSourceValue", () => {
+	it("returns path for file source", () => {
+		expect(getContextSourceValue({ type: "file", path: "src/index.ts" })).toBe("src/index.ts");
+	});
+
+	it("returns pattern for glob source", () => {
+		expect(getContextSourceValue({ type: "glob", pattern: "src/**/*.ts" })).toBe("src/**/*.ts");
+	});
+
+	it("returns run for command source", () => {
+		expect(getContextSourceValue({ type: "command", run: "git diff" })).toBe("git diff");
+	});
+
+	it("returns url for url source", () => {
+		expect(getContextSourceValue({ type: "url", url: "https://example.com" })).toBe(
+			"https://example.com",
+		);
+	});
+});
+
+describe("withResolvedValue", () => {
+	it("replaces path for file source", () => {
+		const source = { type: "file" as const, path: "{{target}}" };
+		expect(withResolvedValue(source, "resolved.ts")).toEqual({ type: "file", path: "resolved.ts" });
+	});
+
+	it("replaces pattern for glob source", () => {
+		const source = { type: "glob" as const, pattern: "{{pat}}" };
+		expect(withResolvedValue(source, "src/*.ts")).toEqual({ type: "glob", pattern: "src/*.ts" });
+	});
+
+	it("replaces run for command source", () => {
+		const source = { type: "command" as const, run: "{{cmd}}" };
+		expect(withResolvedValue(source, "ls -la")).toEqual({ type: "command", run: "ls -la" });
+	});
+
+	it("replaces url for url source", () => {
+		const source = { type: "url" as const, url: "{{u}}" };
+		expect(withResolvedValue(source, "https://resolved.com")).toEqual({
+			type: "url",
+			url: "https://resolved.com",
+		});
+	});
+
+	it("does not mutate the original source", () => {
+		const source = { type: "file" as const, path: "original.ts" };
+		withResolvedValue(source, "new.ts");
+		expect(source.path).toBe("original.ts");
+	});
+});
+
+describe("parseContextSource", () => {
 	it("preserves template variables as strings", () => {
 		const result = parseContextSource({
 			type: "file",


### PR DESCRIPTION
#### 概要

ContextSource の値アクセスヘルパー（`getContextSourceValue`/`withResolvedValue`）を usecase 層からドメインモジュール（`context-source.ts`）に移動し、`VALUE_FIELD` マッピングと共に一箇所に集約。

#### 変更内容

- `getContextSourceValue` と `withResolvedValue` を `src/core/skill/context-source.ts` にエクスポート関数として追加
- `src/usecase/run-agent-skill.ts` からローカル定義を削除しインポートに変更
- `tests/unit/skill/context-source.test.ts` に `getContextSourceValue`（4件）と `withResolvedValue`（5件）のテストを追加

Closes #276