### PR TITLE
fix: bash-tool のコマンドインジェクション脆弱性を修正

### DIFF
--- a/src/core/execution/tools/bash-tool.ts
+++ b/src/core/execution/tools/bash-tool.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "ai";
 import { execa } from "execa";
 import { z } from "zod";
+import { validateCommand } from "./command-validator";
 import { zodToJsonSchema } from "./schema-helper";
 import { type ToolResult, toolFailure, toolSuccess } from "./tool-output";
 
@@ -19,6 +20,11 @@ export const bashTool: Tool<BashInput, ToolResult<BashData>> = {
 	description: "Run a shell command and return stdout/stderr",
 	inputSchema: zodToJsonSchema(bashParams),
 	execute: async ({ command, cwd, timeout }): Promise<ToolResult<BashData>> => {
+		const validationError = validateCommand(command);
+		if (validationError) {
+			return toolFailure(validationError);
+		}
+
 		try {
 			const result = await execa(command, {
 				shell: true,

--- a/src/core/execution/tools/command-validator.ts
+++ b/src/core/execution/tools/command-validator.ts
@@ -1,0 +1,14 @@
+/**
+ * シェルコマンドインジェクション検出用のパターン。
+ * $(...) / `...` / ${...} によるコマンド置換・パラメータ展開を検出する。
+ */
+const COMMAND_SUBSTITUTION_PATTERN = /\$\(|\$\{|`/;
+
+/** コマンド文字列に危険なシェル展開パターンが含まれていないかを検証する。 */
+export function validateCommand(command: string): string | undefined {
+	if (COMMAND_SUBSTITUTION_PATTERN.test(command)) {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: describing literal shell syntax
+		return "Command contains shell expansion patterns ($(...), ${...}, or backticks) which are not allowed";
+	}
+	return undefined;
+}

--- a/tests/core/execution/command-validator.test.ts
+++ b/tests/core/execution/command-validator.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { validateCommand } from "../../../src/core/execution/tools/command-validator";
+
+describe("validateCommand", () => {
+	it("rejects $(...) command substitution", () => {
+		expect(validateCommand("echo $(whoami)")).toBeDefined();
+	});
+
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: describing literal shell syntax
+	it("rejects ${...} parameter expansion", () => {
+		expect(validateCommand("echo $\x7BHOME}")).toBeDefined();
+	});
+
+	it("rejects backtick command substitution", () => {
+		expect(validateCommand("echo `whoami`")).toBeDefined();
+	});
+
+	it("rejects nested $(...) patterns", () => {
+		expect(validateCommand("cat $(echo $(pwd)/file)")).toBeDefined();
+	});
+
+	it("allows simple commands", () => {
+		expect(validateCommand("ls -la")).toBeUndefined();
+	});
+
+	it("allows pipes", () => {
+		expect(validateCommand("cat file.txt | grep pattern")).toBeUndefined();
+	});
+
+	it("allows redirects", () => {
+		expect(validateCommand("echo hello > output.txt")).toBeUndefined();
+	});
+
+	it("allows environment variable references with $VAR (no braces)", () => {
+		expect(validateCommand("echo $HOME")).toBeUndefined();
+	});
+
+	it("allows && and || chaining", () => {
+		expect(validateCommand("mkdir -p dir && cd dir")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
#### 概要

bash-tool.ts の `shell: true` 使用時にコマンドインジェクションが可能な脆弱性を修正。

#### 変更内容

- `command-validator.ts` を新規追加: `$(...)`, `${...}`, バッククォートを検出・拒否する `validateCommand` 関数
- `bash-tool.ts`: コマンド実行前に `validateCommand` でバリデーションを実施
- `command-validator.test.ts`: 拒否・許可パターンのユニットテスト追加

Closes #392