### PR TITLE
test: grep ツールの存在しないパスケースのテストを追加

### DIFF
--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -349,6 +349,16 @@ describe("grep tool", () => {
 			tools.grep.execute?.({ pattern: "test", path: "/nonexistent/path" }, toolCallOpts),
 		).rejects.toThrow("Path not found");
 	});
+
+	it("存在しないディレクトリでエラーを投げる", async () => {
+		const tools = unwrapTools(["grep"]);
+		await expect(
+			tools.grep.execute?.(
+				{ pattern: "test", path: "/tmp/surely-does-not-exist-xyz" },
+				toolCallOpts,
+			),
+		).rejects.toThrow("Path not found");
+	});
 });
 
 describe("fetch tool", () => {


### PR DESCRIPTION
#### 概要

grep ツールに存在しないパスを渡した場合のテストを追加。

#### 変更内容

- 存在しないディレクトリ (`/tmp/surely-does-not-exist-xyz`) で `Path not found` エラーが投げられることを検証するテストを追加

Closes #361