### PR TITLE
docs: agent-executor.ts の AiSdkImagePart に Why コメントを追加

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -92,6 +92,8 @@ async function executeAgentLoop(
 	}
 }
 
+// AI SDK の ImagePart は image: DataContent | URL, mediaType?: string と広い型。
+// ここでは Uint8Array と必須の mimeType に絞り、不正な入力を型レベルで防ぐ。
 type AiSdkImagePart = { type: "image"; image: Uint8Array; mimeType: string };
 
 function toAiSdkContentPart(part: ContentPart): AiSdkTextPart | AiSdkImagePart {


### PR DESCRIPTION
#### 概要

`AiSdkImagePart` 型をローカル定義している理由を Why コメントとして追加。

#### 変更内容

- AI SDK の `ImagePart` 型は `DataContent | URL` と広い型・`mediaType` はオプショナルであるため、直接利用せず `Uint8Array` と必須の `mimeType` に絞ったローカル型を維持する理由をコメントで明記

Closes #357