### PR TITLE
docs: run-agent-skill.ts の startTime 測定位置に Why コメントを追加

### DIFF
--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -125,6 +125,8 @@ export async function runAgentSkill(
 		contentParts.push(...toContentParts(contextResult.value));
 	}
 
+	// durationMs は LLM エージェントの実行時間のみを測定する
+	// （コンテキスト収集時間は含めない — hooks に渡す情報として実行コストを正確に反映するため）
 	const startTime = Date.now();
 
 	const descriptionOverrides = await buildDescriptionOverrides(


### PR DESCRIPTION
#### 概要

`run-agent-skill.ts` の `startTime` が `contextCollector.collect` の後に取得されている理由を明確にする Why コメントを追加。

#### 変更内容

- `durationMs` が LLM エージェント実行時間のみを測定する意図であることを示す Why コメントを追加

Closes #360