### PR TITLE
docs: インストールコマンドを bun install -g に統一

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,13 @@
 ## インストール
 
 ```bash
-bun add -g github:takemo101/taskp
+bun install -g github:takemo101/taskp
+```
+
+バージョンを指定してインストール：
+
+```bash
+bun install -g github:takemo101/taskp#v0.1.7
 ```
 
 > **必要環境:** Bun >= 1.2.0
@@ -30,7 +36,7 @@ source ~/.zshrc
 ### アップデート
 
 ```bash
-bun add -g github:takemo101/taskp
+bun install -g github:takemo101/taskp
 ```
 
 ### アンインストール

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ A CLI tool that runs skills (task procedures) defined in Markdown — collecting
 ## Installation
 
 ```bash
-bun add -g github:takemo101/taskp
+bun install -g github:takemo101/taskp
+```
+
+To install a specific version:
+
+```bash
+bun install -g github:takemo101/taskp#v0.1.7
 ```
 
 > **Requirements:** Bun >= 1.2.0
@@ -30,7 +36,7 @@ source ~/.zshrc
 ### Update
 
 ```bash
-bun add -g github:takemo101/taskp
+bun install -g github:takemo101/taskp
 ```
 
 ### Uninstall


### PR DESCRIPTION
## Summary

- README.md / README.ja.md のインストールコマンドを `bun add -g` から `bun install -g` に変更
- バージョン指定でのインストール方法（`#v0.1.7`）を追記