### PR TITLE
fix: add defensive null check for error message in hook-executor

### DIFF
--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -58,8 +58,9 @@ export function createHookExecutor(
 				if (result.ok) {
 					results.push({ command, success: true });
 				} else {
-					logger.error(`hook warning: "${command}" failed: ${result.error.message}`);
-					results.push({ command, success: false, error: result.error.message });
+					const errorMsg = "message" in result.error ? result.error.message : String(result.error);
+					logger.error(`hook warning: "${command}" failed: ${errorMsg}`);
+					results.push({ command, success: false, error: errorMsg });
 				}
 			}
 


### PR DESCRIPTION
#### 概要

hook-executor のエラーメッセージアクセスに防御的な null チェックを追加。

#### 変更内容

- `result.error.message` への直接アクセスを、`"message" in result.error` による存在チェック付きに変更
- `message` プロパティが存在しない場合は `String(result.error)` にフォールバック

Closes #291