### PR TITLE
refactor: return Result from extractActionSection instead of string | undefined

### DIFF
--- a/src/core/skill/skill-body.ts
+++ b/src/core/skill/skill-body.ts
@@ -1,5 +1,9 @@
 import remarkParse from "remark-parse";
 import { unified } from "unified";
+import type { DomainError } from "../types/errors";
+import { executionError } from "../types/errors";
+import type { Result } from "../types/result";
+import { err, ok } from "../types/result";
 import type { ActionSection } from "./action-section-parser";
 import { getActionSection, parseActionSections } from "./action-section-parser";
 
@@ -14,7 +18,7 @@ export interface SkillBody {
 	 * @param lang - Code language filter (defaults to "bash")
 	 */
 	readonly extractCodeBlocks: (lang?: string) => readonly CodeBlock[];
-	readonly extractActionSection: (name: string) => string | undefined;
+	readonly extractActionSection: (name: string) => Result<string, DomainError>;
 	/**
 	 * @param name - Action name
 	 * @param lang - Code language filter (defaults to "bash")
@@ -35,9 +39,12 @@ export function createSkillBody(content: string): SkillBody {
 	return {
 		content,
 		extractCodeBlocks: (lang = "bash") => extractCodeBlocks(content, lang),
-		extractActionSection: (name: string) => {
+		extractActionSection: (name: string): Result<string, DomainError> => {
 			const section = getActionSection(getSections(), name);
-			return section?.content;
+			if (!section) {
+				return err(executionError(`Action section "## action:${name}" not found in skill body`));
+			}
+			return ok(section.content);
 		},
 		extractActionCodeBlocks: (name: string, lang = "bash") => {
 			const section = getActionSection(getSections(), name);

--- a/src/core/skill/skill-execution-resolver.ts
+++ b/src/core/skill/skill-execution-resolver.ts
@@ -48,20 +48,16 @@ export function resolveAgentExecution(
 
 	const config = resolveActionConfig(actions[actionName], skill.metadata);
 
-	const sectionContent = skill.body.extractActionSection(actionName);
-	if (!sectionContent) {
-		return err(
-			executionError(
-				`Action section "## action:${actionName}" not found in skill "${skill.metadata.name}"`,
-			),
-		);
+	const sectionResult = skill.body.extractActionSection(actionName);
+	if (!sectionResult.ok) {
+		return sectionResult;
 	}
 
 	return ok({
 		inputs: config.inputs,
 		tools: config.tools,
 		context: config.context,
-		content: sectionContent,
+		content: sectionResult.value,
 	});
 }
 
@@ -106,14 +102,14 @@ export function resolveTemplateExecution(
 
 	const config = resolveActionConfig(actionDef, skill.metadata);
 
-	const sectionContent = skill.body.extractActionSection(actionName);
-	if (!sectionContent) {
-		return err(executionError(`Action section "action:${actionName}" not found in skill body.`));
+	const sectionResult = skill.body.extractActionSection(actionName);
+	if (!sectionResult.ok) {
+		return sectionResult;
 	}
 
 	return ok({
 		inputs: config.inputs,
-		content: sectionContent,
+		content: sectionResult.value,
 		codeBlocks: skill.body.extractActionCodeBlocks(actionName, "bash"),
 		timeout: config.timeout,
 	});

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -661,7 +661,10 @@ function createSkillFixture(overrides: {
 		body: {
 			content: "",
 			extractCodeBlocks: () => [],
-			extractActionSection: () => undefined,
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+			}),
 			extractActionCodeBlocks: () => [],
 		},
 		location: `/skills/${overrides.name}/SKILL.md`,

--- a/tests/unit/skill/skill-body.test.ts
+++ b/tests/unit/skill/skill-body.test.ts
@@ -129,18 +129,20 @@ describe("extractCodeBlocks", () => {
 describe("extractActionSection", () => {
 	it("指定アクション名のセクション内容を返す", () => {
 		const body = createSkillBody(withActionSections());
-		const content = body.extractActionSection("add");
+		const result = body.extractActionSection("add");
 
-		expect(content).toBeDefined();
-		expect(content).toContain("Add something.");
-		expect(content).toContain("echo add");
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toContain("Add something.");
+			expect(result.value).toContain("echo add");
+		}
 	});
 
-	it("存在しないアクション名は undefined を返す", () => {
+	it("存在しないアクション名はエラーを返す", () => {
 		const body = createSkillBody(withActionSections());
-		const content = body.extractActionSection("nonexistent");
+		const result = body.extractActionSection("nonexistent");
 
-		expect(content).toBeUndefined();
+		expect(result.ok).toBe(false);
 	});
 });
 

--- a/tests/usecase/init-skill.test.ts
+++ b/tests/usecase/init-skill.test.ts
@@ -34,7 +34,10 @@ function makeSkill(name: string): Skill {
 		body: {
 			content: "",
 			extractCodeBlocks: () => [],
-			extractActionSection: () => undefined,
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+			}),
 			extractActionCodeBlocks: () => [],
 		},
 		location: `.taskp/skills/${name}/SKILL.md`,

--- a/tests/usecase/list-skills.test.ts
+++ b/tests/usecase/list-skills.test.ts
@@ -18,7 +18,10 @@ function createSkill(name: string, scope: SkillScope): Skill {
 		body: {
 			content: `# ${name}`,
 			extractCodeBlocks: () => [],
-			extractActionSection: () => undefined,
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+			}),
 			extractActionCodeBlocks: () => [],
 		},
 		location:

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -27,7 +27,10 @@ function createAgentSkill(overrides?: Partial<Skill["metadata"]>): Skill {
 		body: {
 			content: "You are a helpful assistant.",
 			extractCodeBlocks: () => [],
-			extractActionSection: () => undefined,
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+			}),
 			extractActionCodeBlocks: () => [],
 		},
 		location: "/tmp/test",
@@ -435,7 +438,13 @@ describe("runAgentSkill", () => {
 							review: "## action:review\n\nReview the code in {{target}}.",
 							analyze: "## action:analyze\n\nAnalyze the codebase.",
 						};
-						return sections[name];
+						const content = sections[name];
+						if (!content)
+							return {
+								ok: false as const,
+								error: { type: "EXECUTION_ERROR" as const, message: `not found: ${name}` },
+							};
+						return { ok: true as const, value: content };
 					},
 					extractActionCodeBlocks: () => [],
 				},
@@ -565,7 +574,10 @@ describe("runAgentSkill", () => {
 				body: {
 					content: "No action sections here.",
 					extractCodeBlocks: () => [],
-					extractActionSection: () => undefined,
+					extractActionSection: () => ({
+						ok: false,
+						error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+					}),
 					extractActionCodeBlocks: () => [],
 				},
 				location: "/tmp/test",
@@ -629,7 +641,10 @@ describe("runAgentSkill", () => {
 				body: {
 					content: "# 画像分析\n\n提供された画像を分析してください。\n",
 					extractCodeBlocks: () => [],
-					extractActionSection: () => undefined,
+					extractActionSection: () => ({
+						ok: false,
+						error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+					}),
 					extractActionCodeBlocks: () => [],
 				},
 				location: "/tmp/skills/analyze-image/SKILL.md",

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -40,7 +40,10 @@ function createSkill(overrides: Partial<Skill["metadata"]> = {}): Skill {
 		body: {
 			content: "# deploy",
 			extractCodeBlocks: () => [],
-			extractActionSection: () => undefined,
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR" as const, message: "not found" },
+			}),
 			extractActionCodeBlocks: () => [],
 		},
 		location: "/project/.taskp/skills/deploy/SKILL.md",


### PR DESCRIPTION
#### 概要

extractActionSection の戻り値を string | undefined から Result<string, DomainError> に変更し、Parse Don't Validate 原則に従ったリファクタリング。

#### 変更内容

- extractActionSection が Result<string, DomainError> を返すように変更
- skill-execution-resolver.ts の重複した null チェックとエラーメッセージを削除し、Result をそのまま伝播
- エラーメッセージを単一箇所（skill-body.ts）に統一

Closes #391