### PR TITLE
refactor: remove unsafe type cast in createPresetPromptCollector

### DIFF
--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -78,7 +78,7 @@ export function createPresetPromptCollector(
 	variables: Readonly<Record<string, string>>,
 ): PromptCollector {
 	return {
-		collect: async () => ok(variables as Record<string, string>),
+		collect: async () => ok(variables),
 	};
 }
 


### PR DESCRIPTION
#### 概要

`createPresetPromptCollector` の `collect` コールバックにおける不要な `as Record<string, string>` キャストを削除。

#### 変更内容

- `variables as Record<string, string>` キャストを削除し、型安全に `ok(variables)` を直接返すよう変更
- `variables` は既に `Readonly<Record<string, string>>` 型であり、`PromptCollector.collect` の戻り値型と互換

Closes #318