### PR TITLE
refactor: centralize console logging via Logger port

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -8,6 +8,7 @@ import type {
 	AgentExecutorPort,
 	AgentExecutorResult,
 } from "../usecase/port/agent-executor";
+import type { Logger } from "../usecase/port/logger";
 import { classifyAgentError, toExecutionError } from "./agent-error-handler";
 import type { StreamWriter } from "./stream-writer";
 
@@ -15,15 +16,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function createAgentExecutor(writer: StreamWriter): AgentExecutorPort {
+export function createAgentExecutor(writer: StreamWriter, logger: Logger): AgentExecutorPort {
 	return {
-		execute: async (input) => executeAgentLoop(input, writer),
+		execute: async (input) => executeAgentLoop(input, writer, logger),
 	};
 }
 
 async function executeAgentLoop(
 	input: AgentExecutorInput,
 	writer: StreamWriter,
+	logger: Logger,
 ): ReturnType<AgentExecutorPort["execute"]> {
 	const startTime = Date.now();
 	const toolsResult = buildTools(input.toolNames, input.buildToolsOptions);
@@ -39,7 +41,7 @@ async function executeAgentLoop(
 			prompt: input.prompt,
 			tools,
 			stopWhen: stepCountIs(input.maxSteps),
-			experimental_repairToolCall: repairToolCall,
+			experimental_repairToolCall: createRepairToolCall(logger),
 		});
 
 		for await (const part of result.fullStream) {
@@ -94,23 +96,25 @@ async function executeAgentLoop(
  * 制御文字をエスケープして再パースを試みる。
  * @internal テスト用にエクスポート
  */
-export const repairToolCall: ToolCallRepairFunction<ToolSet> = async (options) => {
-	const raw = options.toolCall.input;
-	// 制御文字（U+0000〜U+001F）を \uXXXX にエスケープ
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional match for JSON control chars
-	const escaped = raw.replace(/[\u0000-\u001f]/g, (ch: string) => {
-		const hex = ch.codePointAt(0)?.toString(16).padStart(4, "0") ?? "0000";
-		return `\\u${hex}`;
-	});
-	if (escaped === raw) return null; // 制御文字が原因ではない → 修復不可
+export function createRepairToolCall(logger: Logger): ToolCallRepairFunction<ToolSet> {
+	return async (options) => {
+		const raw = options.toolCall.input;
+		// 制御文字（U+0000〜U+001F）を \uXXXX にエスケープ
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional match for JSON control chars
+		const escaped = raw.replace(/[\u0000-\u001f]/g, (ch: string) => {
+			const hex = ch.codePointAt(0)?.toString(16).padStart(4, "0") ?? "0000";
+			return `\\u${hex}`;
+		});
+		if (escaped === raw) return null; // 制御文字が原因ではない → 修復不可
 
-	try {
-		const parsed = JSON.parse(escaped) as Record<string, unknown>;
-		return { ...options.toolCall, input: JSON.stringify(parsed) };
-	} catch (error) {
-		console.debug(
-			`[taskp] Tool call repair failed. Original: ${raw}, Escaped: ${escaped}, Error: ${error instanceof Error ? error.message : String(error)}`,
-		);
-		return null;
-	}
-};
+		try {
+			const parsed = JSON.parse(escaped) as Record<string, unknown>;
+			return { ...options.toolCall, input: JSON.stringify(parsed) };
+		} catch (error) {
+			logger.debug(
+				`Tool call repair failed. Original: ${raw}, Escaped: ${escaped}, Error: ${error instanceof Error ? error.message : String(error)}`,
+			);
+			return null;
+		}
+	};
+}

--- a/src/adapter/console-logger.ts
+++ b/src/adapter/console-logger.ts
@@ -1,0 +1,9 @@
+import type { Logger } from "../usecase/port/logger";
+
+export function createConsoleLogger(): Logger {
+	return {
+		debug: (msg) => console.debug(`[taskp] ${msg}`),
+		warn: (msg) => console.warn(`[taskp] ${msg}`),
+		error: (msg) => console.error(`[taskp] ${msg}`),
+	};
+}

--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -1,5 +1,6 @@
 import type { CommandExecutor } from "../usecase/port/command-executor";
 import type { HookContext, HookExecutorPort, HookResult } from "../usecase/port/hook-executor";
+import type { Logger } from "../usecase/port/logger";
 
 const TIMEOUT_MS = 30_000;
 const MAX_ERROR_LENGTH = 1024;
@@ -32,7 +33,10 @@ function buildEnvVars(context: HookContext): Record<string, string> {
 	};
 }
 
-export function createHookExecutor(commandExecutor: CommandExecutor): HookExecutorPort {
+export function createHookExecutor(
+	commandExecutor: CommandExecutor,
+	logger: Logger,
+): HookExecutorPort {
 	return {
 		async execute(
 			commands: readonly string[],
@@ -54,7 +58,7 @@ export function createHookExecutor(commandExecutor: CommandExecutor): HookExecut
 				if (result.ok) {
 					results.push({ command, success: true });
 				} else {
-					console.error(`[taskp] hook warning: "${command}" failed: ${result.error.message}`);
+					logger.error(`hook warning: "${command}" failed: ${result.error.message}`);
 					results.push({ command, success: false, error: result.error.message });
 				}
 			}

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -15,9 +15,9 @@ export {
 	resolveModelSpec,
 } from "./ai-provider";
 export { createCommandRunner } from "./command-runner";
-
 export type { AiConfig, CliConfig, Config, ProviderConfig } from "./config-loader";
 export { createConfigLoader, createDefaultConfigLoader } from "./config-loader";
+export { createConsoleLogger } from "./console-logger";
 export { createContextCollector } from "./context-collector";
 export { createPromptRunner } from "./prompt-runner";
 export type { RetryConfig } from "./retry";

--- a/src/adapter/silent-logger.ts
+++ b/src/adapter/silent-logger.ts
@@ -1,0 +1,9 @@
+import type { Logger } from "../usecase/port/logger";
+
+export function createSilentLogger(): Logger {
+	return {
+		debug: () => {},
+		warn: () => {},
+		error: () => {},
+	};
+}

--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { Skill, SkillScope } from "../core/skill/skill";
+import type { Skill, SkillLogger, SkillScope } from "../core/skill/skill";
 import { parseSkill } from "../core/skill/skill";
 import type { ParseError } from "../core/types/errors";
 import { parseError, type SkillNotFoundError, skillNotFoundError } from "../core/types/errors";
@@ -20,17 +20,19 @@ type SkillLoadAttempt =
 type SkillLoaderDeps = {
 	readonly localRoot: string;
 	readonly globalRoot: string;
+	readonly logger?: SkillLogger;
 };
 
 export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const localSkillsDir = resolve(deps.localRoot, SKILL_DIR_NAME);
 	const globalSkillsDir = resolve(deps.globalRoot, SKILL_DIR_NAME);
 
+	const { logger } = deps;
 	return {
-		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir),
-		listAll: () => listAll(localSkillsDir, globalSkillsDir),
-		listLocal: () => scanDirectory(localSkillsDir, "local"),
-		listGlobal: () => scanDirectory(globalSkillsDir, "global"),
+		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, logger),
+		listAll: () => listAll(localSkillsDir, globalSkillsDir, logger),
+		listLocal: () => scanDirectory(localSkillsDir, "local", logger),
+		listGlobal: () => scanDirectory(globalSkillsDir, "global", logger),
 	};
 }
 
@@ -45,15 +47,16 @@ async function findByName(
 	name: string,
 	localSkillsDir: string,
 	globalSkillsDir: string,
+	logger?: SkillLogger,
 ): Promise<Result<Skill, SkillNotFoundError>> {
 	const localPath = join(localSkillsDir, name, SKILL_FILE_NAME);
-	const localResult = await tryLoadSkill(localPath, "local");
+	const localResult = await tryLoadSkill(localPath, "local", logger);
 	if (localResult.type === "found") {
 		return localResult;
 	}
 
 	const globalPath = join(globalSkillsDir, name, SKILL_FILE_NAME);
-	const globalResult = await tryLoadSkill(globalPath, "global");
+	const globalResult = await tryLoadSkill(globalPath, "global", logger);
 	if (globalResult.type === "found") {
 		return globalResult;
 	}
@@ -61,10 +64,14 @@ async function findByName(
 	return err(skillNotFoundError(name));
 }
 
-async function listAll(localSkillsDir: string, globalSkillsDir: string): Promise<SkillLoadResult> {
+async function listAll(
+	localSkillsDir: string,
+	globalSkillsDir: string,
+	logger?: SkillLogger,
+): Promise<SkillLoadResult> {
 	const [localResult, globalResult] = await Promise.all([
-		scanDirectory(localSkillsDir, "local"),
-		scanDirectory(globalSkillsDir, "global"),
+		scanDirectory(localSkillsDir, "local", logger),
+		scanDirectory(globalSkillsDir, "global", logger),
 	]);
 
 	const localNames = new Set(localResult.skills.map((s) => s.metadata.name));
@@ -76,7 +83,11 @@ async function listAll(localSkillsDir: string, globalSkillsDir: string): Promise
 	};
 }
 
-async function scanDirectory(skillsDir: string, scope: SkillScope): Promise<SkillLoadResult> {
+async function scanDirectory(
+	skillsDir: string,
+	scope: SkillScope,
+	logger?: SkillLogger,
+): Promise<SkillLoadResult> {
 	const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
 
 	const skills: Skill[] = [];
@@ -84,7 +95,7 @@ async function scanDirectory(skillsDir: string, scope: SkillScope): Promise<Skil
 
 	for (const entry of entries.filter((e) => e.isDirectory())) {
 		const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
-		const result = await tryLoadSkill(skillPath, scope);
+		const result = await tryLoadSkill(skillPath, scope, logger);
 		if (result.type === "not_found") {
 			continue;
 		}
@@ -98,7 +109,11 @@ async function scanDirectory(skillsDir: string, scope: SkillScope): Promise<Skil
 	return { skills, failures };
 }
 
-async function tryLoadSkill(path: string, scope: SkillScope): Promise<SkillLoadAttempt> {
+async function tryLoadSkill(
+	path: string,
+	scope: SkillScope,
+	logger?: SkillLogger,
+): Promise<SkillLoadAttempt> {
 	let raw: string;
 	try {
 		raw = await readFile(path, "utf-8");
@@ -109,7 +124,7 @@ async function tryLoadSkill(path: string, scope: SkillScope): Promise<SkillLoadA
 		return { type: "error", ok: false, error: parseError(`Failed to read skill file: ${path}`) };
 	}
 
-	const parseResult = parseSkill(raw, path, scope);
+	const parseResult = parseSkill(raw, path, scope, logger);
 	if (!parseResult.ok) {
 		return { type: "error", ...parseResult };
 	}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { createAgentExecutor } from "./adapter/agent-executor";
 import { createLanguageModel, resolveModelSpec } from "./adapter/ai-provider";
 import { createCommandRunner } from "./adapter/command-runner";
 import { createDefaultConfigLoader } from "./adapter/config-loader";
+import { createConsoleLogger } from "./adapter/console-logger";
 import { createContextCollector } from "./adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "./adapter/context-collector-deps";
 import { createHookExecutor } from "./adapter/hook-executor";
@@ -203,7 +204,8 @@ const cli = Cli.create("taskp", {
 			const progressWriter = createCliProgressWriter(process.stdout);
 
 			const hooksConfig = config?.hooks;
-			const hookExecutor = createHookExecutor(commandExecutor);
+			const logger = createConsoleLogger();
+			const hookExecutor = createHookExecutor(commandExecutor, logger);
 
 			const result = await runSkill(
 				{
@@ -413,12 +415,13 @@ async function runAgentMode(
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
 	const contextCollector = createContextCollector(contextCollectorDeps);
 
-	const agentExecutor = createAgentExecutor(writer);
+	const logger = createConsoleLogger();
+	const agentExecutor = createAgentExecutor(writer, logger);
 
 	const commandExecutor = createCommandRunner({
 		defaultTimeoutMs: configResult.value.cli?.command_timeout_ms,
 	});
-	const hookExecutor = createHookExecutor(commandExecutor);
+	const hookExecutor = createHookExecutor(commandExecutor, logger);
 	const hooksConfig = configResult.value.hooks;
 
 	const result = await runAgentSkill(

--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -6,7 +6,7 @@ export type { ActionSection } from "./action-section-parser";
 export { getActionSection, parseActionSections } from "./action-section-parser";
 export type { ContextSource } from "./context-source";
 export { parseContextSource } from "./context-source";
-export type { Skill, SkillScope } from "./skill";
+export type { Skill, SkillLogger, SkillScope } from "./skill";
 export { parseSkill } from "./skill";
 export type { SkillBody } from "./skill-body";
 export type { InputType, SkillInput } from "./skill-input";

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -9,6 +9,10 @@ import { createSkillBody } from "./skill-body";
 import type { SkillMetadata } from "./skill-metadata";
 import { parseSkillMetadata } from "./skill-metadata";
 
+export type SkillLogger = {
+	readonly warn: (message: string) => void;
+};
+
 export type SkillScope = "local" | "global";
 
 export type Skill = {
@@ -22,6 +26,7 @@ export function parseSkill(
 	raw: string,
 	location: string,
 	scope?: SkillScope,
+	logger?: SkillLogger,
 ): Result<Skill, ParseError> {
 	// gray-matter は不正な frontmatter に対して例外を投げるため、
 	// try-catch で捕捉して Result 型に変換する
@@ -42,7 +47,7 @@ export function parseSkill(
 
 	if (metadata.actions) {
 		if (metadata.inputs.length > 0) {
-			console.warn('[taskp] Skill-level "inputs" is ignored when "actions" is defined');
+			logger?.warn('Skill-level "inputs" is ignored when "actions" is defined');
 		}
 
 		const validationResult = validateActionSections(raw, metadata);

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -3,6 +3,7 @@ import { createCliRenderer } from "@opentui/core";
 import { createLanguageModel, type ModelSpec, resolveModelSpec } from "../adapter/ai-provider";
 import { createCommandRunner } from "../adapter/command-runner";
 import { createDefaultConfigLoader } from "../adapter/config-loader";
+import { createConsoleLogger } from "../adapter/console-logger";
 import { createHookExecutor } from "../adapter/hook-executor";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import { createSystemPromptResolver } from "../adapter/system-prompt-resolver";
@@ -50,7 +51,8 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 			await resolveModelAndConfig(options);
 
 		const commandExecutor = createCommandRunner({ defaultTimeoutMs: commandTimeoutMs });
-		const hookExecutor = createHookExecutor(commandExecutor);
+		const logger = createConsoleLogger();
+		const hookExecutor = createHookExecutor(commandExecutor, logger);
 		const executionDeps: ExecutionDeps = {
 			commandExecutor,
 			hookExecutor,

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { createAgentExecutor } from "../../adapter/agent-executor";
+import { createConsoleLogger } from "../../adapter/console-logger";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
 import { resolveActionConfig } from "../../core/skill/action";
@@ -98,7 +99,8 @@ async function executeAgentMode(
 ): Promise<void> {
 	const writer = createTuiStreamWriter(viewPort);
 	const progressWriter = createTuiProgressWriter(viewPort);
-	const agentExecutor = createAgentExecutor(writer);
+	const logger = createConsoleLogger();
+	const agentExecutor = createAgentExecutor(writer, logger);
 
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
 	const contextCollector = createContextCollector(contextCollectorDeps);

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -2,6 +2,7 @@ export type { AgentExecutorInput, AgentExecutorPort, AgentExecutorResult } from 
 export type { CommandExecutor, ExecOptions, ExecResult } from "./command-executor";
 export type { ContextCollectorPort } from "./context-collector";
 export type { HookContext, HookExecutorPort, HookResult } from "./hook-executor";
+export type { Logger } from "./logger";
 export type { PromptCollector } from "./prompt-collector";
 export type { InitOptions, SkillInitializer } from "./skill-initializer";
 export type { SkillRepository } from "./skill-repository";

--- a/src/usecase/port/logger.ts
+++ b/src/usecase/port/logger.ts
@@ -1,0 +1,5 @@
+export type Logger = {
+	readonly debug: (message: string) => void;
+	readonly warn: (message: string) => void;
+	readonly error: (message: string) => void;
+};

--- a/tests/adapter/agent-executor.test.ts
+++ b/tests/adapter/agent-executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createSilentLogger } from "../../src/adapter/silent-logger";
 import type { StreamWriter } from "../../src/adapter/stream-writer";
 
 function createMockWriter(): StreamWriter & {
@@ -23,7 +24,7 @@ describe("agent-executor adapter", () => {
 	it("createAgentExecutor returns an executor with execute method", async () => {
 		const { createAgentExecutor } = await import("../../src/adapter/agent-executor");
 		const writer = createMockWriter();
-		const executor = createAgentExecutor(writer);
+		const executor = createAgentExecutor(writer, createSilentLogger());
 		expect(typeof executor.execute).toBe("function");
 	});
 

--- a/tests/adapter/hook-executor.test.ts
+++ b/tests/adapter/hook-executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHookExecutor } from "../../src/adapter/hook-executor";
+import { createSilentLogger } from "../../src/adapter/silent-logger";
 import type { ExecutionError } from "../../src/core/types/errors";
 import type { Result } from "../../src/core/types/result";
 import { err, ok } from "../../src/core/types/result";
@@ -9,6 +10,7 @@ import type {
 	ExecResult,
 } from "../../src/usecase/port/command-executor";
 import type { HookContext } from "../../src/usecase/port/hook-executor";
+import type { Logger } from "../../src/usecase/port/logger";
 
 type ExecutedCommand = {
 	readonly command: string;
@@ -55,7 +57,7 @@ describe("HookExecutor", () => {
 			ok({ stdout: "", stderr: "", exitCode: 0 }),
 			ok({ stdout: "", stderr: "", exitCode: 0 }),
 		]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		const results = await hookExecutor.execute(["echo one", "echo two"], successContext);
 
@@ -67,7 +69,7 @@ describe("HookExecutor", () => {
 
 	it("injects environment variables correctly", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], successContext);
 
@@ -86,7 +88,7 @@ describe("HookExecutor", () => {
 
 	it("injects TASKP_ACTION_NAME when actionName is present", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 		const contextWithAction: HookContext = {
 			...successContext,
 			actionName: "add",
@@ -100,7 +102,7 @@ describe("HookExecutor", () => {
 
 	it("injects TASKP_SKILL_REF as skillName:actionName when actionName is present", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 		const contextWithAction: HookContext = {
 			skillName: "task",
 			actionName: "add",
@@ -117,7 +119,7 @@ describe("HookExecutor", () => {
 
 	it("injects TASKP_SKILL_REF as skillName only when no actionName", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], successContext);
 
@@ -127,7 +129,7 @@ describe("HookExecutor", () => {
 
 	it("injects TASKP_ERROR on failure context", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], failedContext);
 
@@ -139,7 +141,7 @@ describe("HookExecutor", () => {
 
 	it("truncates TASKP_ERROR to 1024 characters", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 		const longError = "x".repeat(2000);
 
 		await hookExecutor.execute(["echo test"], {
@@ -153,7 +155,7 @@ describe("HookExecutor", () => {
 
 	it("sets TASKP_ERROR to empty string on success", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], successContext);
 
@@ -167,8 +169,7 @@ describe("HookExecutor", () => {
 			ok({ stdout: "", stderr: "", exitCode: 0 }),
 			err({ type: "EXECUTION_ERROR" as const, message: "timeout" }),
 		]);
-		const hookExecutor = createHookExecutor(executor);
-		vi.spyOn(console, "error").mockImplementation(() => {});
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		const results = await hookExecutor.execute(
 			["bad-cmd", "good-cmd", "timeout-cmd"],
@@ -180,13 +181,11 @@ describe("HookExecutor", () => {
 		expect(results[1]).toEqual({ command: "good-cmd", success: true });
 		expect(results[2]).toEqual({ command: "timeout-cmd", success: false, error: "timeout" });
 		expect(executor.executedCommands).toHaveLength(3);
-
-		vi.restoreAllMocks();
 	});
 
 	it("returns empty array for empty commands", async () => {
 		const executor = createSpyCommandExecutor([]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		const results = await hookExecutor.execute([], successContext);
 
@@ -196,7 +195,7 @@ describe("HookExecutor", () => {
 
 	it("injects TASKP_CALLER_SKILL when callerSkill is present", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 		const contextWithCaller: HookContext = {
 			...successContext,
 			callerSkill: "diagnose",
@@ -210,7 +209,7 @@ describe("HookExecutor", () => {
 
 	it("sets TASKP_CALLER_SKILL to empty string when callerSkill is undefined", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], successContext);
 
@@ -220,24 +219,26 @@ describe("HookExecutor", () => {
 
 	it("sets timeout to 30 seconds", async () => {
 		const executor = createSpyCommandExecutor([ok({ stdout: "", stderr: "", exitCode: 0 })]);
-		const hookExecutor = createHookExecutor(executor);
+		const hookExecutor = createHookExecutor(executor, createSilentLogger());
 
 		await hookExecutor.execute(["echo test"], successContext);
 
 		expect(executor.executedCommands[0].options?.timeout).toBe(30_000);
 	});
 
-	it("outputs warning to stderr on command failure", async () => {
+	it("logs warning via logger on command failure", async () => {
 		const executor = createSpyCommandExecutor([
 			err({ type: "EXECUTION_ERROR" as const, message: "not found" }),
 		]);
-		const hookExecutor = createHookExecutor(executor);
-		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const spyLogger: Logger = {
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		const hookExecutor = createHookExecutor(executor, spyLogger);
 
 		await hookExecutor.execute(["missing-cmd"], successContext);
 
-		expect(errorSpy).toHaveBeenCalledWith('[taskp] hook warning: "missing-cmd" failed: not found');
-
-		vi.restoreAllMocks();
+		expect(spyLogger.error).toHaveBeenCalledWith('hook warning: "missing-cmd" failed: not found');
 	});
 });

--- a/tests/adapter/repair-tool-call.test.ts
+++ b/tests/adapter/repair-tool-call.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it, type MockInstance, vi } from "vitest";
-import { repairToolCall } from "../../src/adapter/agent-executor";
+import type { ToolCallRepairFunction, ToolSet } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createRepairToolCall } from "../../src/adapter/agent-executor";
+import type { Logger } from "../../src/usecase/port/logger";
 
-// repairToolCall は AI SDK の ToolCallRepairFunction 型だが、
-// テストでは必要最小限のプロパティのみ渡す
+function createSpyLogger(): Logger & { readonly calls: { method: string; args: string[] }[] } {
+	const calls: { method: string; args: string[] }[] = [];
+	return {
+		calls,
+		debug: vi.fn((msg: string) => calls.push({ method: "debug", args: [msg] })),
+		warn: vi.fn((msg: string) => calls.push({ method: "warn", args: [msg] })),
+		error: vi.fn((msg: string) => calls.push({ method: "error", args: [msg] })),
+	};
+}
+
 function makeOptions(input: string) {
 	return {
 		system: undefined,
@@ -11,12 +21,13 @@ function makeOptions(input: string) {
 		tools: {},
 		inputSchema: async () => ({}),
 		error: { name: "AI_InvalidToolInputError", message: "invalid input" },
-	} as unknown as Parameters<typeof repairToolCall>[0];
+	} as unknown as Parameters<ToolCallRepairFunction<ToolSet>>[0];
 }
 
 describe("repairToolCall", () => {
 	it("escapes control characters and returns valid JSON", async () => {
-		// タブ文字を含む不正な JSON
+		const logger = createSpyLogger();
+		const repairToolCall = createRepairToolCall(logger);
 		const badInput = '{"command":"echo\\thello"}';
 		const inputWithTab = badInput.replace("\\t", "\t");
 		const result = await repairToolCall(makeOptions(inputWithTab));
@@ -25,22 +36,20 @@ describe("repairToolCall", () => {
 	});
 
 	it("returns null when no control characters present", async () => {
+		const logger = createSpyLogger();
+		const repairToolCall = createRepairToolCall(logger);
 		const validInput = '{"command":"echo hello"}';
 		const result = await repairToolCall(makeOptions(validInput));
 		expect(result).toBeNull();
 	});
 
-	it("returns null and logs debug info when escaped JSON is still invalid", async () => {
-		const debugSpy: MockInstance = vi.spyOn(console, "debug").mockImplementation(() => {});
-		try {
-			// 制御文字はあるが JSON 構造自体が壊れている
-			const broken = '{"command": \x01';
-			const result = await repairToolCall(makeOptions(broken));
-			expect(result).toBeNull();
-			expect(debugSpy).toHaveBeenCalledOnce();
-			expect(debugSpy.mock.calls[0]?.[0]).toMatch(/Tool call repair failed/);
-		} finally {
-			debugSpy.mockRestore();
-		}
+	it("logs debug via logger when escaped JSON is still invalid", async () => {
+		const logger = createSpyLogger();
+		const repairToolCall = createRepairToolCall(logger);
+		const broken = '{"command": \x01';
+		const result = await repairToolCall(makeOptions(broken));
+		expect(result).toBeNull();
+		expect(logger.debug).toHaveBeenCalledOnce();
+		expect(logger.calls[0]?.args[0]).toMatch(/Tool call repair failed/);
 	});
 });


### PR DESCRIPTION
#### 概要

console.* の直接呼び出しを Logger ポートインターフェースに置き換え、依存性逆転原則に準拠させた。

#### 変更内容

- `src/usecase/port/logger.ts` に Logger 型を定義
- `src/adapter/console-logger.ts` に本番用実装を追加
- `src/adapter/silent-logger.ts` にテスト用サイレント実装を追加
- `createAgentExecutor`, `createHookExecutor`, `parseSkill` に Logger を注入
- 全呼び出し元（cli.ts, tui/app.ts, execution-runner.ts）を更新
- テストを Logger 注入方式に更新

Closes #289