### PR TITLE
refactor: expose skipped files in grep-tool instead of silently swallowing errors

### DIFF
--- a/src/core/execution/tools/grep-tool.ts
+++ b/src/core/execution/tools/grep-tool.ts
@@ -15,17 +15,28 @@ export const grepParams = z.object({
 
 type GrepInput = z.infer<typeof grepParams>;
 
+type SkippedFile = {
+	readonly file: string;
+	readonly reason: string;
+};
+
 type GrepResult = {
 	readonly matches: string;
 	readonly count: number;
 	readonly truncated: boolean;
+	readonly skipped: readonly SkippedFile[];
+};
+
+type ResolveResult = {
+	readonly files: readonly string[];
+	readonly skipped: readonly SkippedFile[];
 };
 
 async function resolveSearchFiles(
 	searchPath: string,
 	include: string | undefined,
 	cwd: string,
-): Promise<readonly string[]> {
+): Promise<ResolveResult> {
 	const fullPath = resolve(cwd, searchPath);
 	let fileStat: Stats;
 	try {
@@ -35,19 +46,27 @@ async function resolveSearchFiles(
 	}
 
 	if (fileStat.isFile()) {
-		return [searchPath];
+		return { files: [searchPath], skipped: [] };
 	}
 
 	const globPattern = include ?? "**/*";
 	const files: string[] = [];
+	const skipped: SkippedFile[] = [];
 	for await (const entry of fsGlob(globPattern, { cwd: fullPath })) {
 		const entryPath = join(searchPath, entry);
-		const entryStat = await stat(resolve(cwd, entryPath)).catch(() => undefined);
-		if (entryStat?.isFile()) {
-			files.push(entryPath);
+		try {
+			const entryStat = await stat(resolve(cwd, entryPath));
+			if (entryStat.isFile()) {
+				files.push(entryPath);
+			}
+		} catch (error) {
+			skipped.push({
+				file: entryPath,
+				reason: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
-	return files;
+	return { files, skipped };
 }
 
 function searchFileContent(
@@ -77,8 +96,9 @@ export const grepTool: Tool<GrepInput, GrepResult> = {
 		// （g フラグ付きの場合 lastIndex が更新され、同じ文字列への連続 test() で結果が変わる）
 		const regex = new RegExp(pattern);
 
-		const files = await resolveSearchFiles(searchPath, include, cwd);
+		const { files, skipped: resolveSkipped } = await resolveSearchFiles(searchPath, include, cwd);
 
+		const readSkipped: SkippedFile[] = [];
 		const results: string[] = [];
 		for (const file of files) {
 			if (results.length >= MAX_GREP_MATCHES) break;
@@ -86,8 +106,11 @@ export const grepTool: Tool<GrepInput, GrepResult> = {
 			try {
 				const content = await readFile(fullFilePath, "utf-8");
 				searchFileContent(content, regex, file, results, MAX_GREP_MATCHES);
-			} catch {
-				// Skip unreadable files (binary, permission denied, etc.)
+			} catch (error) {
+				readSkipped.push({
+					file,
+					reason: error instanceof Error ? error.message : String(error),
+				});
 			}
 		}
 
@@ -95,6 +118,7 @@ export const grepTool: Tool<GrepInput, GrepResult> = {
 			matches: results.join("\n"),
 			count: results.length,
 			truncated: results.length >= MAX_GREP_MATCHES,
+			skipped: [...resolveSkipped, ...readSkipped],
 		};
 	},
 };

--- a/tests/core/execution/grep-tool.test.ts
+++ b/tests/core/execution/grep-tool.test.ts
@@ -1,0 +1,99 @@
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { grepTool } from "../../../src/core/execution/tools/grep-tool";
+
+const TEST_DIR = resolve(import.meta.dirname, "__grep-tool-fixture__");
+
+beforeEach(async () => {
+	await mkdir(TEST_DIR, { recursive: true });
+});
+
+afterEach(async () => {
+	await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+type GrepResult = {
+	readonly matches: string;
+	readonly count: number;
+	readonly truncated: boolean;
+	readonly skipped: readonly { readonly file: string; readonly reason: string }[];
+};
+
+async function execute(args: {
+	pattern: string;
+	path?: string;
+	include?: string;
+}): Promise<GrepResult> {
+	const originalCwd = process.cwd;
+	process.cwd = () => TEST_DIR;
+	try {
+		const result = await grepTool.execute?.(args, {
+			toolCallId: "test",
+			messages: [],
+			abortSignal: new AbortController().signal,
+		});
+		if (!result || Symbol.asyncIterator in Object(result)) {
+			throw new Error("Unexpected result type");
+		}
+		return result as GrepResult;
+	} finally {
+		process.cwd = originalCwd;
+	}
+}
+
+describe("grepTool", () => {
+	test("returns matching lines with file path and line number", async () => {
+		await writeFile(join(TEST_DIR, "hello.txt"), "hello world\nfoo bar\nhello again");
+
+		const result = await execute({ pattern: "hello", path: "hello.txt" });
+
+		expect(result.count).toBe(2);
+		expect(result.matches).toContain("hello.txt:1:hello world");
+		expect(result.matches).toContain("hello.txt:3:hello again");
+		expect(result.skipped).toEqual([]);
+	});
+
+	test("returns empty skipped array when all files are readable", async () => {
+		await writeFile(join(TEST_DIR, "a.ts"), "const x = 1;");
+
+		const result = await execute({ pattern: "const", path: "." });
+
+		expect(result.skipped).toEqual([]);
+		expect(result.count).toBe(1);
+	});
+
+	test("tracks skipped files when readFile fails", async () => {
+		await writeFile(join(TEST_DIR, "good.txt"), "match this line");
+		await symlink(join(TEST_DIR, "nonexistent-target"), join(TEST_DIR, "broken-link.txt"));
+
+		const result = await execute({ pattern: "match", path: "." });
+
+		expect(result.count).toBe(1);
+		expect(result.skipped.length).toBeGreaterThanOrEqual(1);
+		const hasbrokenLink = result.skipped.some((s: { readonly file: string }) =>
+			s.file.includes("broken-link.txt"),
+		);
+		expect(hasbrokenLink).toBe(true);
+		const allHaveReasons = result.skipped.every(
+			(s: { readonly reason: string }) => s.reason.length > 0,
+		);
+		expect(allHaveReasons).toBe(true);
+	});
+
+	test("throws when path does not exist", async () => {
+		await expect(execute({ pattern: "foo", path: "nonexistent" })).rejects.toThrow(
+			"Path not found: nonexistent",
+		);
+	});
+
+	test("returns truncated flag when matches exceed limit", async () => {
+		const lines = Array.from({ length: 600 }, (_, i) => `line${i}`).join("\n");
+		await writeFile(join(TEST_DIR, "big.txt"), lines);
+
+		const result = await execute({ pattern: "line", path: "big.txt" });
+
+		expect(result.truncated).toBe(true);
+		expect(result.count).toBe(500);
+	});
+});


### PR DESCRIPTION
#### 概要

grep-tool の stat() と readFile() で発生するエラーを silent に swallow していた問題を修正し、スキップされたファイル情報を GrepResult に含めて呼び出し元に通知するようにした。

#### 変更内容

- `SkippedFile` 型と `ResolveResult` 型を追加
- `GrepResult` に `skipped` フィールドを追加（スキップされたファイルとその理由を記録）
- `resolveSearchFiles` 内の `stat()` エラーをキャッチしてスキップ情報として蓄積
- `execute` 内の `readFile()` エラーをキャッチしてスキップ情報として蓄積
- grep-tool のユニットテストを追加（5テストケース）

Closes #387