### PR TITLE
improve: isTextContentType で追加のテキスト系 content-type を許容

### DIFF
--- a/src/core/execution/tools/fetch-tool.ts
+++ b/src/core/execution/tools/fetch-tool.ts
@@ -55,11 +55,15 @@ type FetchResult = {
 	readonly length: number;
 };
 
-function isTextContentType(contentType: string): boolean {
+/** @internal テスト用に export */
+export function isTextContentType(contentType: string): boolean {
 	return (
 		contentType.includes("text/") ||
 		contentType.includes("application/json") ||
-		contentType.includes("application/xml")
+		contentType.includes("application/xml") ||
+		contentType.includes("+json") ||
+		contentType.includes("+xml") ||
+		contentType.includes("application/javascript")
 	);
 }
 

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -14,6 +14,7 @@ import {
 	validateFetchUrl,
 	validateTaskpRunCall,
 } from "../../../src/core/execution/agent-tools";
+import { isTextContentType } from "../../../src/core/execution/tools/fetch-tool";
 import type { Skill } from "../../../src/core/skill/skill";
 
 describe("buildTools", () => {
@@ -722,5 +723,24 @@ describe("resolveSkillMode", () => {
 	it("存在しないアクション名でスキルのモードを返す", () => {
 		const skill = createSkillFixture({ name: "s", description: "d", mode: "template" });
 		expect(resolveSkillMode(skill, "nonexistent")).toBe("template");
+	});
+});
+
+describe("isTextContentType", () => {
+	it.each([
+		"text/html",
+		"text/plain",
+		"text/csv",
+		"application/json",
+		"application/xml",
+		"application/ld+json",
+		"application/atom+xml",
+		"application/javascript",
+	])("%s をテキストとして許可する", (ct) => {
+		expect(isTextContentType(ct)).toBe(true);
+	});
+
+	it.each(["image/png", "application/octet-stream", "application/pdf"])("%s を拒否する", (ct) => {
+		expect(isTextContentType(ct)).toBe(false);
 	});
 });


### PR DESCRIPTION
#### 概要

fetch ツールの `isTextContentType` が `application/javascript`, `application/ld+json`, `text/csv` 等のテキスト系 content-type を拒否していた問題を修正。

#### 変更内容

- `isTextContentType` に `+json`, `+xml` サフィックスおよび `application/javascript` の判定を追加
- `isTextContentType` をテスト用に export
- 正常系8パターン・異常系3パターンのテストを追加

Closes #358