### PR TITLE
fix(tui): show empty-state screen when no skills found

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -12,6 +12,7 @@ import type { Skill } from "../core/skill/skill";
 import type { SkillInput } from "../core/skill/skill-input";
 import type { HooksConfig } from "../usecase/hook-runner";
 import { copyToClipboard } from "./clipboard";
+import { showEmptyState } from "./screens/empty-state";
 import {
 	createPresetPromptCollector,
 	createSingleSkillRepository,
@@ -43,7 +44,7 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 		const { skills } = await skillRepository.listAll();
 
 		if (skills.length === 0) {
-			console.log("No skills found.");
+			await showEmptyState(renderer);
 			return;
 		}
 

--- a/src/tui/screens/clear-screen.ts
+++ b/src/tui/screens/clear-screen.ts
@@ -1,0 +1,8 @@
+import type { CliRenderer } from "@opentui/core";
+
+/** 現在のレンダーツリーを全てクリアして新しい画面を描画する準備をする */
+export function clearScreen(renderer: CliRenderer): void {
+	for (const child of renderer.root.getChildren()) {
+		renderer.root.remove(child.id);
+	}
+}

--- a/src/tui/screens/empty-state.ts
+++ b/src/tui/screens/empty-state.ts
@@ -1,0 +1,69 @@
+import { BoxRenderable, type CliRenderer, type KeyEvent, TextRenderable } from "@opentui/core";
+import { KeyHelp } from "../components/key-help";
+import { clearScreen } from "./clear-screen";
+
+const CONTAINER_ID = "empty-state-container";
+
+/**
+ * スキルが0件の場合に案内画面を表示する。
+ * ユーザーが Esc を押すと終了する。
+ */
+export async function showEmptyState(renderer: CliRenderer): Promise<void> {
+	return new Promise((resolve) => {
+		clearScreen(renderer);
+
+		const container = new BoxRenderable(renderer, {
+			id: CONTAINER_ID,
+			width: "100%",
+			height: "100%",
+			borderStyle: "rounded",
+			title: "taskp",
+			padding: 1,
+			flexDirection: "column",
+			justifyContent: "flex-start",
+		});
+
+		const message = new TextRenderable(renderer, {
+			id: "empty-message",
+			content: "No skills found.",
+			fg: "#FFFFFF",
+			marginBottom: 1,
+		});
+
+		const hint1 = new TextRenderable(renderer, {
+			id: "empty-hint-init",
+			content: "taskp init <name>    Create a new skill",
+			fg: "#888888",
+			marginLeft: 2,
+		});
+
+		const hint2 = new TextRenderable(renderer, {
+			id: "empty-hint-setup",
+			content: "taskp setup          Set up project configuration",
+			fg: "#888888",
+			marginLeft: 2,
+		});
+
+		const help = KeyHelp([{ key: "Esc", description: "Quit" }]);
+
+		container.add(message);
+		container.add(hint1);
+		container.add(hint2);
+		container.add(help);
+		renderer.root.add(container);
+
+		const keyHandler = (key: KeyEvent) => {
+			if (key.name === "escape") {
+				cleanup();
+				resolve();
+			}
+		};
+
+		renderer.keyInput.on("keypress", keyHandler);
+
+		function cleanup(): void {
+			renderer.keyInput.off("keypress", keyHandler);
+			renderer.root.remove(CONTAINER_ID);
+		}
+	});
+}

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -14,6 +14,7 @@ import { KeyHelp } from "../components/key-help";
 import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../components/spinner";
 import { ToolStatusDisplay } from "../components/tool-status";
 import type { ExecutionViewPort } from "../tui-stream-writer";
+import { clearScreen } from "./clear-screen";
 import { type ExecutionDeps, runExecution } from "./execution-runner";
 
 export type {
@@ -184,10 +185,4 @@ function startSpinner(text: TextRenderable): () => void {
 		text.fg = "#FFFFFF";
 		text.content = "";
 	};
-}
-
-function clearScreen(renderer: CliRenderer): void {
-	for (const child of renderer.root.getChildren()) {
-		renderer.root.remove(child.id);
-	}
 }

--- a/src/tui/screens/input-form.ts
+++ b/src/tui/screens/input-form.ts
@@ -18,6 +18,7 @@ import type { Skill } from "../../core/skill/skill";
 import type { SkillInput } from "../../core/skill/skill-input";
 import { KeyHelp } from "../components/key-help";
 import { flatSelectStyle } from "../components/styles";
+import { clearScreen } from "./clear-screen";
 
 const CONTAINER_ID = "form-container";
 const TEXTAREA_DEFAULT_HEIGHT = 5;
@@ -356,10 +357,4 @@ function createTextInputElement(
 	});
 
 	return inputElement;
-}
-
-function clearScreen(renderer: CliRenderer): void {
-	for (const child of renderer.root.getChildren()) {
-		renderer.root.remove(child.id);
-	}
 }

--- a/src/tui/screens/skill-selector.ts
+++ b/src/tui/screens/skill-selector.ts
@@ -16,6 +16,7 @@ import {
 } from "../components/fuzzy-select";
 import { KeyHelp } from "../components/key-help";
 import { flatSelectStyle } from "../components/styles";
+import { clearScreen } from "./clear-screen";
 
 const CONTAINER_ID = "selector-container";
 
@@ -199,11 +200,5 @@ function autoExpandForSearch(
 		if (opt.parentSkillName) {
 			expandedSkills.add(opt.parentSkillName);
 		}
-	}
-}
-
-function clearScreen(renderer: CliRenderer): void {
-	for (const child of renderer.root.getChildren()) {
-		renderer.root.remove(child.id);
 	}
 }


### PR DESCRIPTION
## Summary

- スキル0件時に `console.log` で即終了する代わりに、TUI 画面内で案内メッセージを表示するように修正
- 4ファイルに重複していた `clearScreen` ユーティリティを `clear-screen.ts` に共通化

## Changes

| ファイル | 内容 |
|---------|------|
| `src/tui/screens/empty-state.ts` | 新規: 0件時の案内画面 (メッセージ + `taskp init` / `taskp setup` ヒント) |
| `src/tui/screens/clear-screen.ts` | 新規: `clearScreen` 共通ユーティリティ |
| `src/tui/app.ts` | `console.log` + `return` → `await showEmptyState(renderer)` に置き換え |
| `src/tui/screens/skill-selector.ts` | ローカル `clearScreen` を共通 import に置き換え |
| `src/tui/screens/input-form.ts` | 同上 |
| `src/tui/screens/execution-view.ts` | 同上 |

Closes #379