### PR TITLE
refactor: agent-executor を prompt string から messages 形式に移行

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -1,6 +1,7 @@
-import type { ToolCallRepairFunction, ToolSet } from "ai";
+import type { TextPart as AiSdkTextPart, ToolCallRepairFunction, ToolSet, UserContent } from "ai";
 import { stepCountIs, streamText } from "ai";
 import { buildTools } from "../core/execution/agent-tools";
+import type { ContentPart } from "../core/execution/content-part";
 import { executionError } from "../core/types/errors";
 import { err, ok } from "../core/types/result";
 import type {
@@ -38,7 +39,7 @@ async function executeAgentLoop(
 		const result = streamText({
 			model: input.model,
 			system: input.systemPrompt,
-			prompt: input.prompt,
+			messages: [{ role: "user", content: toAiSdkContent(input.contentParts) }],
 			tools,
 			stopWhen: stepCountIs(input.maxSteps),
 			experimental_repairToolCall: createRepairToolCall(logger),
@@ -89,6 +90,21 @@ async function executeAgentLoop(
 		}
 		return err(toExecutionError(classified));
 	}
+}
+
+type AiSdkImagePart = { type: "image"; image: Uint8Array; mimeType: string };
+
+function toAiSdkContentPart(part: ContentPart): AiSdkTextPart | AiSdkImagePart {
+	switch (part.type) {
+		case "text":
+			return { type: "text", text: part.text };
+		case "image":
+			return { type: "image", image: part.data, mimeType: part.mediaType };
+	}
+}
+
+function toAiSdkContent(parts: readonly ContentPart[]): UserContent {
+	return parts.map(toAiSdkContentPart);
 }
 
 /**

--- a/src/core/execution/content-part.ts
+++ b/src/core/execution/content-part.ts
@@ -1,0 +1,7 @@
+export type TextPart = { readonly type: "text"; readonly text: string };
+export type ImagePart = {
+	readonly type: "image";
+	readonly data: Uint8Array;
+	readonly mediaType: string;
+};
+export type ContentPart = TextPart | ImagePart;

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -10,4 +10,5 @@ export type {
 	ToolName,
 } from "./agent-tools.js";
 export { buildTaskpRunDescription, buildTools, TOOL_NAMES } from "./agent-tools.js";
+export type { ContentPart, ImagePart, TextPart } from "./content-part.js";
 export type { ExecutionMode } from "./execution-mode.js";

--- a/src/usecase/port/agent-executor.ts
+++ b/src/usecase/port/agent-executor.ts
@@ -1,12 +1,13 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { BuildToolsOptions } from "../../core/execution/agent-tools";
+import type { ContentPart } from "../../core/execution/content-part";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
 
 export type AgentExecutorInput = {
 	readonly model: LanguageModelV3;
 	readonly systemPrompt: string;
-	readonly prompt: string;
+	readonly contentParts: readonly ContentPart[];
 	readonly toolNames: readonly string[];
 	readonly maxSteps: number;
 	readonly buildToolsOptions?: BuildToolsOptions;

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,6 +1,7 @@
 import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
+import type { ContentPart } from "../core/execution/content-part";
 import { resolveActionConfig } from "../core/skill";
 import {
 	type ContextSource,
@@ -124,7 +125,7 @@ export async function runAgentSkill(
 		promptParts.push(contextResult.value);
 	}
 
-	const prompt = promptParts.join("\n\n");
+	const contentParts: readonly ContentPart[] = [{ type: "text", text: promptParts.join("\n\n") }];
 
 	const startTime = Date.now();
 
@@ -137,7 +138,7 @@ export async function runAgentSkill(
 	const executeResult = await deps.agentExecutor.execute({
 		model: input.model,
 		systemPrompt,
-		prompt,
+		contentParts,
 		toolNames,
 		maxSteps: MAX_STEPS,
 		buildToolsOptions: descriptionOverrides ? { descriptionOverrides } : undefined,

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -94,8 +94,10 @@ describe("runAgentSkill", () => {
 		expect(executorCall.model).toBe(mockModel);
 		// systemPrompt は taskp の基盤プロンプト（ツール使用ルール等）が入る
 		expect(executorCall.systemPrompt).toContain("task execution agent");
-		// prompt に SKILL.md 本文が含まれる
-		expect(executorCall.prompt).toContain("You are a helpful assistant.");
+		// contentParts に SKILL.md 本文が含まれる
+		expect(executorCall.contentParts).toEqual([
+			{ type: "text", text: expect.stringContaining("You are a helpful assistant.") },
+		]);
 		expect(executorCall.toolNames).toEqual(["bash", "read"]);
 		expect(executorCall.maxSteps).toBe(50);
 	});
@@ -114,10 +116,11 @@ describe("runAgentSkill", () => {
 			process.cwd(),
 		);
 
-		// prompt に SKILL.md 本文と context ソース出力の両方が含まれる
+		// contentParts に SKILL.md 本文と context ソース出力の両方が含まれる
 		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
-		expect(executorCall.prompt).toContain("You are a helpful assistant.");
-		expect(executorCall.prompt).toContain("collected context");
+		const textContent = executorCall.contentParts[0].text;
+		expect(textContent).toContain("You are a helpful assistant.");
+		expect(textContent).toContain("collected context");
 	});
 
 	it("skips context collection when no context sources defined", async () => {
@@ -366,8 +369,9 @@ describe("runAgentSkill", () => {
 
 			const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock
 				.calls[0][0];
-			expect(executorCall.prompt).toContain("Analyze the codebase.");
-			expect(executorCall.prompt).not.toContain("Global instructions.");
+			const textContent = executorCall.contentParts[0].text;
+			expect(textContent).toContain("Analyze the codebase.");
+			expect(textContent).not.toContain("Global instructions.");
 		});
 
 		it("uses action-specific tools", async () => {
@@ -512,7 +516,7 @@ describe("runAgentSkill", () => {
 
 			const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock
 				.calls[0][0];
-			expect(executorCall.prompt).toContain("Review the code in src/main.ts.");
+			expect(executorCall.contentParts[0].text).toContain("Review the code in src/main.ts.");
 		});
 	});
 


### PR DESCRIPTION
#### 概要

`agent-executor.ts` の `streamText` 呼び出しを `prompt: string` から `messages` 配列形式に移行するリファクタリング。画像対応の前提となる変更。

#### 変更内容

- `ContentPart` 型（`TextPart` / `ImagePart`）を `src/core/execution/content-part.ts` に新規定義
- `AgentExecutorInput.prompt` → `AgentExecutorInput.contentParts` に変更
- `streamText({ prompt })` → `streamText({ messages: [{ role: "user", content }] })` に変更
- `toAiSdkContent` 変換関数を追加（core 層の `ContentPart` → AI SDK の content part 形式）
- `run-agent-skill.ts` の呼び出し側を `contentParts` 形式に対応
- テストを `contentParts` 形式に更新

Closes #340