### PR TITLE
fix: validateFetchUrl の 172.x プライベートIP判定を RFC 1918 準拠に修正

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -286,7 +286,7 @@ const askUserTool: Tool<AskUserInput, string> = {
 const MAX_FETCH_LENGTH = 50_000;
 const FETCH_TIMEOUT_MS = 30_000;
 
-const PRIVATE_IP_PREFIXES = ["10.", "172.", "192.168."] as const;
+const PRIVATE_IP_PREFIXES = ["10.", "192.168."] as const;
 const BLOCKED_HOSTNAMES = [
 	"localhost",
 	"127.0.0.1",
@@ -294,6 +294,13 @@ const BLOCKED_HOSTNAMES = [
 	"0.0.0.0",
 	"169.254.169.254",
 ] as const;
+
+/** RFC 1918: 172.16.0.0/12 (172.16.0.0 – 172.31.255.255) */
+function isPrivate172Block(hostname: string): boolean {
+	if (!hostname.startsWith("172.")) return false;
+	const secondOctet = Number.parseInt(hostname.split(".")[1], 10);
+	return secondOctet >= 16 && secondOctet <= 31;
+}
 
 function validateFetchUrl(url: string): void {
 	const parsed = new URL(url);
@@ -305,7 +312,8 @@ function validateFetchUrl(url: string): void {
 	const { hostname } = parsed;
 	const isBlocked =
 		(BLOCKED_HOSTNAMES as readonly string[]).includes(hostname) ||
-		PRIVATE_IP_PREFIXES.some((prefix) => hostname.startsWith(prefix));
+		PRIVATE_IP_PREFIXES.some((prefix) => hostname.startsWith(prefix)) ||
+		isPrivate172Block(hostname);
 
 	if (isBlocked) {
 		throw new Error(`Access to internal/private addresses is not allowed: ${hostname}`);

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -415,10 +415,18 @@ describe("validateFetchUrl", () => {
 		);
 	});
 
-	it("172.x.x.x プライベート IP を拒否する", () => {
+	it("172.16.0.0/12 プライベート IP を拒否する", () => {
 		expect(() => validateFetchUrl("http://172.16.0.1")).toThrow(
 			"Access to internal/private addresses is not allowed: 172.16.0.1",
 		);
+		expect(() => validateFetchUrl("http://172.31.255.255")).toThrow(
+			"Access to internal/private addresses is not allowed: 172.31.255.255",
+		);
+	});
+
+	it("172.x.x.x の非プライベート範囲は許可する", () => {
+		expect(() => validateFetchUrl("http://172.15.0.1")).not.toThrow();
+		expect(() => validateFetchUrl("http://172.32.0.1")).not.toThrow();
 	});
 
 	it("不正な URL でエラーを投げる", () => {


### PR DESCRIPTION
#### 概要

`validateFetchUrl` の SSRF 対策で `172.` プレフィックスマッチにより RFC 1918 範囲外の正当なパブリック IP もブロックしていた問題を修正。

#### 変更内容

- `PRIVATE_IP_PREFIXES` から `"172."` を削除
- `isPrivate172Block` ヘルパー関数を追加し、172.16.0.0/12 を正確に判定
- テスト追加: 境界値（172.15.0.1 許可、172.16.0.1 ブロック、172.31.255.255 ブロック、172.32.0.1 許可）

Closes #353