### PR TITLE
feat: context-source に image タイプ追加 + collector で画像バイナリ収集

### DIFF
--- a/docs/SKILL-SPEC.md
+++ b/docs/SKILL-SPEC.md
@@ -163,6 +163,8 @@ context:
     run: "git diff --cached"
   - type: url
     url: "https://example.com/api-docs"
+  - type: image
+    path: "{{image_path}}"        # 画像ファイル（変数展開可能）
 ```
 
 ```typescript
@@ -170,8 +172,24 @@ type ContextSource =
   | { type: "file"; path: string }
   | { type: "glob"; pattern: string }
   | { type: "command"; run: string }
-  | { type: "url"; url: string };
+  | { type: "url"; url: string }
+  | { type: "image"; path: string };
 ```
+
+#### image タイプ
+
+画像ファイルを `Uint8Array` + mediaType としてバイナリ読み込みし、マルチモーダルコンテンツとして LLM に送信する。
+
+対応フォーマット:
+
+| 拡張子 | mediaType |
+|--------|-----------|
+| `.png` | `image/png` |
+| `.jpg`, `.jpeg` | `image/jpeg` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+
+未対応の拡張子（`.svg`, `.bmp` 等）はエラーになる。
 
 ## スキル探索ルール
 

--- a/src/adapter/context-collector.ts
+++ b/src/adapter/context-collector.ts
@@ -1,16 +1,20 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { extname, join } from "node:path";
 import type { ContextSource } from "../core/skill/context-source";
 import type { ExecutionError } from "../core/types/errors";
 import { executionError } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { ok } from "../core/types/result";
+import { err, ok } from "../core/types/result";
+import type { CollectedContext } from "../usecase/port/context-collector";
 import { tryCatch } from "./error-handler-utils";
 
-type CollectedContext = {
-	readonly source: ContextSource;
-	readonly content: string;
-};
+const IMAGE_MEDIA_TYPES: ReadonlyMap<string, string> = new Map([
+	[".png", "image/png"],
+	[".jpg", "image/jpeg"],
+	[".jpeg", "image/jpeg"],
+	[".gif", "image/gif"],
+	[".webp", "image/webp"],
+]);
 
 export type ContextCollectorDeps = {
 	readonly executeCommand: (
@@ -29,7 +33,8 @@ export function createContextCollector(deps: ContextCollectorDeps) {
 		collect: (
 			sources: readonly ContextSource[],
 			cwd: string,
-		): Promise<Result<string, ExecutionError>> => collectAll(sources, cwd, deps),
+		): Promise<Result<readonly CollectedContext[], ExecutionError>> =>
+			collectAll(sources, cwd, deps),
 	};
 }
 
@@ -39,7 +44,7 @@ async function collectAll(
 	sources: readonly ContextSource[],
 	cwd: string,
 	deps: ContextCollectorDeps,
-): Promise<Result<string, ExecutionError>> {
+): Promise<Result<readonly CollectedContext[], ExecutionError>> {
 	const results: CollectedContext[] = [];
 
 	for (const source of sources) {
@@ -50,7 +55,7 @@ async function collectAll(
 		results.push(...result.value);
 	}
 
-	return ok(results.map((r) => r.content).join("\n\n"));
+	return ok(results);
 }
 
 async function collectOne(
@@ -67,6 +72,8 @@ async function collectOne(
 			return collectCommand(source.run, cwd, deps);
 		case "url":
 			return collectUrl(source.url, deps);
+		case "image":
+			return collectImage(source.path, cwd);
 	}
 }
 
@@ -78,7 +85,7 @@ async function collectFile(
 	return tryCatch(
 		async () => {
 			const content = await readFile(fullPath, "utf-8");
-			return [{ source: { type: "file" as const, path }, content }];
+			return [{ kind: "text" as const, source: { type: "file" as const, path }, content }];
 		},
 		() => executionError(`Failed to read file: ${fullPath}`),
 	);
@@ -100,13 +107,15 @@ async function collectGlob(
 		paths.map((path, i) => readGlobMatch(pattern, join(cwd, path), i, total)),
 	);
 
+	const collected: CollectedContext[] = [];
 	for (const result of results) {
 		if (!result.ok) {
 			return result;
 		}
+		collected.push(result.value);
 	}
 
-	return ok(results.filter((r) => r.ok).map((r) => r.value));
+	return ok(collected);
 }
 
 async function readGlobMatch(
@@ -118,7 +127,7 @@ async function readGlobMatch(
 	return tryCatch(
 		async () => {
 			const content = await readFile(fullPath, "utf-8");
-			return { source: { type: "glob" as const, pattern }, content };
+			return { kind: "text" as const, source: { type: "glob" as const, pattern }, content };
 		},
 		(e) =>
 			executionError(
@@ -136,7 +145,7 @@ async function collectCommand(
 	if (!result.ok) {
 		return result;
 	}
-	return ok([{ source: { type: "command", run }, content: result.value }]);
+	return ok([{ kind: "text", source: { type: "command", run }, content: result.value }]);
 }
 
 async function collectUrl(
@@ -147,5 +156,40 @@ async function collectUrl(
 	if (!result.ok) {
 		return result;
 	}
-	return ok([{ source: { type: "url", url }, content: result.value }]);
+	return ok([{ kind: "text", source: { type: "url", url }, content: result.value }]);
+}
+
+function resolveImageMediaType(filePath: string): Result<string, ExecutionError> {
+	const ext = extname(filePath).toLowerCase();
+	const mediaType = IMAGE_MEDIA_TYPES.get(ext);
+	if (!mediaType) {
+		return err(executionError(`Unsupported image extension: ${ext || "(none)"}`));
+	}
+	return ok(mediaType);
+}
+
+async function collectImage(
+	path: string,
+	cwd: string,
+): Promise<Result<readonly CollectedContext[], ExecutionError>> {
+	const fullPath = join(cwd, path);
+	const mediaTypeResult = resolveImageMediaType(fullPath);
+	if (!mediaTypeResult.ok) {
+		return mediaTypeResult;
+	}
+
+	return tryCatch(
+		async () => {
+			const data = new Uint8Array(await readFile(fullPath));
+			return [
+				{
+					kind: "image" as const,
+					source: { type: "image" as const, path },
+					data,
+					mediaType: mediaTypeResult.value,
+				},
+			];
+		},
+		() => executionError(`Failed to read image: ${fullPath}`),
+	);
 }

--- a/src/adapter/progress-formatter.ts
+++ b/src/adapter/progress-formatter.ts
@@ -35,6 +35,9 @@ export function formatContextSources(sources: readonly ContextSource[]): string 
 			case "url":
 				lines.push(`🔗 ${source.url}`);
 				break;
+			case "image":
+				lines.push(`🖼️ ${source.path}`);
+				break;
 		}
 	}
 	return `${lines.join("\n")}\n`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -491,6 +491,8 @@ function contextSourceValue(ctx: ContextSource): string {
 			return ctx.run;
 		case "url":
 			return ctx.url;
+		case "image":
+			return ctx.path;
 	}
 }
 

--- a/src/core/skill/context-source.ts
+++ b/src/core/skill/context-source.ts
@@ -20,11 +20,17 @@ const urlSourceSchema = z.object({
 	url: z.string(),
 });
 
+const imageSourceSchema = z.object({
+	type: z.literal("image"),
+	path: z.string(),
+});
+
 export const contextSourceSchema = z.discriminatedUnion("type", [
 	fileSourceSchema,
 	globSourceSchema,
 	commandSourceSchema,
 	urlSourceSchema,
+	imageSourceSchema,
 ]);
 
 export type ContextSource = z.infer<typeof contextSourceSchema>;
@@ -39,6 +45,8 @@ export function getContextSourceValue(source: ContextSource): string {
 			return source.run;
 		case "url":
 			return source.url;
+		case "image":
+			return source.path;
 	}
 }
 
@@ -52,6 +60,8 @@ export function withResolvedValue(source: ContextSource, value: string): Context
 			return { ...source, run: value };
 		case "url":
 			return { ...source, url: value };
+		case "image":
+			return { ...source, path: value };
 	}
 }
 

--- a/src/usecase/port/context-collector.ts
+++ b/src/usecase/port/context-collector.ts
@@ -2,9 +2,18 @@ import type { ContextSource } from "../../core/skill/context-source";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
 
+export type CollectedContext =
+	| { readonly kind: "text"; readonly source: ContextSource; readonly content: string }
+	| {
+			readonly kind: "image";
+			readonly source: ContextSource;
+			readonly data: Uint8Array;
+			readonly mediaType: string;
+	  };
+
 export type ContextCollectorPort = {
 	readonly collect: (
 		sources: readonly ContextSource[],
 		cwd: string,
-	) => Promise<Result<string, ExecutionError>>;
+	) => Promise<Result<readonly CollectedContext[], ExecutionError>>;
 };

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -17,7 +17,7 @@ import type { ReservedVars } from "../core/variable/template-renderer";
 import { renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
-import type { ContextCollectorPort } from "./port/context-collector";
+import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
 import type { HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
@@ -103,9 +103,9 @@ export async function runAgentSkill(
 		date: reserved.date,
 	});
 
-	// prompt: SKILL.md 本文（タスク指示）+ context ソース出力（データ）を結合
-	// system = 「どう振る舞うか」、prompt = 「何をするか」の分離
-	const promptParts: string[] = [skillPrompt];
+	// prompt: SKILL.md 本文（タスク指示）を先頭に、context ソース出力（データ）を続けて配置
+	// system = 「どう振る舞うか」、contentParts = 「何をするか」の分離
+	const contentParts: ContentPart[] = [{ type: "text", text: skillPrompt }];
 
 	const contextSources: readonly ContextSource[] = resolved?.context ?? skill.metadata.context;
 
@@ -122,10 +122,8 @@ export async function runAgentSkill(
 		if (!contextResult.ok) {
 			return contextResult;
 		}
-		promptParts.push(contextResult.value);
+		contentParts.push(...toContentParts(contextResult.value));
 	}
-
-	const contentParts: readonly ContentPart[] = [{ type: "text", text: promptParts.join("\n\n") }];
 
 	const startTime = Date.now();
 
@@ -238,6 +236,19 @@ function resolveContextSources(
 	}
 
 	return ok(resolved);
+}
+
+function toContentPart(ctx: CollectedContext): ContentPart {
+	switch (ctx.kind) {
+		case "text":
+			return { type: "text", text: ctx.content };
+		case "image":
+			return { type: "image", data: ctx.data, mediaType: ctx.mediaType };
+	}
+}
+
+function toContentParts(contexts: readonly CollectedContext[]): readonly ContentPart[] {
+	return contexts.map(toContentPart);
 }
 
 async function buildDescriptionOverrides(

--- a/tests/adapter/context-collector.test.ts
+++ b/tests/adapter/context-collector.test.ts
@@ -33,7 +33,7 @@ describe("ContextCollector", () => {
 	});
 
 	describe("file type", () => {
-		it("reads file content", async () => {
+		it("reads file content with kind text", async () => {
 			await writeFile(join(tempDir, "data.txt"), "file content");
 			const collector = createContextCollector(stubDeps());
 			const sources: ContextSource[] = [{ type: "file", path: "data.txt" }];
@@ -42,7 +42,13 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toBe("file content");
+			expect(result.value).toEqual([
+				{
+					kind: "text",
+					source: { type: "file", path: "data.txt" },
+					content: "file content",
+				},
+			]);
 		});
 
 		it("returns error for missing file", async () => {
@@ -59,7 +65,7 @@ describe("ContextCollector", () => {
 	});
 
 	describe("glob type", () => {
-		it("reads files matching pattern", async () => {
+		it("reads files matching pattern with kind text", async () => {
 			await writeFile(join(tempDir, "a.md"), "aaa");
 			await writeFile(join(tempDir, "b.md"), "bbb");
 			const collector = createContextCollector(
@@ -73,8 +79,17 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toContain("aaa");
-			expect(result.value).toContain("bbb");
+			expect(result.value).toHaveLength(2);
+			expect(result.value[0]).toEqual({
+				kind: "text",
+				source: { type: "glob", pattern: "*.md" },
+				content: "aaa",
+			});
+			expect(result.value[1]).toEqual({
+				kind: "text",
+				source: { type: "glob", pattern: "*.md" },
+				content: "bbb",
+			});
 		});
 
 		it("reads files in subdirectories", async () => {
@@ -91,10 +106,14 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toContain("deep content");
+			expect(result.value).toHaveLength(1);
+			expect(result.value[0].kind).toBe("text");
+			if (result.value[0].kind === "text") {
+				expect(result.value[0].content).toContain("deep content");
+			}
 		});
 
-		it("returns empty string for no matches", async () => {
+		it("returns empty array for no matches", async () => {
 			const collector = createContextCollector(stubDeps());
 			const sources: ContextSource[] = [{ type: "glob", pattern: "*.xyz" }];
 
@@ -102,7 +121,7 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toBe("");
+			expect(result.value).toEqual([]);
 		});
 
 		it("returns error when scanGlob fails", async () => {
@@ -141,7 +160,7 @@ describe("ContextCollector", () => {
 	});
 
 	describe("command type", () => {
-		it("returns command stdout", async () => {
+		it("returns command stdout with kind text", async () => {
 			const collector = createContextCollector(
 				stubDeps({
 					executeCommand: async () => ok("command output"),
@@ -153,7 +172,13 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toBe("command output");
+			expect(result.value).toEqual([
+				{
+					kind: "text",
+					source: { type: "command", run: "echo hello" },
+					content: "command output",
+				},
+			]);
 		});
 
 		it("passes cwd to command executor", async () => {
@@ -190,7 +215,7 @@ describe("ContextCollector", () => {
 	});
 
 	describe("url type", () => {
-		it("returns fetched content", async () => {
+		it("returns fetched content with kind text", async () => {
 			const collector = createContextCollector(
 				stubDeps({
 					fetchUrl: async () => ok("fetched content"),
@@ -202,7 +227,13 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toBe("fetched content");
+			expect(result.value).toEqual([
+				{
+					kind: "text",
+					source: { type: "url", url: "https://example.com" },
+					content: "fetched content",
+				},
+			]);
 		});
 
 		it("returns error on fetch failure", async () => {
@@ -222,8 +253,90 @@ describe("ContextCollector", () => {
 		});
 	});
 
+	describe("image type", () => {
+		it("reads image as Uint8Array with correct mediaType", async () => {
+			const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+			await writeFile(join(tempDir, "test.png"), imageData);
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [{ type: "image", path: "test.png" }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toHaveLength(1);
+			expect(result.value[0].kind).toBe("image");
+			if (result.value[0].kind === "image") {
+				expect(result.value[0].data).toBeInstanceOf(Uint8Array);
+				expect(result.value[0].data).toEqual(imageData);
+				expect(result.value[0].mediaType).toBe("image/png");
+				expect(result.value[0].source).toEqual({ type: "image", path: "test.png" });
+			}
+		});
+
+		it.each([
+			[".png", "image/png"],
+			[".jpg", "image/jpeg"],
+			[".jpeg", "image/jpeg"],
+			[".gif", "image/gif"],
+			[".webp", "image/webp"],
+		])("resolves %s to %s", async (ext, expectedMediaType) => {
+			const imageData = new Uint8Array([0xff, 0xd8]);
+			await writeFile(join(tempDir, `test${ext}`), imageData);
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [{ type: "image", path: `test${ext}` }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value[0].kind).toBe("image");
+			if (result.value[0].kind === "image") {
+				expect(result.value[0].mediaType).toBe(expectedMediaType);
+			}
+		});
+
+		it("returns error for unsupported extension", async () => {
+			await writeFile(join(tempDir, "test.svg"), "<svg></svg>");
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [{ type: "image", path: "test.svg" }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			expect(result.error.message).toContain("Unsupported image extension: .svg");
+		});
+
+		it("returns error for bmp extension", async () => {
+			await writeFile(join(tempDir, "test.bmp"), new Uint8Array([0x42, 0x4d]));
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [{ type: "image", path: "test.bmp" }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			expect(result.error.message).toContain("Unsupported image extension: .bmp");
+		});
+
+		it("returns error for missing image file", async () => {
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [{ type: "image", path: "missing.png" }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("EXECUTION_ERROR");
+			expect(result.error.message).toContain("Failed to read image");
+		});
+	});
+
 	describe("multiple sources", () => {
-		it("joins content from multiple sources", async () => {
+		it("collects all sources in order", async () => {
 			await writeFile(join(tempDir, "file.txt"), "from file");
 			const collector = createContextCollector(
 				stubDeps({
@@ -239,7 +352,36 @@ describe("ContextCollector", () => {
 
 			expect(result.ok).toBe(true);
 			if (!result.ok) return;
-			expect(result.value).toBe("from file\n\nfrom command");
+			expect(result.value).toHaveLength(2);
+			expect(result.value[0]).toEqual({
+				kind: "text",
+				source: { type: "file", path: "file.txt" },
+				content: "from file",
+			});
+			expect(result.value[1]).toEqual({
+				kind: "text",
+				source: { type: "command", run: "echo hi" },
+				content: "from command",
+			});
+		});
+
+		it("mixes text and image sources", async () => {
+			await writeFile(join(tempDir, "file.txt"), "text content");
+			const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+			await writeFile(join(tempDir, "photo.png"), imageData);
+			const collector = createContextCollector(stubDeps());
+			const sources: ContextSource[] = [
+				{ type: "file", path: "file.txt" },
+				{ type: "image", path: "photo.png" },
+			];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toHaveLength(2);
+			expect(result.value[0].kind).toBe("text");
+			expect(result.value[1].kind).toBe("image");
 		});
 
 		it("stops on first error", async () => {

--- a/tests/unit/skill/context-source.test.ts
+++ b/tests/unit/skill/context-source.test.ts
@@ -41,6 +41,22 @@ describe("parseContextSource", () => {
 		});
 	});
 
+	it("parses image type", () => {
+		const result = parseContextSource({
+			type: "image",
+			path: "mockup.png",
+		});
+		expect(result).toEqual({ type: "image", path: "mockup.png" });
+	});
+
+	it("parses image type with template variable", () => {
+		const result = parseContextSource({
+			type: "image",
+			path: "{{image_path}}",
+		});
+		expect(result).toEqual({ type: "image", path: "{{image_path}}" });
+	});
+
 	it("throws on invalid type", () => {
 		expect(() => parseContextSource({ type: "invalid" })).toThrow();
 	});
@@ -59,6 +75,10 @@ describe("parseContextSource", () => {
 
 	it("throws on missing required field for url", () => {
 		expect(() => parseContextSource({ type: "url" })).toThrow();
+	});
+
+	it("throws on missing required field for image", () => {
+		expect(() => parseContextSource({ type: "image" })).toThrow();
 	});
 
 	it("throws on missing type", () => {
@@ -84,6 +104,10 @@ describe("getContextSourceValue", () => {
 			"https://example.com",
 		);
 	});
+
+	it("returns path for image source", () => {
+		expect(getContextSourceValue({ type: "image", path: "screenshot.png" })).toBe("screenshot.png");
+	});
 });
 
 describe("withResolvedValue", () => {
@@ -107,6 +131,14 @@ describe("withResolvedValue", () => {
 		expect(withResolvedValue(source, "https://resolved.com")).toEqual({
 			type: "url",
 			url: "https://resolved.com",
+		});
+	});
+
+	it("replaces path for image source", () => {
+		const source = { type: "image" as const, path: "{{img}}" };
+		expect(withResolvedValue(source, "photo.jpg")).toEqual({
+			type: "image",
+			path: "photo.jpg",
 		});
 	});
 

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -48,7 +48,15 @@ function createMockDeps(skill: Skill) {
 	};
 
 	const contextCollector: ContextCollectorPort = {
-		collect: vi.fn().mockResolvedValue(ok("collected context")),
+		collect: vi.fn().mockResolvedValue(
+			ok([
+				{
+					kind: "text" as const,
+					source: { type: "file" as const, path: "README.md" },
+					content: "collected context",
+				},
+			]),
+		),
 	};
 
 	const agentExecutor: AgentExecutorPort = {
@@ -116,11 +124,89 @@ describe("runAgentSkill", () => {
 			process.cwd(),
 		);
 
-		// contentParts に SKILL.md 本文と context ソース出力の両方が含まれる
+		// contentParts にスキル本文（先頭）と context ソース出力が別々の part として含まれる
 		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
-		const textContent = executorCall.contentParts[0].text;
-		expect(textContent).toContain("You are a helpful assistant.");
-		expect(textContent).toContain("collected context");
+		expect(executorCall.contentParts[0]).toEqual({
+			type: "text",
+			text: expect.stringContaining("You are a helpful assistant."),
+		});
+		expect(executorCall.contentParts[1]).toEqual({
+			type: "text",
+			text: "collected context",
+		});
+	});
+
+	it("converts image CollectedContext to ImagePart in contentParts", async () => {
+		const skill = createAgentSkill({
+			context: [{ type: "image", path: "mockup.png" }],
+		});
+		const deps = createMockDeps(skill);
+		const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+		(deps.contextCollector.collect as ReturnType<typeof vi.fn>).mockResolvedValue(
+			ok([
+				{
+					kind: "image" as const,
+					source: { type: "image" as const, path: "mockup.png" },
+					data: imageData,
+					mediaType: "image/png",
+				},
+			]),
+		);
+
+		await runAgentSkill({ name: "test-agent", presets: {}, model: mockModel }, deps);
+
+		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(executorCall.contentParts).toHaveLength(2);
+		expect(executorCall.contentParts[0].type).toBe("text");
+		expect(executorCall.contentParts[1]).toEqual({
+			type: "image",
+			data: imageData,
+			mediaType: "image/png",
+		});
+	});
+
+	it("preserves source definition order in contentParts", async () => {
+		const skill = createAgentSkill({
+			context: [
+				{ type: "file", path: "README.md" },
+				{ type: "image", path: "mockup.png" },
+			],
+		});
+		const deps = createMockDeps(skill);
+		const imageData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+		(deps.contextCollector.collect as ReturnType<typeof vi.fn>).mockResolvedValue(
+			ok([
+				{
+					kind: "text" as const,
+					source: { type: "file" as const, path: "README.md" },
+					content: "readme content",
+				},
+				{
+					kind: "image" as const,
+					source: { type: "image" as const, path: "mockup.png" },
+					data: imageData,
+					mediaType: "image/png",
+				},
+			]),
+		);
+
+		await runAgentSkill({ name: "test-agent", presets: {}, model: mockModel }, deps);
+
+		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(executorCall.contentParts).toHaveLength(3);
+		expect(executorCall.contentParts[0]).toEqual({
+			type: "text",
+			text: expect.stringContaining("You are a helpful assistant."),
+		});
+		expect(executorCall.contentParts[1]).toEqual({
+			type: "text",
+			text: "readme content",
+		});
+		expect(executorCall.contentParts[2]).toEqual({
+			type: "image",
+			data: imageData,
+			mediaType: "image/png",
+		});
 	});
 
 	it("skips context collection when no context sources defined", async () => {


### PR DESCRIPTION
#### 概要

SKILL.md の `context:` に `type: image` を追加し、画像ファイルを `Uint8Array` + mediaType として収集できるようにした。`ContextCollectorPort` の戻り値を `string` から `CollectedContext[]` に変更し、テキストと画像を統一的に扱えるようにした。

#### 変更内容

- `src/core/skill/context-source.ts`: `imageSourceSchema` 追加、`getContextSourceValue`/`withResolvedValue` に image case 追加
- `src/usecase/port/context-collector.ts`: `CollectedContext` discriminated union 型を定義、`ContextCollectorPort.collect` 戻り値型を `Result<readonly CollectedContext[], ExecutionError>` に変更
- `src/adapter/context-collector.ts`: `collectImage()` 新規追加、既存コレクターに `kind: 'text'` 追加、mediaType 判定ロジック追加
- `src/usecase/run-agent-skill.ts`: `CollectedContext[]` → `ContentPart[]` 変換ロジック追加
- `src/cli.ts`, `src/adapter/progress-formatter.ts`: image case 追加
- `docs/SKILL-SPEC.md`: image タイプのドキュメント追加
- テスト: 3ファイルに image 関連テスト追加・既存テスト更新

Closes #341