### PR TITLE
docs: add JSDoc for lang parameter defaults in SkillBody interface

### DIFF
--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -10,8 +10,15 @@ export interface CodeBlock {
 
 export interface SkillBody {
 	readonly content: string;
+	/**
+	 * @param lang - Code language filter (defaults to "bash")
+	 */
 	readonly extractCodeBlocks: (lang?: string) => readonly CodeBlock[];
 	readonly extractActionSection: (name: string) => string | undefined;
+	/**
+	 * @param name - Action name
+	 * @param lang - Code language filter (defaults to "bash")
+	 */
 	readonly extractActionCodeBlocks: (name: string, lang?: string) => readonly CodeBlock[];
 }
 


### PR DESCRIPTION
#### 概要

SkillBody インターフェースの `extractCodeBlocks` と `extractActionCodeBlocks` メソッドに JSDoc コメントを追加し、`lang` パラメータのデフォルト値 `"bash"` を明示化。

#### 変更内容

- `extractCodeBlocks` に `@param lang` の JSDoc を追加（defaults to "bash"）
- `extractActionCodeBlocks` に `@param name`, `@param lang` の JSDoc を追加（defaults to "bash"）

Closes #389