### PR TITLE
refactor: extract DEFAULT_TOOLS to shared constants file

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,3 @@
+// agent モードのスキルが最低限のファイル操作を行えるよう、
+// ツール未指定時のデフォルトセットを定義
+export const DEFAULT_TOOLS = ["bash", "read", "write"] as const;

--- a/src/core/skill/action.ts
+++ b/src/core/skill/action.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DEFAULT_TOOLS } from "../constants";
 import type { ContextSource } from "./context-source";
 import { contextSourceSchema } from "./context-source";
 import type { SkillInput } from "./skill-input";
@@ -6,8 +7,6 @@ import { skillInputSchema } from "./skill-input";
 import type { SkillMetadata } from "./skill-metadata";
 
 const skillModeSchema = z.enum(["template", "agent"]);
-
-const DEFAULT_TOOLS = ["bash", "read", "write"] as const;
 
 const actionSchema = z.object({
 	description: z.string().min(1),

--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DEFAULT_TOOLS } from "../constants";
 import type { ParseError } from "../types/errors";
 import { parseError } from "../types/errors";
 import type { Result } from "../types/result";
@@ -10,10 +11,6 @@ import type { SkillInput } from "./skill-input";
 import { skillInputSchema } from "./skill-input";
 
 const skillModeSchema = z.enum(["template", "agent"]);
-
-// agent モードのスキルが最低限のファイル操作を行えるよう、
-// ツール未指定時のデフォルトセットを定義
-const DEFAULT_TOOLS = ["bash", "read", "write"] as const;
 
 const skillMetadataSchema = z
 	.object({


### PR DESCRIPTION
#### 概要

DEFAULT_TOOLS 定数の DRY 違反を解消し、単一のソースファイルに集約。

#### 変更内容

- `src/core/constants.ts` を新規作成し、`DEFAULT_TOOLS` を定義
- `src/core/skill/action.ts` から重複定義を削除、共有定数をインポート
- `src/core/skill/skill-metadata.ts` から重複定義を削除、共有定数をインポート

Closes #290