### PR TITLE
refactor: remove unsafe type cast for ExecOptions.env

### DIFF
--- a/src/adapter/command-runner.ts
+++ b/src/adapter/command-runner.ts
@@ -24,7 +24,7 @@ export function createCommandRunner(deps?: CommandRunnerDeps): CommandExecutor {
 					const result = await execaCommand(command, {
 						shell: true,
 						cwd: options?.cwd,
-						env: options?.env as Record<string, string> | undefined,
+						env: options?.env ? { ...options.env } : undefined,
 						timeout: options?.timeout ?? timeoutMs,
 					});
 


### PR DESCRIPTION
#### 概要

`command-runner.ts` の `as Record<string, string>` キャストをスプレッド演算子に置き換え、型安全性を向上。

#### 変更内容

- `options?.env as Record<string, string> | undefined` を `options?.env ? { ...options.env } : undefined` に変更
- `Readonly<Record<string, string>>` から `Record<string, string>` への変換を型キャストではなくスプレッドコピーで実現

Closes #315