### PR TITLE
docs: README に agent ツール一覧・画像コンテキスト・grep/edit/fetch を追記

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -313,11 +313,16 @@ tools:                  # agent モードで使用するツール（省略可）
   - bash
   - read
   - write
+  - edit
+  - grep
+  - fetch
 context:                # 自動的にコンテキストに含めるソース（省略可）
   - type: file
     path: "src/{{target}}"
   - type: command
     run: "git diff --cached"
+  - type: image
+    path: "docs/diagram.png"
 actions:                # マルチアクション定義（省略可）
   build:
     description: プロジェクトをビルドする
@@ -374,7 +379,33 @@ taskp run my-skill:test --model anthropic/claude-sonnet-4-20250514
 
 本文中で `{{変数名}}` を使って入力値を展開できます。
 
-### 組み込みツール: `taskp_run`
+### エージェントツール
+
+agent モードでは、以下の組み込みツールが利用できます：
+
+| ツール | 説明 |
+|--------|------|
+| `bash` | シェルコマンドを実行 |
+| `read` | ファイル内容を読み取り |
+| `write` | ファイルに書き込み |
+| `edit` | ファイル内の特定文字列を置換（完全一致が1箇所のみ必要） |
+| `grep` | ファイル内容をパターン検索（正規表現対応） |
+| `fetch` | URL からテキストコンテンツを取得（http/https のみ） |
+| `glob` | glob パターンでファイルを検索 |
+| `ask_user` | 実行中にユーザーに質問 |
+| `taskp_run` | 他の template モードスキルを呼び出し |
+
+`tools` フィールドで必要なツールを指定します：
+
+```yaml
+tools:
+  - bash
+  - read
+  - grep
+  - fetch
+```
+
+#### `taskp_run`
 
 agent モードで LLM が他の template モードスキルを呼び出せます：
 
@@ -393,6 +424,20 @@ tools:
 - template モードのスキルのみ呼び出し可能（agent のネストは不可）
 - 再帰呼び出しは検出・ブロック
 - 最大ネスト深度: 3
+
+### 画像コンテキスト
+
+スキルのコンテキストに画像を含めてマルチモーダル LLM に送信できます：
+
+```yaml
+context:
+  - type: image
+    path: "docs/architecture.png"
+  - type: image
+    path: "screenshots/{{target}}.png"    # 変数展開対応
+```
+
+対応フォーマット: PNG, JPEG, GIF, WebP。画像はバイナリデータとして直接 LLM に送信されます。
 
 ## カスタムシステムプロンプト
 

--- a/README.md
+++ b/README.md
@@ -313,11 +313,16 @@ tools:                  # Tools for agent mode (optional)
   - bash
   - read
   - write
+  - edit
+  - grep
+  - fetch
 context:                # Sources auto-included in context (optional)
   - type: file
     path: "src/{{target}}"
   - type: command
     run: "git diff --cached"
+  - type: image
+    path: "docs/diagram.png"
 actions:                # Multi-action definitions (optional)
   build:
     description: Build the project
@@ -374,9 +379,35 @@ taskp run my-skill:test --model anthropic/claude-sonnet-4-20250514
 
 Use `{{variable_name}}` in the body to expand input values.
 
-### Built-in Tool: `taskp_run`
+### Agent Tools
 
-In agent mode, the LLM can invoke other template-mode skills using the `taskp_run` tool:
+In agent mode, the following built-in tools are available:
+
+| Tool | Description |
+|------|-------------|
+| `bash` | Execute shell commands |
+| `read` | Read file contents |
+| `write` | Write to files |
+| `edit` | Replace a specific string in a file (exact single match required) |
+| `grep` | Search file contents for a pattern (regex supported) |
+| `fetch` | Fetch text content from a URL (http/https only) |
+| `glob` | Find files by glob pattern |
+| `ask_user` | Prompt the user for input during execution |
+| `taskp_run` | Invoke another template-mode skill |
+
+Specify the tools you need in the `tools` field:
+
+```yaml
+tools:
+  - bash
+  - read
+  - grep
+  - fetch
+```
+
+#### `taskp_run`
+
+The LLM can invoke other template-mode skills using the `taskp_run` tool:
 
 ```yaml
 ---
@@ -393,6 +424,20 @@ Constraints:
 - Only template-mode skills can be called (no agent nesting)
 - Recursive calls are detected and blocked
 - Maximum nesting depth: 3
+
+### Image Context
+
+Skills can include images as context for multimodal LLM processing:
+
+```yaml
+context:
+  - type: image
+    path: "docs/architecture.png"
+  - type: image
+    path: "screenshots/{{target}}.png"    # Variable expansion supported
+```
+
+Supported formats: PNG, JPEG, GIF, WebP. The image is sent as binary data directly to the LLM.
 
 ## Custom System Prompt
 


### PR DESCRIPTION
## Summary

issue #340 以降に実装された機能が README に未記載だったため追記。

- **Agent Tools セクション追加**: 全9ツール（bash, read, write, edit, grep, fetch, glob, ask_user, taskp_run）の一覧表を追加
- **画像コンテキスト**: `type: image` のドキュメントと使用例を追加（対応フォーマット: PNG, JPEG, GIF, WebP）
- **フロントマター例更新**: `tools` に edit/grep/fetch、`context` に image タイプを追加

EN/JA 両方の README を同時に更新。

## Related Issues

- #348 context-source に image タイプ追加
- #349 画像コンテキスト E2E 統合
- #350 grep ツール追加
- #351 edit ツール追加
- #352 fetch ツール追加