### PR TITLE
docs: unsafe cast に Why コメントを追加

### DIFF
--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -152,6 +152,7 @@ export function renderTemplate(
 
 	const rendered = expanded.replace(VARIABLE_PATTERN, (_, name: string) => {
 		const value = resolveVariable(name, variables, reserved);
+		// ステップ 3 で全変数の定義を検証済みのため undefined は到達しない
 		return value as string;
 	});
 


### PR DESCRIPTION
#### 概要

template-renderer.ts の unsafe type cast に Why コメントを追加し、coding-rules.md の規約に準拠させた。

#### 変更内容

- `return value as string;` に、ステップ 3 で全変数の定義を検証済みであることを説明する Why コメントを追加

Closes #284