### PR TITLE
refactor: use Result types in tool execute functions instead of throwing exceptions

### DIFF
--- a/src/core/execution/tools/bash-tool.ts
+++ b/src/core/execution/tools/bash-tool.ts
@@ -1,6 +1,8 @@
 import type { Tool } from "ai";
 import { execa } from "execa";
 import { z } from "zod";
+import { type ExecutionError, executionError } from "../../types/errors";
+import { err, ok, type Result } from "../../types/result";
 import { zodToJsonSchema } from "./schema-helper";
 
 export const bashParams = z.object({
@@ -12,16 +14,20 @@ export const bashParams = z.object({
 type BashInput = z.infer<typeof bashParams>;
 type BashResult = { readonly stdout: string; readonly stderr: string; readonly exitCode: number };
 
-export const bashTool: Tool<BashInput, BashResult> = {
+export const bashTool: Tool<BashInput, Result<BashResult, ExecutionError>> = {
 	description: "Run a shell command and return stdout/stderr",
 	inputSchema: zodToJsonSchema(bashParams),
-	execute: async ({ command, cwd, timeout }) => {
-		const result = await execa(command, {
-			shell: true,
-			cwd: cwd ?? process.cwd(),
-			timeout: timeout ?? 30_000,
-			reject: false,
-		});
-		return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode ?? 1 };
+	execute: async ({ command, cwd, timeout }): Promise<Result<BashResult, ExecutionError>> => {
+		try {
+			const result = await execa(command, {
+				shell: true,
+				cwd: cwd ?? process.cwd(),
+				timeout: timeout ?? 30_000,
+				reject: false,
+			});
+			return ok({ stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode ?? 1 });
+		} catch {
+			return err(executionError(`Failed to execute command: ${command}`));
+		}
 	},
 };

--- a/src/core/execution/tools/edit-tool.ts
+++ b/src/core/execution/tools/edit-tool.ts
@@ -1,6 +1,8 @@
 import { readFile, writeFile } from "node:fs/promises";
 import type { Tool } from "ai";
 import { z } from "zod";
+import { type ExecutionError, executionError } from "../../types/errors";
+import { err, ok, type Result } from "../../types/result";
 import { zodToJsonSchema } from "./schema-helper";
 
 export const editParams = z.object({
@@ -11,42 +13,58 @@ export const editParams = z.object({
 
 type EditInput = z.infer<typeof editParams>;
 
-export const editTool: Tool<EditInput, string> = {
+function validateMatch(
+	content: string,
+	oldString: string,
+	path: string,
+): Result<number, ExecutionError> {
+	const index = content.indexOf(oldString);
+	if (index === -1) {
+		return err(executionError(`String not found in ${path}`));
+	}
+
+	const secondIndex = content.indexOf(oldString, index + 1);
+	if (secondIndex !== -1) {
+		return err(
+			executionError(
+				`Multiple matches found in ${path}. Provide more context in oldString to uniquely identify the location.`,
+			),
+		);
+	}
+
+	return ok(index);
+}
+
+export const editTool: Tool<EditInput, Result<string, ExecutionError>> = {
 	description:
 		"Replace a specific string in a file. The oldString must match exactly one location in the file.",
 	inputSchema: zodToJsonSchema(editParams),
-	execute: async ({ path, oldString, newString }) => {
+	execute: async ({ path, oldString, newString }): Promise<Result<string, ExecutionError>> => {
 		if (oldString === newString) {
-			return `No changes needed in ${path}`;
+			return ok(`No changes needed in ${path}`);
 		}
 
 		let content: string;
 		try {
 			content = await readFile(path, "utf-8");
-		} catch (error) {
-			throw new Error(`Failed to read file: ${path}`, { cause: error });
+		} catch {
+			return err(executionError(`Failed to read file: ${path}`));
 		}
 
-		const index = content.indexOf(oldString);
-		if (index === -1) {
-			throw new Error(`String not found in ${path}`);
+		const matchResult = validateMatch(content, oldString, path);
+		if (!matchResult.ok) {
+			return matchResult;
 		}
 
-		const secondIndex = content.indexOf(oldString, index + 1);
-		if (secondIndex !== -1) {
-			throw new Error(
-				`Multiple matches found in ${path}. Provide more context in oldString to uniquely identify the location.`,
-			);
-		}
-
+		const index = matchResult.value;
 		const updated = content.slice(0, index) + newString + content.slice(index + oldString.length);
 
 		try {
 			await writeFile(path, updated, "utf-8");
-		} catch (error) {
-			throw new Error(`Failed to write file: ${path}`, { cause: error });
+		} catch {
+			return err(executionError(`Failed to write file: ${path}`));
 		}
 
-		return `Edited ${path}`;
+		return ok(`Edited ${path}`);
 	},
 };

--- a/src/core/execution/tools/glob-tool.ts
+++ b/src/core/execution/tools/glob-tool.ts
@@ -1,6 +1,8 @@
 import { glob as fsGlob } from "node:fs/promises";
 import type { Tool } from "ai";
 import { z } from "zod";
+import { type ExecutionError, executionError } from "../../types/errors";
+import { err, ok, type Result } from "../../types/result";
 import { zodToJsonSchema } from "./schema-helper";
 
 export const globParams = z.object({
@@ -9,18 +11,18 @@ export const globParams = z.object({
 
 type GlobInput = z.infer<typeof globParams>;
 
-export const globTool: Tool<GlobInput, readonly string[]> = {
+export const globTool: Tool<GlobInput, Result<readonly string[], ExecutionError>> = {
 	description: "Search for files matching a glob pattern",
 	inputSchema: zodToJsonSchema(globParams),
-	execute: async ({ pattern }) => {
+	execute: async ({ pattern }): Promise<Result<readonly string[], ExecutionError>> => {
 		try {
 			const matches: string[] = [];
 			for await (const entry of fsGlob(pattern)) {
 				matches.push(entry);
 			}
-			return matches;
-		} catch (error) {
-			throw new Error(`Failed to glob pattern: ${pattern}`, { cause: error });
+			return ok(matches);
+		} catch {
+			return err(executionError(`Failed to glob pattern: ${pattern}`));
 		}
 	},
 };

--- a/src/core/execution/tools/read-tool.ts
+++ b/src/core/execution/tools/read-tool.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import type { Tool } from "ai";
 import { z } from "zod";
+import { type ExecutionError, executionError } from "../../types/errors";
+import { err, ok, type Result } from "../../types/result";
 import { zodToJsonSchema } from "./schema-helper";
 
 export const readParams = z.object({
@@ -10,14 +12,15 @@ export const readParams = z.object({
 
 type ReadInput = z.infer<typeof readParams>;
 
-export const readTool: Tool<ReadInput, string> = {
+export const readTool: Tool<ReadInput, Result<string, ExecutionError>> = {
 	description: "Read the contents of a file",
 	inputSchema: zodToJsonSchema(readParams),
-	execute: async ({ path }) => {
+	execute: async ({ path }): Promise<Result<string, ExecutionError>> => {
 		try {
-			return await readFile(path, "utf-8");
-		} catch (error) {
-			throw new Error(`Failed to read file: ${path}`, { cause: error });
+			const content = await readFile(path, "utf-8");
+			return ok(content);
+		} catch {
+			return err(executionError(`Failed to read file: ${path}`));
 		}
 	},
 };

--- a/src/core/execution/tools/write-tool.ts
+++ b/src/core/execution/tools/write-tool.ts
@@ -1,6 +1,8 @@
 import { writeFile } from "node:fs/promises";
 import type { Tool } from "ai";
 import { z } from "zod";
+import { type ExecutionError, executionError } from "../../types/errors";
+import { err, ok, type Result } from "../../types/result";
 import { zodToJsonSchema } from "./schema-helper";
 
 export const writeParams = z.object({
@@ -10,15 +12,15 @@ export const writeParams = z.object({
 
 type WriteInput = z.infer<typeof writeParams>;
 
-export const writeTool: Tool<WriteInput, string> = {
+export const writeTool: Tool<WriteInput, Result<string, ExecutionError>> = {
 	description: "Write content to a file",
 	inputSchema: zodToJsonSchema(writeParams),
-	execute: async ({ path, content }) => {
+	execute: async ({ path, content }): Promise<Result<string, ExecutionError>> => {
 		try {
 			await writeFile(path, content, "utf-8");
-			return `Written to ${path}`;
-		} catch (error) {
-			throw new Error(`Failed to write file: ${path}`, { cause: error });
+			return ok(`Written to ${path}`);
+		} catch {
+			return err(executionError(`Failed to write file: ${path}`));
 		}
 	},
 };

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -74,7 +74,7 @@ describe("bash tool", () => {
 			{ command: "echo hello" },
 			{ toolCallId: "1", messages: [], abortSignal: AbortSignal.timeout(5000) },
 		);
-		expect(result).toEqual({ stdout: "hello", stderr: "", exitCode: 0 });
+		expect(result).toEqual({ ok: true, value: { stdout: "hello", stderr: "", exitCode: 0 } });
 	});
 
 	it("失敗したコマンドの exitCode と stderr を返す", async () => {
@@ -82,30 +82,37 @@ describe("bash tool", () => {
 		const result = (await tools.bash.execute?.(
 			{ command: "echo err >&2 && exit 1" },
 			{ toolCallId: "2", messages: [], abortSignal: AbortSignal.timeout(5000) },
-		)) as { stdout: string; stderr: string; exitCode: number };
-		expect(result.exitCode).toBe(1);
-		expect(result.stderr).toBe("err");
+		)) as { ok: true; value: { stdout: string; stderr: string; exitCode: number } };
+		expect(result.ok).toBe(true);
+		expect(result.value.exitCode).toBe(1);
+		expect(result.value.stderr).toBe("err");
 	});
 });
 
 describe("read tool", () => {
 	it("ファイルの内容を読み込む", async () => {
 		const tools = unwrapTools(["read"]);
-		const result = await tools.read.execute?.(
+		const result = (await tools.read.execute?.(
 			{ path: join(__dirname, "agent-tools.test.ts") },
 			{ toolCallId: "3", messages: [], abortSignal: AbortSignal.timeout(5000) },
-		);
-		expect(result).toContain("describe");
+		)) as { ok: true; value: string };
+		expect(result.ok).toBe(true);
+		expect(result.value).toContain("describe");
 	});
 
-	it("存在しないファイルでエラーを投げる", async () => {
+	it("存在しないファイルで err を返す", async () => {
 		const tools = unwrapTools(["read"]);
-		await expect(
-			tools.read.execute?.(
-				{ path: "/nonexistent/path/file.txt" },
-				{ toolCallId: "3", messages: [], abortSignal: AbortSignal.timeout(5000) },
-			),
-		).rejects.toThrow("Failed to read file: /nonexistent/path/file.txt");
+		const result = await tools.read.execute?.(
+			{ path: "/nonexistent/path/file.txt" },
+			{ toolCallId: "3", messages: [], abortSignal: AbortSignal.timeout(5000) },
+		);
+		expect(result).toEqual({
+			ok: false,
+			error: {
+				type: "EXECUTION_ERROR",
+				message: "Failed to read file: /nonexistent/path/file.txt",
+			},
+		});
 	});
 });
 
@@ -119,7 +126,7 @@ describe("write tool", () => {
 				{ path: filePath, content: "hello world" },
 				{ toolCallId: "4", messages: [], abortSignal: AbortSignal.timeout(5000) },
 			);
-			expect(result).toBe(`Written to ${filePath}`);
+			expect(result).toEqual({ ok: true, value: `Written to ${filePath}` });
 			const written = await readFile(filePath, "utf-8");
 			expect(written).toBe("hello world");
 		} finally {
@@ -127,15 +134,17 @@ describe("write tool", () => {
 		}
 	});
 
-	it("存在しないディレクトリへの書き込みでエラーを投げる", async () => {
+	it("存在しないディレクトリへの書き込みで err を返す", async () => {
 		const tools = unwrapTools(["write"]);
 		const invalidPath = "/nonexistent/dir/file.txt";
-		await expect(
-			tools.write.execute?.(
-				{ path: invalidPath, content: "test" },
-				{ toolCallId: "4", messages: [], abortSignal: AbortSignal.timeout(5000) },
-			),
-		).rejects.toThrow(`Failed to write file: ${invalidPath}`);
+		const result = await tools.write.execute?.(
+			{ path: invalidPath, content: "test" },
+			{ toolCallId: "4", messages: [], abortSignal: AbortSignal.timeout(5000) },
+		);
+		expect(result).toEqual({
+			ok: false,
+			error: { type: "EXECUTION_ERROR", message: `Failed to write file: ${invalidPath}` },
+		});
 	});
 });
 
@@ -145,8 +154,9 @@ describe("glob tool", () => {
 		const result = (await tools.glob.execute?.(
 			{ pattern: "tests/core/execution/*.test.ts" },
 			{ toolCallId: "5", messages: [], abortSignal: AbortSignal.timeout(5000) },
-		)) as string[];
-		expect(result).toContain("tests/core/execution/agent-tools.test.ts");
+		)) as { ok: true; value: readonly string[] };
+		expect(result.ok).toBe(true);
+		expect(result.value).toContain("tests/core/execution/agent-tools.test.ts");
 	});
 });
 
@@ -161,7 +171,7 @@ describe("edit tool", () => {
 				{ path: filePath, oldString: "world", newString: "universe" },
 				{ toolCallId: "e1", messages: [], abortSignal: AbortSignal.timeout(5000) },
 			);
-			expect(result).toBe(`Edited ${filePath}`);
+			expect(result).toEqual({ ok: true, value: `Edited ${filePath}` });
 			const content = await readFile(filePath, "utf-8");
 			expect(content).toBe("hello universe foo bar");
 		} finally {
@@ -169,49 +179,58 @@ describe("edit tool", () => {
 		}
 	});
 
-	it("oldString が見つからない場合エラーを投げる", async () => {
+	it("oldString が見つからない場合 err を返す", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "agent-tools-test-"));
 		const filePath = join(dir, "test.txt");
 		try {
 			await writeFile(filePath, "hello world", "utf-8");
 			const tools = unwrapTools(["edit"]);
-			await expect(
-				tools.edit.execute?.(
-					{ path: filePath, oldString: "nonexistent", newString: "replaced" },
-					{ toolCallId: "e2", messages: [], abortSignal: AbortSignal.timeout(5000) },
-				),
-			).rejects.toThrow(`String not found in ${filePath}`);
+			const result = await tools.edit.execute?.(
+				{ path: filePath, oldString: "nonexistent", newString: "replaced" },
+				{ toolCallId: "e2", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			);
+			expect(result).toEqual({
+				ok: false,
+				error: { type: "EXECUTION_ERROR", message: `String not found in ${filePath}` },
+			});
 		} finally {
 			await rm(dir, { recursive: true });
 		}
 	});
 
-	it("複数マッチ時にエラーを投げる", async () => {
+	it("複数マッチ時に err を返す", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "agent-tools-test-"));
 		const filePath = join(dir, "test.txt");
 		try {
 			await writeFile(filePath, "hello hello hello", "utf-8");
 			const tools = unwrapTools(["edit"]);
-			await expect(
-				tools.edit.execute?.(
-					{ path: filePath, oldString: "hello", newString: "hi" },
-					{ toolCallId: "e3", messages: [], abortSignal: AbortSignal.timeout(5000) },
-				),
-			).rejects.toThrow(`Multiple matches found in ${filePath}`);
+			const result = await tools.edit.execute?.(
+				{ path: filePath, oldString: "hello", newString: "hi" },
+				{ toolCallId: "e3", messages: [], abortSignal: AbortSignal.timeout(5000) },
+			);
+			expect(result).toEqual({
+				ok: false,
+				error: {
+					type: "EXECUTION_ERROR",
+					message: `Multiple matches found in ${filePath}. Provide more context in oldString to uniquely identify the location.`,
+				},
+			});
 		} finally {
 			await rm(dir, { recursive: true });
 		}
 	});
 
-	it("存在しないファイルでエラーを投げる", async () => {
+	it("存在しないファイルで err を返す", async () => {
 		const tools = unwrapTools(["edit"]);
 		const invalidPath = "/nonexistent/path/file.txt";
-		await expect(
-			tools.edit.execute?.(
-				{ path: invalidPath, oldString: "old", newString: "new" },
-				{ toolCallId: "e4", messages: [], abortSignal: AbortSignal.timeout(5000) },
-			),
-		).rejects.toThrow(`Failed to read file: ${invalidPath}`);
+		const result = await tools.edit.execute?.(
+			{ path: invalidPath, oldString: "old", newString: "new" },
+			{ toolCallId: "e4", messages: [], abortSignal: AbortSignal.timeout(5000) },
+		);
+		expect(result).toEqual({
+			ok: false,
+			error: { type: "EXECUTION_ERROR", message: `Failed to read file: ${invalidPath}` },
+		});
 	});
 
 	it("oldString と newString が同一の場合は書き込みをスキップする", async () => {
@@ -225,7 +244,7 @@ describe("edit tool", () => {
 				{ path: filePath, oldString: "world", newString: "world" },
 				{ toolCallId: "e5", messages: [], abortSignal: AbortSignal.timeout(5000) },
 			);
-			expect(result).toBe(`No changes needed in ${filePath}`);
+			expect(result).toEqual({ ok: true, value: `No changes needed in ${filePath}` });
 			const { mtimeMs: mtimeAfter } = await stat(filePath);
 			expect(mtimeAfter).toBe(mtimeBefore);
 		} finally {


### PR DESCRIPTION
#### 概要

ツールの execute 関数で例外を throw する代わりに Result 型を返すようリファクタリング。docs/arch/error-handling.md の方針に準拠。

#### 変更内容

- read-tool.ts: `Result<string, ExecutionError>` を返すように変更
- write-tool.ts: `Result<string, ExecutionError>` を返すように変更
- edit-tool.ts: `Result<string, ExecutionError>` を返すように変更、バリデーションロジックを `validateMatch` 関数に抽出
- glob-tool.ts: `Result<readonly string[], ExecutionError>` を返すように変更
- bash-tool.ts: `Result<BashResult, ExecutionError>` を返すように変更
- テストを Result 型のアサーションに更新

Closes #384