### PR TITLE
improve: edit ツールで oldString === newString の場合に早期リターン

### DIFF
--- a/src/core/execution/tools/edit-tool.ts
+++ b/src/core/execution/tools/edit-tool.ts
@@ -16,6 +16,10 @@ export const editTool: Tool<EditInput, string> = {
 		"Replace a specific string in a file. The oldString must match exactly one location in the file.",
 	inputSchema: zodToJsonSchema(editParams),
 	execute: async ({ path, oldString, newString }) => {
+		if (oldString === newString) {
+			return `No changes needed in ${path}`;
+		}
+
 		let content: string;
 		try {
 			content = await readFile(path, "utf-8");

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -211,6 +211,25 @@ describe("edit tool", () => {
 				{ toolCallId: "e4", messages: [], abortSignal: AbortSignal.timeout(5000) },
 			),
 		).rejects.toThrow(`Failed to read file: ${invalidPath}`);
+	});
+
+	it("oldString と newString が同一の場合は書き込みをスキップする", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "agent-tools-test-"));
+		const filePath = join(dir, "test.txt");
+		try {
+			await writeFile(filePath, "hello world", "utf-8");
+			const { mtimeMs: mtimeBefore } = await stat(filePath);
+			const tools = unwrapTools(["edit"]);
+			const result = await tools.edit.execute?.(
+				{ path: filePath, oldString: "world", newString: "world" },
+				{ toolCallId: "e5", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			);
+			expect(result).toBe(`No changes needed in ${filePath}`);
+			const { mtimeMs: mtimeAfter } = await stat(filePath);
+			expect(mtimeAfter).toBe(mtimeBefore);
+		} finally {
+			await rm(dir, { recursive: true });
+		}
 	});
 });
 


### PR DESCRIPTION
#### 概要

edit ツールで `oldString` と `newString` が同一の場合に不要なファイル I/O を避けるため早期リターンを追加。

#### 変更内容

- `src/core/execution/tools/edit-tool.ts`: `oldString === newString` の場合に `No changes needed` を返して早期リターン
- `tests/core/execution/agent-tools.test.ts`: 同一文字列での早期リターンと mtime 不変を検証するテストを追加

Closes #359