### PR TITLE
refactor: extract resolveSkillConfig to fix Demeter's Law violations

### DIFF
--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -9,6 +9,8 @@ export { parseContextSource } from "./context-source";
 export type { Skill, SkillLogger, SkillScope } from "./skill";
 export { parseSkill } from "./skill";
 export type { SkillBody } from "./skill-body";
+export type { AgentExecutionConfig, TemplateExecutionConfig } from "./skill-execution-resolver";
+export { resolveAgentExecution, resolveTemplateExecution } from "./skill-execution-resolver";
 export type { InputType, SkillInput } from "./skill-input";
 export { parseSkillInput } from "./skill-input";
 export type { SkillMetadata, SkillMode } from "./skill-metadata";

--- a/src/core/skill/skill-execution-resolver.ts
+++ b/src/core/skill/skill-execution-resolver.ts
@@ -1,0 +1,120 @@
+import type { DomainError } from "../types/errors";
+import { executionError } from "../types/errors";
+import type { Result } from "../types/result";
+import { err, ok } from "../types/result";
+import { resolveActionConfig } from "./action";
+import type { ContextSource } from "./context-source";
+import type { Skill } from "./skill";
+import type { CodeBlock } from "./skill-body";
+import type { SkillInput } from "./skill-input";
+
+export type AgentExecutionConfig = {
+	readonly inputs: readonly SkillInput[];
+	readonly tools: readonly string[];
+	readonly context: readonly ContextSource[];
+	readonly content: string;
+};
+
+export type TemplateExecutionConfig = {
+	readonly inputs: readonly SkillInput[];
+	readonly content: string;
+	readonly codeBlocks: readonly CodeBlock[];
+	readonly timeout: number | undefined;
+};
+
+/**
+ * エージェントモード実行に必要な設定を Skill から解決する。
+ * actionName 指定時はアクション設定を優先し、未指定時はスキルレベルの設定を使用する。
+ */
+export function resolveAgentExecution(
+	skill: Skill,
+	actionName: string | undefined,
+): Result<AgentExecutionConfig, DomainError> {
+	if (!actionName) {
+		return ok({
+			inputs: skill.metadata.inputs,
+			tools: skill.metadata.tools,
+			context: skill.metadata.context,
+			content: skill.body.content,
+		});
+	}
+
+	const actions = skill.metadata.actions;
+	if (!actions?.[actionName]) {
+		return err(
+			executionError(`Action "${actionName}" is not defined in skill "${skill.metadata.name}"`),
+		);
+	}
+
+	const config = resolveActionConfig(actions[actionName], skill.metadata);
+
+	const sectionContent = skill.body.extractActionSection(actionName);
+	if (!sectionContent) {
+		return err(
+			executionError(
+				`Action section "## action:${actionName}" not found in skill "${skill.metadata.name}"`,
+			),
+		);
+	}
+
+	return ok({
+		inputs: config.inputs,
+		tools: config.tools,
+		context: config.context,
+		content: sectionContent,
+	});
+}
+
+/**
+ * テンプレートモード実行に必要な設定を Skill から解決する。
+ * actionName 指定時はアクション設定を優先し、未指定時はスキルレベルの設定を使用する。
+ */
+export function resolveTemplateExecution(
+	skill: Skill,
+	actionName: string | undefined,
+): Result<TemplateExecutionConfig, DomainError> {
+	const hasActions = skill.metadata.actions !== undefined;
+
+	if (hasActions && !actionName) {
+		return err(
+			executionError(
+				`Skill "${skill.metadata.name}" has actions defined. Specify an action to run.`,
+			),
+		);
+	}
+
+	if (!actionName) {
+		return ok({
+			inputs: skill.metadata.inputs,
+			content: skill.body.content,
+			codeBlocks: skill.body.extractCodeBlocks("bash"),
+			timeout: skill.metadata.timeout,
+		});
+	}
+
+	const actions = skill.metadata.actions;
+	if (!actions) {
+		return err(executionError(`Skill "${skill.metadata.name}" does not define actions.`));
+	}
+
+	const actionDef = actions[actionName];
+	if (!actionDef) {
+		return err(
+			executionError(`Action "${actionName}" not found in skill "${skill.metadata.name}".`),
+		);
+	}
+
+	const config = resolveActionConfig(actionDef, skill.metadata);
+
+	const sectionContent = skill.body.extractActionSection(actionName);
+	if (!sectionContent) {
+		return err(executionError(`Action section "action:${actionName}" not found in skill body.`));
+	}
+
+	return ok({
+		inputs: config.inputs,
+		content: sectionContent,
+		codeBlocks: skill.body.extractActionCodeBlocks(actionName, "bash"),
+		timeout: config.timeout,
+	});
+}

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,17 +1,15 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
-import { resolveActionConfig } from "../core/skill";
 import {
 	type ContextSource,
 	getContextSourceValue,
 	withResolvedValue,
 } from "../core/skill/context-source";
-import type { Skill } from "../core/skill/skill";
-import type { SkillInput } from "../core/skill/skill-input";
-import { type DomainError, domainErrorMessage, executionError } from "../core/types/errors";
+import { resolveAgentExecution } from "../core/skill/skill-execution-resolver";
+import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { err, ok } from "../core/types/result";
+import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
@@ -60,13 +58,12 @@ export async function runAgentSkill(
 
 	const skill = findResult.value;
 
-	const actionConfig = input.action ? resolveActionForAgent(skill, input.action) : undefined;
-	if (actionConfig !== undefined && !actionConfig.ok) {
-		return actionConfig;
+	const executionConfig = resolveAgentExecution(skill, input.action);
+	if (!executionConfig.ok) {
+		return executionConfig;
 	}
-	const resolved = actionConfig?.value;
+	const { inputs, tools: toolNames, context: contextSources, content } = executionConfig.value;
 
-	const inputs: readonly SkillInput[] = resolved?.inputs ?? skill.metadata.inputs;
 	const collectResult = await deps.promptCollector.collect(inputs, input.presets, {
 		noInput: input.noInput,
 	});
@@ -80,15 +77,12 @@ export async function runAgentSkill(
 
 	const reserved = buildReservedVars(skill.location);
 
-	const rawContent = resolved?.sectionContent ?? skill.body.content;
-	const renderResult = renderTemplate(rawContent, variables, reserved);
+	const renderResult = renderTemplate(content, variables, reserved);
 	if (!renderResult.ok) {
 		return renderResult;
 	}
 
 	const skillPrompt = renderResult.value;
-
-	const toolNames: readonly string[] = resolved?.tools ?? skill.metadata.tools;
 
 	// system prompt: SystemPromptResolver が SYSTEM.md の探索とフォールバックを一元管理
 	const systemPrompt = await deps.systemPromptResolver.resolve({
@@ -100,8 +94,6 @@ export async function runAgentSkill(
 	// prompt: SKILL.md 本文（タスク指示）を先頭に、context ソース出力（データ）を続けて配置
 	// system = 「どう振る舞うか」、contentParts = 「何をするか」の分離
 	const contentParts: ContentPart[] = [{ type: "text", text: skillPrompt }];
-
-	const contextSources: readonly ContextSource[] = resolved?.context ?? skill.metadata.context;
 
 	if (contextSources.length > 0) {
 		progress.writeContextSources(contextSources);
@@ -171,43 +163,6 @@ export async function runAgentSkill(
 	return ok({
 		skillName: skill.metadata.name,
 		result: executeResult.value,
-	});
-}
-
-type ResolvedAction = {
-	readonly inputs: readonly SkillInput[];
-	readonly tools: readonly string[];
-	readonly context: readonly ContextSource[];
-	readonly sectionContent: string;
-};
-
-function resolveActionForAgent(
-	skill: Skill,
-	actionName: string,
-): Result<ResolvedAction, DomainError> {
-	const actions = skill.metadata.actions;
-	if (!actions?.[actionName]) {
-		return err(
-			executionError(`Action "${actionName}" is not defined in skill "${skill.metadata.name}"`),
-		);
-	}
-
-	const config = resolveActionConfig(actions[actionName], skill.metadata);
-
-	const sectionContent = skill.body.extractActionSection(actionName);
-	if (!sectionContent) {
-		return err(
-			executionError(
-				`Action section "## action:${actionName}" not found in skill "${skill.metadata.name}"`,
-			),
-		);
-	}
-
-	return ok({
-		inputs: config.inputs,
-		tools: config.tools,
-		context: config.context,
-		sectionContent,
 	});
 }
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -1,10 +1,12 @@
-import { resolveActionConfig } from "../core/skill/action";
 import type { Skill } from "../core/skill/skill";
 import type { CodeBlock } from "../core/skill/skill-body";
-import type { SkillInput } from "../core/skill/skill-input";
-import { type DomainError, domainErrorMessage, executionError } from "../core/types/errors";
+import {
+	resolveTemplateExecution,
+	type TemplateExecutionConfig,
+} from "../core/skill/skill-execution-resolver";
+import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
-import { err, ok } from "../core/types/result";
+import { ok } from "../core/types/result";
 import type { ReservedVars } from "../core/variable/template-renderer";
 import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
@@ -45,13 +47,6 @@ export type RunSkillDeps = {
 	readonly hooksConfig?: HooksConfig;
 };
 
-type SkillExecutionConfig = {
-	readonly inputs: readonly SkillInput[];
-	readonly content: string;
-	readonly codeBlocks: readonly CodeBlock[];
-	readonly timeout: number | undefined;
-};
-
 export async function runSkill(
 	input: RunSkillInput,
 	deps: RunSkillDeps,
@@ -62,7 +57,7 @@ export async function runSkill(
 	}
 
 	const skill = findResult.value;
-	const configResult = resolveSkillExecution(skill, input.action);
+	const configResult = resolveTemplateExecution(skill, input.action);
 	if (!configResult.ok) {
 		return configResult;
 	}
@@ -70,57 +65,9 @@ export async function runSkill(
 	return executeSkill(skill, configResult.value, input, deps);
 }
 
-function resolveSkillExecution(
-	skill: Skill,
-	action: string | undefined,
-): Result<SkillExecutionConfig, DomainError> {
-	const hasActions = skill.metadata.actions !== undefined;
-
-	if (hasActions && !action) {
-		return err(
-			executionError(
-				`Skill "${skill.metadata.name}" has actions defined. Specify an action to run.`,
-			),
-		);
-	}
-
-	if (!action) {
-		return ok({
-			inputs: skill.metadata.inputs,
-			content: skill.body.content,
-			codeBlocks: skill.body.extractCodeBlocks("bash"),
-			timeout: skill.metadata.timeout,
-		});
-	}
-
-	const actions = skill.metadata.actions;
-	if (!actions) {
-		return err(executionError(`Skill "${skill.metadata.name}" does not define actions.`));
-	}
-
-	const actionDef = actions[action];
-	if (!actionDef) {
-		return err(executionError(`Action "${action}" not found in skill "${skill.metadata.name}".`));
-	}
-
-	const config = resolveActionConfig(actionDef, skill.metadata);
-
-	const sectionContent = skill.body.extractActionSection(action);
-	if (!sectionContent) {
-		return err(executionError(`Action section "action:${action}" not found in skill body.`));
-	}
-
-	return ok({
-		inputs: config.inputs,
-		content: sectionContent,
-		codeBlocks: skill.body.extractActionCodeBlocks(action, "bash"),
-		timeout: config.timeout,
-	});
-}
-
 async function executeSkill(
 	skill: Skill,
-	config: SkillExecutionConfig,
+	config: TemplateExecutionConfig,
 	input: RunSkillInput,
 	deps: RunSkillDeps,
 ): Promise<Result<RunOutput, DomainError>> {

--- a/tests/core/skill/skill-execution-resolver.test.ts
+++ b/tests/core/skill/skill-execution-resolver.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { parseSkill } from "../../../src/core/skill/skill";
+import {
+	resolveAgentExecution,
+	resolveTemplateExecution,
+} from "../../../src/core/skill/skill-execution-resolver";
+import { domainErrorMessage } from "../../../src/core/types/errors";
+
+function buildSkillRaw(frontmatter: string, body: string): string {
+	return `---\n${frontmatter}\n---\n${body}`;
+}
+
+const simpleSkill = buildSkillRaw(
+	[
+		"name: test-skill",
+		'description: "A test skill"',
+		"mode: agent",
+		"inputs:",
+		'  - { name: "target", type: "text", message: "Target?" }',
+		"tools: [bash, read]",
+		"context:",
+		'  - { type: "file", path: "README.md" }',
+		"timeout: 60000",
+	].join("\n"),
+	"\n# Test Skill\n\nDo something with {{target}}\n\n```bash\necho hello\n```\n",
+);
+
+const actionSkill = buildSkillRaw(
+	[
+		"name: multi-action",
+		'description: "Multi action skill"',
+		"mode: agent",
+		"tools: [bash]",
+		"actions:",
+		"  deploy:",
+		'    description: "Deploy"',
+		"    inputs:",
+		'      - { name: "env", type: "text", message: "Env?" }',
+		"    tools: [bash, write]",
+		"    context:",
+		'      - { type: "file", path: "deploy.md" }',
+		"    timeout: 30000",
+		"  test:",
+		'    description: "Test"',
+		"    mode: template",
+	].join("\n"),
+	[
+		"",
+		"## action:deploy",
+		"",
+		"Deploy to {{env}}",
+		"",
+		"```bash",
+		"deploy --env {{env}}",
+		"```",
+		"",
+		"## action:test",
+		"",
+		"Run tests",
+		"",
+		"```bash",
+		"npm test",
+		"```",
+	].join("\n"),
+);
+
+function parseTestSkill(raw: string) {
+	const result = parseSkill(raw, "/test/SKILL.md");
+	if (!result.ok) throw new Error("Failed to parse skill");
+	return result.value;
+}
+
+describe("resolveAgentExecution", () => {
+	it("アクション未指定時はスキルレベルの設定を返す", () => {
+		const skill = parseTestSkill(simpleSkill);
+		const result = resolveAgentExecution(skill, undefined);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.inputs).toStrictEqual(skill.metadata.inputs);
+		expect(result.value.tools).toStrictEqual(["bash", "read"]);
+		expect(result.value.context).toStrictEqual([{ type: "file", path: "README.md" }]);
+		expect(result.value.content).toContain("Do something with {{target}}");
+	});
+
+	it("アクション指定時はアクションの設定を返す", () => {
+		const skill = parseTestSkill(actionSkill);
+		const result = resolveAgentExecution(skill, "deploy");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.inputs).toStrictEqual([{ name: "env", type: "text", message: "Env?" }]);
+		expect(result.value.tools).toStrictEqual(["bash", "write"]);
+		expect(result.value.context).toStrictEqual([{ type: "file", path: "deploy.md" }]);
+		expect(result.value.content).toContain("Deploy to {{env}}");
+	});
+
+	it("存在しないアクション名でエラーを返す", () => {
+		const skill = parseTestSkill(actionSkill);
+		const result = resolveAgentExecution(skill, "nonexistent");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(domainErrorMessage(result.error)).toContain("nonexistent");
+	});
+});
+
+describe("resolveTemplateExecution", () => {
+	it("アクション未指定時はスキルレベルの設定を返す", () => {
+		const skill = parseTestSkill(simpleSkill);
+		const result = resolveTemplateExecution(skill, undefined);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.inputs).toStrictEqual(skill.metadata.inputs);
+		expect(result.value.content).toContain("Do something with {{target}}");
+		expect(result.value.codeBlocks.length).toBe(1);
+		expect(result.value.timeout).toBe(60000);
+	});
+
+	it("アクション指定時はアクションの設定を返す", () => {
+		const skill = parseTestSkill(actionSkill);
+		const result = resolveTemplateExecution(skill, "deploy");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.inputs).toStrictEqual([{ name: "env", type: "text", message: "Env?" }]);
+		expect(result.value.content).toContain("Deploy to {{env}}");
+		expect(result.value.codeBlocks.length).toBe(1);
+		expect(result.value.timeout).toBe(30000);
+	});
+
+	it("アクション定義済みスキルでアクション未指定時はエラーを返す", () => {
+		const skill = parseTestSkill(actionSkill);
+		const result = resolveTemplateExecution(skill, undefined);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(domainErrorMessage(result.error)).toContain("has actions defined");
+	});
+
+	it("存在しないアクション名でエラーを返す", () => {
+		const skill = parseTestSkill(actionSkill);
+		const result = resolveTemplateExecution(skill, "nonexistent");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(domainErrorMessage(result.error)).toContain("nonexistent");
+	});
+});


### PR DESCRIPTION
#### 概要

Skill の内部構造（metadata, body）への深いアクセスを `resolveSkillConfig()` に集約し、デメテルの法則違反を解消。

#### 変更内容

- `src/core/skill/resolve-skill-config.ts` を新規作成。`resolveSkillConfig(skill, actionName?)` で Skill のメタデータとボディから実行設定を一括解決
- `run-agent-skill.ts` の `resolveActionForAgent()` と `resolved?.inputs ?? skill.metadata.inputs` パターンを `resolveSkillConfig()` に置き換え
- `run-skill.ts` の `resolveSkillExecution()` を `resolveSkillConfig()` に置き換え
- `resolveSkillConfig` のユニットテストを追加

Closes #386