### PR TITLE
fix: grep ツールの resolveSearchFiles で存在しないパスの例外を処理

### DIFF
--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { glob as fsGlob, readFile, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { input } from "@inquirer/prompts";
@@ -208,7 +209,12 @@ async function resolveSearchFiles(
 	cwd: string,
 ): Promise<readonly string[]> {
 	const fullPath = resolve(cwd, searchPath);
-	const fileStat = await stat(fullPath);
+	let fileStat: Stats;
+	try {
+		fileStat = await stat(fullPath);
+	} catch {
+		throw new Error(`Path not found: ${searchPath}`);
+	}
 
 	if (fileStat.isFile()) {
 		return [searchPath];

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -342,6 +342,13 @@ describe("grep tool", () => {
 			await rm(dir, { recursive: true });
 		}
 	});
+
+	it("存在しないパスでエラーを投げる", async () => {
+		const tools = unwrapTools(["grep"]);
+		await expect(
+			tools.grep.execute?.({ pattern: "test", path: "/nonexistent/path" }, toolCallOpts),
+		).rejects.toThrow("Path not found");
+	});
 });
 
 describe("fetch tool", () => {


### PR DESCRIPTION
#### 概要

grep ツールの `resolveSearchFiles` 関数で `stat()` が存在しないパスに対して未処理の例外を投げる問題を修正。

#### 変更内容

- `stat()` を try-catch で囲み、存在しないパスの場合にユーザーフレンドリーなエラーメッセージを返すように修正
- 存在しないパスでのエラーを確認するテストを追加

Closes #355