### PR TITLE
refactor: extract ENOENT magic string to FILE_NOT_FOUND_CODE constant

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -11,6 +11,8 @@ import type { SkillLoadResult, SkillRepository } from "../usecase/port/skill-rep
 
 const SKILL_DIR_NAME = ".taskp/skills";
 const SKILL_FILE_NAME = "SKILL.md";
+// Node.js file system error code for "file not found"
+const FILE_NOT_FOUND_CODE = "ENOENT";
 
 type SkillLoadAttempt =
 	| { readonly type: "found"; readonly ok: true; readonly value: Skill }
@@ -132,5 +134,5 @@ async function tryLoadSkill(
 }
 
 function isFileNotFound(e: unknown): boolean {
-	return e instanceof Error && "code" in e && e.code === "ENOENT";
+	return e instanceof Error && "code" in e && e.code === FILE_NOT_FOUND_CODE;
 }


### PR DESCRIPTION
#### 概要

`src/adapter/skill-loader.ts` のマジックストリング `"ENOENT"` を名前付き定数 `FILE_NOT_FOUND_CODE` に抽出。

#### 変更内容

- モジュールレベル定数 `FILE_NOT_FOUND_CODE` を追加
- `isFileNotFound` 関数内のハードコード文字列を定数参照に置換

Closes #319