### PR TITLE
fix: scanDirectory がシンボリックリンクされたスキルディレクトリを認識しない

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -95,7 +95,12 @@ async function scanDirectory(
 	const skills: Skill[] = [];
 	const failures: { path: string; error: string }[] = [];
 
-	for (const entry of entries.filter((e) => e.isDirectory())) {
+	// Node.js の readdir({ withFileTypes: true }) はシンボリックリンクを stat-follow しないため、
+	// symlink 先がディレクトリでも isDirectory() が false を返す。isSymbolicLink() を併用して
+	// symlink 先ディレクトリも走査対象に含める。
+	// Note: symlink はスキルディレクトリ外の任意パスを指せるが、開発者が自身の環境で
+	// 配置する CLI ツールのため、パスの制限は行わない。
+	for (const entry of entries.filter((e) => e.isDirectory() || e.isSymbolicLink())) {
 		const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
 		const result = await tryLoadSkill(skillPath, scope, logger);
 		if (result.type === "not_found") {

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -224,6 +224,89 @@ describe("SkillLoader", () => {
 			const { failures } = await loader.listGlobal();
 
 			expect(failures).toHaveLength(1);
+		});
+	});
+
+	describe("symlink", () => {
+		const externalDirs: string[] = [];
+
+		afterEach(() => {
+			for (const dir of externalDirs) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+			externalDirs.length = 0;
+		});
+
+		it("シンボリックリンクされたスキルディレクトリを読み込める", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "my-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(join(externalSkillDir, "SKILL.md"), makeSkillMd("my-skill", "外部スキル"));
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "my-skill"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listLocal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("my-skill");
+		});
+
+		it("シンボリックリンクされたスキルを findByName で検索できる", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "linked-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("linked-skill", "リンクスキル"),
+			);
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "linked-skill"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("linked-skill");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("linked-skill");
+			expect(result.value.scope).toBe("global");
+		});
+
+		it("壊れたシンボリックリンクはスキップされる", async () => {
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync("/nonexistent/path/to/skill", join(skillsDir, "broken-link"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listLocal();
+
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(0);
+		});
+
+		it("ファイルへのシンボリックリンクは failures に記録される", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalFile = join(externalDir, "not-a-dir.md");
+			writeFileSync(externalFile, makeSkillMd("oops", "ファイルリンク"));
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalFile, join(skillsDir, "file-link"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listLocal();
+
+			// ファイルへの symlink は file-link/SKILL.md を readFile → ENOTDIR で失敗する
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(1);
+			expect(failures[0].path).toMatch(/file-link/);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- `scanDirectory` の `readdir` フィルタに `isSymbolicLink()` を追加し、シンボリックリンクされたスキルディレクトリを認識するように修正
- 壊れた symlink・ファイルへの symlink のエッジケースも適切にハンドリング
- テスト4件追加（symlink ディレクトリ読み込み / findByName / 壊れたリンク / ファイルへのリンク）

Closes #378