### PR TITLE
fix: fetch ツールで HTTP リダイレクトによる SSRF バイパスを防止

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -337,6 +337,7 @@ const fetchTool: Tool<FetchInput, FetchResult> = {
 
 		const response = await fetch(url, {
 			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			redirect: "error",
 		});
 
 		if (!response.ok) {

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -426,6 +426,38 @@ describe("validateFetchUrl", () => {
 	});
 });
 
+describe("fetch tool redirect prevention", () => {
+	it("redirect: 'error' を設定して SSRF バイパスを防止する", async () => {
+		const result = buildTools(["fetch"]);
+		if (!result.ok) throw new Error("buildTools failed");
+
+		const fetchExecute = result.value.fetch.execute;
+		if (!fetchExecute) throw new Error("fetch.execute is undefined");
+
+		let capturedInit: RequestInit | undefined;
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
+			capturedInit = init;
+			return Promise.resolve(
+				new Response("ok", {
+					status: 200,
+					headers: { "content-type": "text/plain" },
+				}),
+			);
+		}) as typeof globalThis.fetch;
+
+		try {
+			await fetchExecute(
+				{ url: "https://example.com" },
+				{ toolCallId: "test", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			);
+			expect(capturedInit?.redirect).toBe("error");
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});
+
 describe("fetch tool truncation", () => {
 	it("MAX_FETCH_LENGTH のデフォルト値が 50000 である", () => {
 		expect(MAX_FETCH_LENGTH).toBe(50_000);


### PR DESCRIPTION
#### 概要

fetch ツールの `fetch()` 呼び出しに `redirect: "error"` を設定し、HTTP リダイレクトを介した SSRF バイパスを防止する。

#### 変更内容

- `src/core/execution/agent-tools.ts`: `fetch()` に `redirect: "error"` オプションを追加
- `tests/core/execution/agent-tools.test.ts`: `redirect: "error"` が設定されていることを検証するテストを追加

Closes #354