### PR TITLE
refactor: extract buildReservedVars into shared template-renderer module

### DIFF
--- a/src/core/variable/index.ts
+++ b/src/core/variable/index.ts
@@ -1,2 +1,2 @@
 // Variable domain models
-export { type ReservedVars, renderTemplate } from "./template-renderer";
+export { buildReservedVars, type ReservedVars, renderTemplate } from "./template-renderer";

--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import { type RenderError, renderError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
 
@@ -7,6 +8,15 @@ export type ReservedVars = {
 	readonly date: string;
 	readonly timestamp: string;
 };
+
+export function buildReservedVars(skillLocation: string): ReservedVars {
+	return {
+		cwd: process.cwd(),
+		skillDir: dirname(skillLocation),
+		date: new Date().toISOString().split("T")[0],
+		timestamp: new Date().toISOString(),
+	};
+}
 
 const VARIABLE_PATTERN = /\{\{(\w+)\}\}/g;
 

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,4 +1,3 @@
-import { dirname } from "node:path";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
@@ -14,7 +13,7 @@ import { type DomainError, domainErrorMessage, executionError } from "../core/ty
 import type { Result } from "../core/types/result";
 import { err, ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
-import { renderTemplate } from "../core/variable/template-renderer";
+import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
@@ -79,12 +78,7 @@ export async function runAgentSkill(
 
 	progress.writeInputs(inputs, variables);
 
-	const reserved: ReservedVars = {
-		cwd: process.cwd(),
-		skillDir: dirname(skill.location),
-		date: new Date().toISOString().split("T")[0],
-		timestamp: new Date().toISOString(),
-	};
+	const reserved = buildReservedVars(skill.location);
 
 	const rawContent = resolved?.sectionContent ?? skill.body.content;
 	const renderResult = renderTemplate(rawContent, variables, reserved);

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,4 +1,3 @@
-import { dirname } from "node:path";
 import { resolveActionConfig } from "../core/skill/action";
 import type { Skill } from "../core/skill/skill";
 import type { CodeBlock } from "../core/skill/skill-body";
@@ -7,7 +6,7 @@ import { type DomainError, domainErrorMessage, executionError } from "../core/ty
 import type { Result } from "../core/types/result";
 import { err, ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
-import { renderTemplate } from "../core/variable/template-renderer";
+import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
 import type { HookExecutorPort } from "./port/hook-executor";
@@ -117,15 +116,6 @@ function resolveSkillExecution(
 		codeBlocks: skill.body.extractActionCodeBlocks(action, "bash"),
 		timeout: config.timeout,
 	});
-}
-
-function buildReservedVars(skillLocation: string): ReservedVars {
-	return {
-		cwd: process.cwd(),
-		skillDir: dirname(skillLocation),
-		date: new Date().toISOString().split("T")[0],
-		timestamp: new Date().toISOString(),
-	};
 }
 
 async function executeSkill(


### PR DESCRIPTION
#### 概要

run-skill.ts と run-agent-skill.ts で重複していた `buildReservedVars` ロジックを `template-renderer.ts` に共通関数として抽出。

#### 変更内容

- `buildReservedVars(skillLocation)` を `src/core/variable/template-renderer.ts` に追加・エクスポート
- `run-skill.ts` のローカル `buildReservedVars` 関数を削除し、共通関数をインポート
- `run-agent-skill.ts` のインライン ReservedVars 構築を `buildReservedVars` 呼び出しに置換
- 不要になった `dirname` インポートを両ファイルから削除

Closes #385