### PR TITLE
fix: add null check for node.lang in extractCodeBlocks

### DIFF
--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -52,7 +52,7 @@ function extractCodeBlocks(markdownContent: string, lang: string): readonly Code
 	const blocks: CodeBlock[] = [];
 
 	for (const node of tree.children) {
-		if (node.type === "code" && node.lang === lang) {
+		if (node.type === "code" && node.lang != null && node.lang === lang) {
 			blocks.push({ lang: node.lang, code: node.value });
 		}
 	}

--- a/tests/unit/skill/skill-body.test.ts
+++ b/tests/unit/skill/skill-body.test.ts
@@ -103,6 +103,16 @@ describe("extractCodeBlocks", () => {
 		expect(blocks).toEqual([{ lang: "bash", code: "echo hello" }]);
 	});
 
+	it("言語指定のないコードブロックを除外する", () => {
+		const raw = withFrontmatter(
+			["", "```", "bare code", "```", "", "```bash", "echo hello", "```", ""].join("\n"),
+		);
+		const body = createSkillBody(raw);
+		const blocks = body.extractCodeBlocks();
+
+		expect(blocks).toEqual([{ lang: "bash", code: "echo hello" }]);
+	});
+
 	it("コードブロックがない場合は空配列を返す", () => {
 		const raw = withFrontmatter("\n# Title\n\nNo code blocks here.\n");
 		const body = createSkillBody(raw);


### PR DESCRIPTION
#### 概要

`extractCodeBlocks` で `node.lang` が null/undefined の場合のガードを追加し、型安全性を向上。

#### 変更内容

- `node.lang != null` チェックを `extractCodeBlocks` の条件に追加
- 言語指定のないコードブロックが除外されることを確認するテストを追加

Closes #317