### PR TITLE
refactor: replace unsafe type assertion with explicit undefined guard in template-renderer

### DIFF
--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -152,8 +152,10 @@ export function renderTemplate(
 
 	const rendered = expanded.replace(VARIABLE_PATTERN, (_, name: string) => {
 		const value = resolveVariable(name, variables, reserved);
-		// ステップ 3 で全変数の定義を検証済みのため undefined は到達しない
-		return value as string;
+		if (value === undefined) {
+			throw new Error(`unreachable: variable '${name}' was validated but is undefined`);
+		}
+		return value;
 	});
 
 	return ok(rendered);


### PR DESCRIPTION
#### 概要

`template-renderer.ts` の `resolveVariable` 戻り値に対する unsafe な `as string` 型アサーションを、明示的な undefined ガードに置き換えた。

#### 変更内容

- `value as string` を削除し、`value === undefined` チェック + `throw new Error` に置換
- 到達不能ケースを Fail Fast で検出する防御的実装に変更

Closes #321