### PR TITLE
refactor: separate BuildToolsOptions into individual parameters

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -29,7 +29,7 @@ async function executeAgentLoop(
 	logger: Logger,
 ): ReturnType<AgentExecutorPort["execute"]> {
 	const startTime = Date.now();
-	const toolsResult = buildTools(input.toolNames, input.buildToolsOptions);
+	const toolsResult = buildTools(input.toolNames, input.taskpRunDeps, input.toolDescriptions);
 	if (!toolsResult.ok) {
 		return toolsResult;
 	}

--- a/src/core/execution/agent-loop.ts
+++ b/src/core/execution/agent-loop.ts
@@ -2,7 +2,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { stepCountIs, streamText } from "ai";
 import { type ExecutionError, executionError } from "../types/errors";
 import { err, ok, type Result } from "../types/result";
-import type { BuildToolsOptions } from "./agent-tools";
+import type { TaskpRunDeps, ToolDescriptions } from "./agent-tools";
 import { buildTools } from "./agent-tools";
 
 // エージェントの無限ループを防ぐための安全装置。
@@ -19,7 +19,8 @@ export type AgentLoopInput = {
 	readonly systemPrompt: string;
 	readonly context: string;
 	readonly toolNames: readonly string[];
-	readonly buildToolsOptions?: BuildToolsOptions;
+	readonly taskpRunDeps?: TaskpRunDeps;
+	readonly toolDescriptions?: ToolDescriptions;
 };
 
 export function createAgentLoop() {
@@ -32,7 +33,7 @@ export function createAgentLoop() {
 async function executeAgentLoop(
 	input: AgentLoopInput,
 ): Promise<Result<AgentLoopResult, ExecutionError>> {
-	const toolsResult = buildTools(input.toolNames, input.buildToolsOptions);
+	const toolsResult = buildTools(input.toolNames, input.taskpRunDeps, input.toolDescriptions);
 	if (!toolsResult.ok) {
 		return toolsResult;
 	}

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -82,32 +82,28 @@ export function getPrimaryArgKey(toolName: string): string | undefined {
 	return PRIMARY_ARG_KEYS[toolName as ToolName];
 }
 
-export type DescriptionOverrides = Readonly<Record<string, string>>;
-
-export type BuildToolsOptions = {
-	readonly taskpRunDeps?: TaskpRunDeps;
-	readonly descriptionOverrides?: DescriptionOverrides;
-};
+export type ToolDescriptions = Readonly<Record<string, string>>;
 
 export function buildTools(
 	toolNames: readonly string[],
-	options?: BuildToolsOptions,
+	taskpRunDeps?: TaskpRunDeps,
+	toolDescriptions?: ToolDescriptions,
 ): Result<ToolSet, ExecutionError> {
 	const tools: ToolSet = {};
 	for (const name of toolNames) {
 		if (name === "taskp_run") {
-			if (!options?.taskpRunDeps) {
-				return err(executionError("taskp_run requires taskpRunDeps in BuildToolsOptions"));
+			if (!taskpRunDeps) {
+				return err(executionError("taskp_run requires taskpRunDeps"));
 			}
-			const description = options.descriptionOverrides?.taskp_run ?? TASKP_RUN_DEFAULT_DESCRIPTION;
-			tools[name] = createTaskpRunTool(options.taskpRunDeps, description);
+			const description = toolDescriptions?.taskp_run ?? TASKP_RUN_DEFAULT_DESCRIPTION;
+			tools[name] = createTaskpRunTool(taskpRunDeps, description);
 			continue;
 		}
 		const t = staticTools[name];
 		if (t === undefined) {
 			return err(executionError(`Unknown tool: ${name}`));
 		}
-		const override = options?.descriptionOverrides?.[name];
+		const override = toolDescriptions?.[name];
 		tools[name] = override ? { ...t, description: override } : t;
 	}
 	return ok(tools);

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -3,10 +3,9 @@
 export type { AgentLoopInput, AgentLoopResult } from "./agent-loop.js";
 export { createAgentLoop } from "./agent-loop.js";
 export type {
-	BuildToolsOptions,
-	DescriptionOverrides,
 	TaskpRunDeps,
 	TaskpRunResult,
+	ToolDescriptions,
 	ToolName,
 } from "./agent-tools.js";
 export { buildTaskpRunDescription, buildTools, TOOL_NAMES } from "./agent-tools.js";

--- a/src/usecase/port/agent-executor.ts
+++ b/src/usecase/port/agent-executor.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import type { BuildToolsOptions } from "../../core/execution/agent-tools";
+import type { TaskpRunDeps, ToolDescriptions } from "../../core/execution/agent-tools";
 import type { ContentPart } from "../../core/execution/content-part";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
@@ -10,7 +10,8 @@ export type AgentExecutorInput = {
 	readonly contentParts: readonly ContentPart[];
 	readonly toolNames: readonly string[];
 	readonly maxSteps: number;
-	readonly buildToolsOptions?: BuildToolsOptions;
+	readonly taskpRunDeps?: TaskpRunDeps;
+	readonly toolDescriptions?: ToolDescriptions;
 };
 
 export type AgentExecutorResult = {

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -123,7 +123,7 @@ export async function runAgentSkill(
 	// （コンテキスト収集時間は含めない — hooks に渡す情報として実行コストを正確に反映するため）
 	const startTime = Date.now();
 
-	const descriptionOverrides = await buildDescriptionOverrides(
+	const toolDescriptions = await buildToolDescriptions(
 		toolNames,
 		deps.skillRepository,
 		skill.metadata.name,
@@ -135,7 +135,7 @@ export async function runAgentSkill(
 		contentParts,
 		toolNames,
 		maxSteps: MAX_STEPS,
-		buildToolsOptions: descriptionOverrides ? { descriptionOverrides } : undefined,
+		toolDescriptions,
 	});
 
 	const durationMs = Date.now() - startTime;
@@ -247,7 +247,7 @@ function toContentParts(contexts: readonly CollectedContext[]): readonly Content
 	return contexts.map(toContentPart);
 }
 
-async function buildDescriptionOverrides(
+async function buildToolDescriptions(
 	toolNames: readonly string[],
 	skillRepository: SkillRepository,
 	currentSkillName: string,

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -616,20 +616,16 @@ describe("fetch tool execute", () => {
 	});
 });
 
-describe("buildTools with descriptionOverrides", () => {
+describe("buildTools with toolDescriptions", () => {
 	it("指定したツールの description を上書きする", () => {
-		const result = buildTools(["bash"], {
-			descriptionOverrides: { bash: "Custom bash description" },
-		});
+		const result = buildTools(["bash"], undefined, { bash: "Custom bash description" });
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.bash.description).toBe("Custom bash description");
 	});
 
 	it("上書き対象外のツールは元の description を維持する", () => {
-		const result = buildTools(["bash", "read"], {
-			descriptionOverrides: { bash: "Overridden" },
-		});
+		const result = buildTools(["bash", "read"], undefined, { bash: "Overridden" });
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.bash.description).toBe("Overridden");

--- a/tests/core/execution/taskp-run-tool.test.ts
+++ b/tests/core/execution/taskp-run-tool.test.ts
@@ -139,7 +139,7 @@ function createDeps(skills: readonly Skill[], callStack?: readonly string[]): Ta
 }
 
 function unwrapTaskpRun(deps: TaskpRunDeps) {
-	const result = buildTools(["taskp_run"], { taskpRunDeps: deps });
+	const result = buildTools(["taskp_run"], deps);
 	if (!result.ok) throw new Error(`buildTools failed: ${result.error.message}`);
 	return result.value.taskp_run;
 }
@@ -162,7 +162,7 @@ describe("buildTools with taskp_run", () => {
 
 	it("taskpRunDeps ありで taskp_run を構築できる", () => {
 		const deps = createDeps([]);
-		const result = buildTools(["taskp_run"], { taskpRunDeps: deps });
+		const result = buildTools(["taskp_run"], deps);
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(result.value.taskp_run).toBeDefined();
@@ -171,7 +171,7 @@ describe("buildTools with taskp_run", () => {
 
 	it("taskp_run と他のツールを同時に構築できる", () => {
 		const deps = createDeps([]);
-		const result = buildTools(["bash", "taskp_run"], { taskpRunDeps: deps });
+		const result = buildTools(["bash", "taskp_run"], deps);
 		expect(result.ok).toBe(true);
 		if (!result.ok) return;
 		expect(Object.keys(result.value)).toEqual(["bash", "taskp_run"]);


### PR DESCRIPTION
#### 概要

BuildToolsOptions の混在する関心事を分離し、buildTools 関数のシグネチャを明確化。

#### 変更内容

- `BuildToolsOptions` と `DescriptionOverrides` 型を削除
- `buildTools` の引数を個別パラメータに分離: `(toolNames, taskpRunDeps?, toolDescriptions?)`
- `ToolDescriptions` 型エイリアスを追加
- 全呼び出し元・テストを更新

Closes #388