### PR TITLE
docs: grep ツールの RegExp 生成に Why コメントを追加

### DIFF
--- a/src/core/execution/tools/grep-tool.ts
+++ b/src/core/execution/tools/grep-tool.ts
@@ -73,6 +73,8 @@ export const grepTool: Tool<GrepInput, GrepResult> = {
 	execute: async ({ pattern, path, include }) => {
 		const cwd = process.cwd();
 		const searchPath = path ?? ".";
+		// g フラグなしで生成することで regex.test() がステートレスに動作する
+		// （g フラグ付きの場合 lastIndex が更新され、同じ文字列への連続 test() で結果が変わる）
 		const regex = new RegExp(pattern);
 
 		const files = await resolveSearchFiles(searchPath, include, cwd);


### PR DESCRIPTION
#### 概要

grep ツールの `new RegExp(pattern)` に g フラグを付けない理由を Why コメントとして明示。

#### 変更内容

- `src/core/execution/tools/grep-tool.ts` に Why コメントを追加（g フラグなしで regex.test() がステートレスに動作する理由）

Closes #363