### PR TITLE
refactor: eliminate redundant gray-matter parsing in skill module

### DIFF
--- a/src/core/skill/action-section-parser.ts
+++ b/src/core/skill/action-section-parser.ts
@@ -1,4 +1,3 @@
-import matter from "gray-matter";
 import type { Heading, Root, RootContent } from "mdast";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
@@ -13,8 +12,7 @@ export type ActionSection = {
 	readonly codeBlocks: readonly CodeBlock[];
 };
 
-export function parseActionSections(markdown: string): readonly ActionSection[] {
-	const { content } = matter(markdown);
+export function parseActionSections(content: string): readonly ActionSection[] {
 	const tree = unified().use(remarkParse).parse(content);
 
 	const sections: ActionSection[] = [];

--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -1,4 +1,3 @@
-import matter from "gray-matter";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import type { ActionSection } from "./action-section-parser";
@@ -16,16 +15,12 @@ export interface SkillBody {
 	readonly extractActionCodeBlocks: (name: string, lang?: string) => readonly CodeBlock[];
 }
 
-export function createSkillBody(rawMarkdown: string): SkillBody {
-	// frontmatter を除いた本文のみを保持する
-	// （メタデータは SkillMetadata 側で管理するため分離）
-	const { content } = matter(rawMarkdown);
-
+export function createSkillBody(content: string): SkillBody {
 	// アクションセクションは content から一度だけパースしてキャッシュする
 	let cachedSections: readonly ActionSection[] | null = null;
 	const getSections = (): readonly ActionSection[] => {
 		if (cachedSections === null) {
-			cachedSections = parseActionSections(rawMarkdown);
+			cachedSections = parseActionSections(content);
 		}
 		return cachedSections;
 	};

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -50,7 +50,7 @@ export function parseSkill(
 			logger?.warn('Skill-level "inputs" is ignored when "actions" is defined');
 		}
 
-		const validationResult = validateActionSections(raw, metadata);
+		const validationResult = validateActionSections(parsed.content, metadata);
 		if (!validationResult.ok) {
 			return validationResult;
 		}
@@ -58,17 +58,20 @@ export function parseSkill(
 
 	return ok({
 		metadata,
-		body: createSkillBody(raw),
+		body: createSkillBody(parsed.content),
 		location,
 		scope: scope ?? inferScope(location),
 	});
 }
 
-function validateActionSections(raw: string, metadata: SkillMetadata): Result<void, ParseError> {
+function validateActionSections(
+	content: string,
+	metadata: SkillMetadata,
+): Result<void, ParseError> {
 	const actions = metadata.actions;
 	if (!actions) return ok(undefined);
 
-	const sections = parseActionSections(raw);
+	const sections = parseActionSections(content);
 
 	const actionKeys = new Set(Object.keys(actions));
 	const sectionNames = new Set(sections.map((section) => section.name));

--- a/tests/core/execution/taskp-run-tool.test.ts
+++ b/tests/core/execution/taskp-run-tool.test.ts
@@ -1,3 +1,4 @@
+import matter from "gray-matter";
 import { describe, expect, it } from "vitest";
 import type { TaskpRunDeps, TaskpRunResult } from "../../../src/core/execution/agent-tools";
 import { buildTools, TOOL_NAMES } from "../../../src/core/execution/agent-tools";
@@ -122,7 +123,7 @@ function createSkill(raw: string, nameOverride?: string): Skill {
 			context: [],
 			...(actions ? { actions } : {}),
 		},
-		body: createSkillBody(raw),
+		body: createSkillBody(matter(raw).content),
 		location: `/skills/${name}`,
 		scope: "global",
 	};

--- a/tests/helpers/make-skill.ts
+++ b/tests/helpers/make-skill.ts
@@ -1,3 +1,4 @@
+import matter from "gray-matter";
 import type { Skill, SkillScope } from "../../src/core/skill/skill";
 import { createSkillBody } from "../../src/core/skill/skill-body";
 import type { SkillMetadata } from "../../src/core/skill/skill-metadata";
@@ -29,7 +30,7 @@ export function makeSkill(overrides: SkillOverrides = {}): Skill {
 			context: overrides.context ?? [],
 			model: overrides.model,
 		},
-		body: createSkillBody(rawMarkdown),
+		body: createSkillBody(matter(rawMarkdown).content),
 		location: overrides.location ?? `/skills/${name}/SKILL.md`,
 		scope: overrides.scope ?? "local",
 	};

--- a/tests/unit/skill/skill-body.test.ts
+++ b/tests/unit/skill/skill-body.test.ts
@@ -1,43 +1,38 @@
 import { describe, expect, it } from "vitest";
 import { createSkillBody } from "../../../src/core/skill/skill-body";
 
-const withFrontmatter = (body: string) => `---\nname: test\ndescription: test skill\n---\n${body}`;
-
 const withActionSections = () =>
-	withFrontmatter(
-		[
-			"",
-			"# Overview",
-			"",
-			"General description.",
-			"",
-			"## action:add",
-			"",
-			"Add something.",
-			"",
-			"```bash",
-			"echo add",
-			"```",
-			"",
-			"## action:delete",
-			"",
-			"Delete something.",
-			"",
-			"```bash",
-			"echo delete",
-			"```",
-			"",
-			"```python",
-			"print('delete')",
-			"```",
-			"",
-		].join("\n"),
-	);
+	[
+		"# Overview",
+		"",
+		"General description.",
+		"",
+		"## action:add",
+		"",
+		"Add something.",
+		"",
+		"```bash",
+		"echo add",
+		"```",
+		"",
+		"## action:delete",
+		"",
+		"Delete something.",
+		"",
+		"```bash",
+		"echo delete",
+		"```",
+		"",
+		"```python",
+		"print('delete')",
+		"```",
+		"",
+	].join("\n");
 
 describe("createSkillBody", () => {
-	it("フロントマターを除去した本文を保持する", () => {
-		const raw = withFrontmatter("\n# Title\n\nSome content\n");
-		const body = createSkillBody(raw);
+	it("渡されたコンテンツをそのまま保持する", () => {
+		const content = "# Title\n\nSome content";
+		const body = createSkillBody(content);
 
 		expect(body.content.trim()).toBe("# Title\n\nSome content");
 	});
@@ -45,32 +40,28 @@ describe("createSkillBody", () => {
 
 describe("extractCodeBlocks", () => {
 	it("単一の bash コードブロックを抽出する", () => {
-		const raw = withFrontmatter("\n# Title\n\n```bash\nnpm run build\n```\n");
-		const body = createSkillBody(raw);
+		const body = createSkillBody("# Title\n\n```bash\nnpm run build\n```\n");
 		const blocks = body.extractCodeBlocks();
 
 		expect(blocks).toEqual([{ lang: "bash", code: "npm run build" }]);
 	});
 
 	it("複数の bash コードブロックを順序通りに抽出する", () => {
-		const raw = withFrontmatter(
-			[
-				"",
-				"# Deploy",
-				"",
-				"```bash",
-				"npm run build",
-				"```",
-				"",
-				"Middle text",
-				"",
-				"```bash",
-				"npm run deploy",
-				"```",
-				"",
-			].join("\n"),
-		);
-		const body = createSkillBody(raw);
+		const content = [
+			"# Deploy",
+			"",
+			"```bash",
+			"npm run build",
+			"```",
+			"",
+			"Middle text",
+			"",
+			"```bash",
+			"npm run deploy",
+			"```",
+			"",
+		].join("\n");
+		const body = createSkillBody(content);
 		const blocks = body.extractCodeBlocks();
 
 		expect(blocks).toEqual([
@@ -80,42 +71,45 @@ describe("extractCodeBlocks", () => {
 	});
 
 	it("bash 以外の言語ブロックを除外する", () => {
-		const raw = withFrontmatter(
-			[
-				"",
-				"```typescript",
-				'const x = "hello";',
-				"```",
-				"",
-				"```bash",
-				"echo hello",
-				"```",
-				"",
-				"```python",
-				"print('hi')",
-				"```",
-				"",
-			].join("\n"),
-		);
-		const body = createSkillBody(raw);
+		const content = [
+			"```typescript",
+			'const x = "hello";',
+			"```",
+			"",
+			"```bash",
+			"echo hello",
+			"```",
+			"",
+			"```python",
+			"print('hi')",
+			"```",
+			"",
+		].join("\n");
+		const body = createSkillBody(content);
 		const blocks = body.extractCodeBlocks();
 
 		expect(blocks).toEqual([{ lang: "bash", code: "echo hello" }]);
 	});
 
 	it("コードブロックがない場合は空配列を返す", () => {
-		const raw = withFrontmatter("\n# Title\n\nNo code blocks here.\n");
-		const body = createSkillBody(raw);
+		const body = createSkillBody("# Title\n\nNo code blocks here.\n");
 		const blocks = body.extractCodeBlocks();
 
 		expect(blocks).toEqual([]);
 	});
 
 	it("lang 引数で任意の言語を指定して抽出できる", () => {
-		const raw = withFrontmatter(
-			["", "```bash", "echo hello", "```", "", "```python", "print('hi')", "```", ""].join("\n"),
-		);
-		const body = createSkillBody(raw);
+		const content = [
+			"```bash",
+			"echo hello",
+			"```",
+			"",
+			"```python",
+			"print('hi')",
+			"```",
+			"",
+		].join("\n");
+		const body = createSkillBody(content);
 		const blocks = body.extractCodeBlocks("python");
 
 		expect(blocks).toEqual([{ lang: "python", code: "print('hi')" }]);

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -1,3 +1,4 @@
+import matter from "gray-matter";
 import { describe, expect, it, vi } from "vitest";
 import type { Skill } from "../../src/core/skill/skill";
 import { createSkillBody } from "../../src/core/skill/skill-body";
@@ -57,7 +58,7 @@ function createTestSkill(
 			context: [],
 			...overrides,
 		},
-		body: createSkillBody(rawMarkdown),
+		body: createSkillBody(matter(rawMarkdown).content),
 		location: "/skills/deploy",
 		scope: "global",
 	};
@@ -468,7 +469,7 @@ echo "listing tasks"
 						},
 					},
 				},
-				body: createSkillBody(ACTION_SKILL_MD),
+				body: createSkillBody(matter(ACTION_SKILL_MD).content),
 				location: "/skills/task",
 				scope: "global",
 			};


### PR DESCRIPTION
#### 概要

`matter()` が skill パース時に複数回呼ばれていた冗長な処理を排除し、1回のパース結果を再利用するようリファクタリング。

#### 変更内容

- `createSkillBody` のシグネチャを `rawMarkdown: string` から `content: string`（frontmatter 除去済み）に変更
- `parseActionSections` のシグネチャを同様に content 受け取りに変更し、内部の `matter()` 呼び出しを削除
- `parseSkill` で `parsed.content` を `createSkillBody` と `validateActionSections` に渡すよう変更
- テストファイルを新しいシグネチャに合わせて更新

Closes #314