### PR TITLE
refactor: move action validation from CLI to core layer

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,8 +18,9 @@ import { createSystemPromptResolver } from "./adapter/system-prompt-resolver";
 import type { Action } from "./core/skill/action";
 import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
-import type { Skill, SkillScope } from "./core/skill/skill";
+import type { SkillScope } from "./core/skill/skill";
 import { parseSkillRef } from "./core/skill/skill-ref";
+import { validateActionExists, validateActionRequired } from "./core/skill/validate-skill-action";
 import { type DomainError, domainErrorMessage, ErrorType, EXIT_CODE } from "./core/types/errors";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
 import { createListSkillsUseCase } from "./usecase/list-skills";
@@ -106,31 +107,6 @@ function formatError(error: DomainError): string {
 	return `Error: ${domainErrorMessage(error)}`;
 }
 
-function requireActionForActionsSkill(skill: Skill, actionName: string | undefined): void {
-	if (skill.metadata.actions && !actionName) {
-		const names = Object.keys(skill.metadata.actions).join(", ");
-		console.error(
-			`Error: Skill "${skill.metadata.name}" requires an action. Available actions: ${names}\nUse: taskp run ${skill.metadata.name}:<action> or use the TUI (taskp tui)`,
-		);
-		process.exit(EXIT_CODE[ErrorType.Config]);
-	}
-}
-
-function requireValidAction(skill: Skill, actionName: string | undefined): Action | undefined {
-	if (!actionName) return undefined;
-
-	const actions = skill.metadata.actions;
-	if (!actions || !(actionName in actions)) {
-		const available = actions ? Object.keys(actions).join(", ") : "none";
-		console.error(
-			`Error: Action "${actionName}" not found in skill "${skill.metadata.name}". Available actions: ${available}`,
-		);
-		process.exit(EXIT_CODE[ErrorType.SkillNotFound]);
-	}
-
-	return actions[actionName];
-}
-
 const cli = Cli.create("taskp", {
 	version: "0.1.6",
 	description:
@@ -175,8 +151,18 @@ const cli = Cli.create("taskp", {
 
 			const skill = findResult.value;
 
-			requireActionForActionsSkill(skill, ref.action);
-			const action = requireValidAction(skill, ref.action);
+			const actionRequiredResult = validateActionRequired(skill, ref.action);
+			if (!actionRequiredResult.ok) {
+				console.error(formatError(actionRequiredResult.error));
+				process.exit(EXIT_CODE[actionRequiredResult.error.type]);
+			}
+
+			const actionExistsResult = validateActionExists(skill, ref.action);
+			if (!actionExistsResult.ok) {
+				console.error(formatError(actionExistsResult.error));
+				process.exit(EXIT_CODE[actionExistsResult.error.type]);
+			}
+			const action = actionExistsResult.value;
 
 			// アクション指定時は resolveActionConfig で mode を決定
 			const effectiveMode = action

--- a/src/core/skill/validate-skill-action.ts
+++ b/src/core/skill/validate-skill-action.ts
@@ -1,0 +1,40 @@
+import type { ConfigError, DomainError } from "../types/errors";
+import { configError, skillNotFoundError } from "../types/errors";
+import type { Result } from "../types/result";
+import { err, ok } from "../types/result";
+import type { Action } from "./action";
+import type { Skill } from "./skill";
+
+export function validateActionRequired(
+	skill: Skill,
+	actionName: string | undefined,
+): Result<void, ConfigError> {
+	if (skill.metadata.actions && !actionName) {
+		const names = Object.keys(skill.metadata.actions).join(", ");
+		return err(
+			configError(
+				`Skill "${skill.metadata.name}" requires an action. Available actions: ${names}\nUse: taskp run ${skill.metadata.name}:<action> or use the TUI (taskp tui)`,
+			),
+		);
+	}
+	return ok(undefined);
+}
+
+export function validateActionExists(
+	skill: Skill,
+	actionName: string | undefined,
+): Result<Action | undefined, DomainError> {
+	if (!actionName) return ok(undefined);
+
+	const actions = skill.metadata.actions;
+	if (!actions || !(actionName in actions)) {
+		const available = actions ? Object.keys(actions).join(", ") : "none";
+		return err(
+			skillNotFoundError(
+				`Action "${actionName}" not found in skill "${skill.metadata.name}". Available actions: ${available}`,
+			),
+		);
+	}
+
+	return ok(actions[actionName]);
+}

--- a/tests/unit/skill/validate-skill-action.test.ts
+++ b/tests/unit/skill/validate-skill-action.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { Skill } from "../../../src/core/skill/skill";
+import type { SkillBody } from "../../../src/core/skill/skill-body";
+import type { SkillMetadata } from "../../../src/core/skill/skill-metadata";
+import {
+	validateActionExists,
+	validateActionRequired,
+} from "../../../src/core/skill/validate-skill-action";
+import { ErrorType } from "../../../src/core/types/errors";
+
+function createTestSkill(overrides: Partial<SkillMetadata> = {}): Skill {
+	return {
+		metadata: {
+			name: "test-skill",
+			description: "A test skill",
+			mode: "template",
+			inputs: [],
+			tools: ["bash"],
+			context: [],
+			...overrides,
+		} as SkillMetadata,
+		body: {} as SkillBody,
+		location: "/test/SKILL.md",
+		scope: "local",
+	};
+}
+
+describe("validateActionRequired", () => {
+	it("アクション定義があり actionName が未指定の場合エラーを返す", () => {
+		const skill = createTestSkill({
+			actions: {
+				build: { description: "Build the project" },
+				test: { description: "Run tests" },
+			},
+		});
+
+		const result = validateActionRequired(skill, undefined);
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Config);
+			expect(result.error.message).toContain("requires an action");
+			expect(result.error.message).toContain("build, test");
+		}
+	});
+
+	it("アクション定義があり actionName が指定されている場合は ok を返す", () => {
+		const skill = createTestSkill({
+			actions: {
+				build: { description: "Build the project" },
+			},
+		});
+
+		const result = validateActionRequired(skill, "build");
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("アクション定義がない場合は ok を返す", () => {
+		const skill = createTestSkill();
+
+		const result = validateActionRequired(skill, undefined);
+
+		expect(result.ok).toBe(true);
+	});
+});
+
+describe("validateActionExists", () => {
+	it("actionName が未指定の場合は ok(undefined) を返す", () => {
+		const skill = createTestSkill();
+
+		const result = validateActionExists(skill, undefined);
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toBeUndefined();
+		}
+	});
+
+	it("存在するアクションを指定した場合はそのアクションを返す", () => {
+		const action = { description: "Build the project" };
+		const skill = createTestSkill({
+			actions: { build: action },
+		});
+
+		const result = validateActionExists(skill, "build");
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toEqual(action);
+		}
+	});
+
+	it("存在しないアクションを指定した場合エラーを返す", () => {
+		const skill = createTestSkill({
+			actions: {
+				build: { description: "Build the project" },
+			},
+		});
+
+		const result = validateActionExists(skill, "deploy");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.SkillNotFound);
+			if (result.error.type === ErrorType.SkillNotFound) {
+				expect(result.error.name).toContain("deploy");
+				expect(result.error.name).toContain("build");
+			}
+		}
+	});
+
+	it("アクション定義自体がない場合エラーを返す", () => {
+		const skill = createTestSkill();
+
+		const result = validateActionExists(skill, "build");
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.SkillNotFound);
+			if (result.error.type === ErrorType.SkillNotFound) {
+				expect(result.error.name).toContain("build");
+				expect(result.error.name).toContain("none");
+			}
+		}
+	});
+});


### PR DESCRIPTION
#### 概要

CLI層に直接記述されていたアクションバリデーション（`requireActionForActionsSkill`、`requireValidAction`）をcore層に移動し、Result型を返す純粋関数に変換。

#### 変更内容

- `src/core/skill/validate-skill-action.ts` を新規作成（`validateActionRequired`、`validateActionExists`）
- `src/cli.ts` から `requireActionForActionsSkill`、`requireValidAction` を削除し、新しいバリデーション関数を使用
- `tests/unit/skill/validate-skill-action.test.ts` にユニットテスト7件を追加

Closes #288