### PR TITLE
refactor: FormControllerの責任をFocusManager・ValueStore・RenderStateManagerに分離

### DIFF
--- a/src/tui/screens/form/focus-manager.ts
+++ b/src/tui/screens/form/focus-manager.ts
@@ -1,0 +1,40 @@
+import type { FormElement } from "./form-element";
+
+class FocusManager {
+	private focusIndex = 0;
+	private elements: readonly FormElement[] = [];
+
+	setElements(elements: readonly FormElement[]): void {
+		this.elements = elements;
+	}
+
+	get currentIndex(): number {
+		return this.focusIndex;
+	}
+
+	get elementCount(): number {
+		return this.elements.length;
+	}
+
+	isAtLast(): boolean {
+		return this.focusIndex >= this.elements.length - 1;
+	}
+
+	moveNext(): boolean {
+		if (this.isAtLast()) return false;
+		this.focusIndex++;
+		return true;
+	}
+
+	movePrevious(): boolean {
+		if (this.focusIndex <= 0) return false;
+		this.focusIndex--;
+		return true;
+	}
+
+	focusCurrent(): void {
+		this.elements[this.focusIndex].element.focus();
+	}
+}
+
+export { FocusManager };

--- a/src/tui/screens/form/form-controller.ts
+++ b/src/tui/screens/form/form-controller.ts
@@ -1,0 +1,66 @@
+import { FocusManager } from "./focus-manager";
+import type { FormElement } from "./form-element";
+import { RenderStateManager } from "./render-state-manager";
+import { ValueStore } from "./value-store";
+
+class FormController {
+	private readonly focusManager: FocusManager;
+	private readonly valueStore: ValueStore;
+	private readonly renderState: RenderStateManager;
+	private elements: readonly FormElement[] = [];
+	private readonly onComplete: (result: Record<string, string>) => void;
+
+	constructor(onComplete: (result: Record<string, string>) => void) {
+		this.onComplete = onComplete;
+		this.focusManager = new FocusManager();
+		this.valueStore = new ValueStore();
+		this.renderState = new RenderStateManager(this.focusManager, this.valueStore);
+	}
+
+	setElements(elements: readonly FormElement[]): void {
+		this.elements = elements;
+		this.focusManager.setElements(elements);
+	}
+
+	advanceFocus(): void {
+		if (this.focusManager.isAtLast()) {
+			this.completeForm();
+			return;
+		}
+		this.focusManager.moveNext();
+		this.syncView();
+	}
+
+	moveFocusForward(): void {
+		if (!this.focusManager.moveNext()) return;
+		this.syncView();
+	}
+
+	retreatFocus(): void {
+		if (!this.focusManager.movePrevious()) return;
+		this.syncView();
+	}
+
+	setValue(name: string, value: string): void {
+		this.valueStore.set(name, value);
+		const el = this.elements.find((e) => e.input.name === name);
+		if (el) {
+			this.renderState.markCompleted(el);
+		}
+	}
+
+	applyFocus(): void {
+		this.syncView();
+	}
+
+	private syncView(): void {
+		this.renderState.updateLabels(this.elements);
+		this.focusManager.focusCurrent();
+	}
+
+	private completeForm(): void {
+		this.onComplete(this.valueStore.collect(this.elements));
+	}
+}
+
+export { FormController };

--- a/src/tui/screens/form/form-element.ts
+++ b/src/tui/screens/form/form-element.ts
@@ -1,0 +1,15 @@
+import type {
+	InputRenderable,
+	SelectRenderable,
+	TextareaRenderable,
+	TextRenderable,
+} from "@opentui/core";
+import type { SkillInput } from "../../../core/skill/skill-input";
+
+type FormElement = {
+	readonly input: SkillInput;
+	readonly label: TextRenderable;
+	readonly element: InputRenderable | SelectRenderable | TextareaRenderable;
+};
+
+export type { FormElement };

--- a/src/tui/screens/form/render-state-manager.ts
+++ b/src/tui/screens/form/render-state-manager.ts
@@ -1,0 +1,33 @@
+import { dim, green, t } from "@opentui/core";
+import type { FocusManager } from "./focus-manager";
+import type { FormElement } from "./form-element";
+import type { ValueStore } from "./value-store";
+
+class RenderStateManager {
+	private readonly focusManager: FocusManager;
+	private readonly valueStore: ValueStore;
+
+	constructor(focusManager: FocusManager, valueStore: ValueStore) {
+		this.focusManager = focusManager;
+		this.valueStore = valueStore;
+	}
+
+	updateLabels(elements: readonly FormElement[]): void {
+		for (let i = 0; i < elements.length; i++) {
+			const el = elements[i];
+			if (i === this.focusManager.currentIndex) {
+				el.label.content = t`${green("?")} ${el.input.message}`;
+			} else if (this.valueStore.has(el.input.name)) {
+				// 値が設定済みのラベルはそのまま維持
+			} else {
+				el.label.content = t`${dim("○")} ${el.input.message}`;
+			}
+		}
+	}
+
+	markCompleted(element: FormElement): void {
+		element.label.content = t`${green("✔")} ${element.input.message}`;
+	}
+}
+
+export { RenderStateManager };

--- a/src/tui/screens/form/value-store.ts
+++ b/src/tui/screens/form/value-store.ts
@@ -1,0 +1,29 @@
+import type { FormElement } from "./form-element";
+
+class ValueStore {
+	private readonly values: Record<string, string> = {};
+
+	set(name: string, value: string): void {
+		this.values[name] = value;
+	}
+
+	has(name: string): boolean {
+		return name in this.values;
+	}
+
+	collect(elements: readonly FormElement[]): Record<string, string> {
+		const result: Record<string, string> = {};
+		for (const { input } of elements) {
+			if (this.has(input.name)) {
+				result[input.name] = this.values[input.name];
+			} else if (input.default !== undefined) {
+				result[input.name] = String(input.default);
+			} else {
+				result[input.name] = "";
+			}
+		}
+		return result;
+	}
+}
+
+export { ValueStore };

--- a/src/tui/screens/input-form.ts
+++ b/src/tui/screens/input-form.ts
@@ -2,7 +2,6 @@ import {
 	BoxRenderable,
 	type CliRenderer,
 	dim,
-	green,
 	InputRenderable,
 	InputRenderableEvents,
 	type KeyEvent,
@@ -19,86 +18,11 @@ import type { SkillInput } from "../../core/skill/skill-input";
 import { KeyHelp } from "../components/key-help";
 import { flatSelectStyle } from "../components/styles";
 import { clearScreen } from "./clear-screen";
+import { FormController } from "./form/form-controller";
+import type { FormElement } from "./form/form-element";
 
 const CONTAINER_ID = "form-container";
 const TEXTAREA_DEFAULT_HEIGHT = 5;
-
-type FormElement = {
-	readonly input: SkillInput;
-	readonly label: TextRenderable;
-	readonly element: InputRenderable | SelectRenderable | TextareaRenderable;
-};
-
-class FormController {
-	private focusIndex = 0;
-	private readonly values: Record<string, string> = {};
-	private elements: readonly FormElement[] = [];
-	private readonly onComplete: (result: Record<string, string>) => void;
-
-	constructor(onComplete: (result: Record<string, string>) => void) {
-		this.onComplete = onComplete;
-	}
-
-	setElements(elements: readonly FormElement[]): void {
-		this.elements = elements;
-	}
-
-	advanceFocus(): void {
-		if (this.focusIndex < this.elements.length - 1) {
-			this.focusIndex++;
-			this.applyFocus();
-		} else {
-			this.completeForm();
-		}
-	}
-
-	moveFocusForward(): void {
-		if (this.focusIndex >= this.elements.length - 1) return;
-		this.focusIndex++;
-		this.applyFocus();
-	}
-
-	retreatFocus(): void {
-		if (this.focusIndex <= 0) return;
-		this.focusIndex--;
-		this.applyFocus();
-	}
-
-	setValue(name: string, value: string): void {
-		this.values[name] = value;
-		const el = this.elements.find((e) => e.input.name === name);
-		if (el) {
-			el.label.content = t`${green("✔")} ${el.input.message}`;
-		}
-	}
-
-	applyFocus(): void {
-		for (let i = 0; i < this.elements.length; i++) {
-			const el = this.elements[i];
-			if (i === this.focusIndex) {
-				el.label.content = t`${green("?")} ${el.input.message}`;
-			} else if (el.input.name in this.values) {
-			} else {
-				el.label.content = t`${dim("○")} ${el.input.message}`;
-			}
-		}
-		this.elements[this.focusIndex].element.focus();
-	}
-
-	private completeForm(): void {
-		const result: Record<string, string> = {};
-		for (const { input } of this.elements) {
-			if (input.name in this.values) {
-				result[input.name] = this.values[input.name];
-			} else if (input.default !== undefined) {
-				result[input.name] = String(input.default);
-			} else {
-				result[input.name] = "";
-			}
-		}
-		this.onComplete(result);
-	}
-}
 
 function createFormElements(
 	renderer: CliRenderer,

--- a/tests/tui/screens/form/focus-manager-verify.ts
+++ b/tests/tui/screens/form/focus-manager-verify.ts
@@ -1,0 +1,73 @@
+import { FocusManager } from "../../../../src/tui/screens/form/focus-manager";
+import type { FormElement } from "../../../../src/tui/screens/form/form-element";
+
+function createMockElements(count: number): readonly FormElement[] {
+	return Array.from({ length: count }, (_, i) => ({
+		input: { name: `field-${i}`, message: `Field ${i}`, type: "text" as const },
+		label: { content: "" },
+		element: { focus: () => {} },
+	})) as unknown as FormElement[];
+}
+
+const fm = new FocusManager();
+const elements = createMockElements(3);
+fm.setElements(elements);
+
+// Initial state
+if ((fm.currentIndex as number) !== 0) throw new Error("FAIL: initial index should be 0");
+console.log("PASS: initial index is 0");
+
+if (fm.isAtLast()) throw new Error("FAIL: should not be at last initially");
+console.log("PASS: not at last initially");
+
+// moveNext
+if (!fm.moveNext()) throw new Error("FAIL: moveNext should return true");
+if ((fm.currentIndex as number) !== 1) throw new Error("FAIL: index should be 1 after moveNext");
+console.log("PASS: moveNext works");
+
+// moveNext to last
+fm.moveNext();
+if (!fm.isAtLast()) throw new Error("FAIL: should be at last");
+console.log("PASS: isAtLast works");
+
+// moveNext beyond last
+if (fm.moveNext()) throw new Error("FAIL: moveNext at last should return false");
+if ((fm.currentIndex as number) !== 2) throw new Error("FAIL: index should stay at 2");
+console.log("PASS: moveNext at last returns false");
+
+// movePrevious
+if (!fm.movePrevious()) throw new Error("FAIL: movePrevious should return true");
+if ((fm.currentIndex as number) !== 1)
+	throw new Error("FAIL: index should be 1 after movePrevious");
+console.log("PASS: movePrevious works");
+
+// movePrevious to beginning
+fm.movePrevious();
+if (fm.movePrevious()) throw new Error("FAIL: movePrevious at 0 should return false");
+if ((fm.currentIndex as number) !== 0) throw new Error("FAIL: index should stay at 0");
+console.log("PASS: movePrevious at 0 returns false");
+
+// elementCount
+if (fm.elementCount !== 3) throw new Error("FAIL: elementCount should be 3");
+console.log("PASS: elementCount works");
+
+// focusCurrent calls focus
+let focusCalled = false;
+const elements2 = [
+	{
+		input: { name: "f", message: "F", type: "text" as const },
+		label: { content: "" },
+		element: {
+			focus: () => {
+				focusCalled = true;
+			},
+		},
+	},
+] as unknown as FormElement[];
+const fm2 = new FocusManager();
+fm2.setElements(elements2);
+fm2.focusCurrent();
+if (!focusCalled) throw new Error("FAIL: focusCurrent should call element.focus()");
+console.log("PASS: focusCurrent calls focus");
+
+console.log("ALL CHECKS PASSED");

--- a/tests/tui/screens/form/focus-manager.test.ts
+++ b/tests/tui/screens/form/focus-manager.test.ts
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { describe, expect, it } from "vitest";
+
+const VERIFY_SCRIPT = join(import.meta.dirname, "focus-manager-verify.ts");
+
+describe("FocusManager", () => {
+	it("manages focus navigation correctly", async () => {
+		const result = await execaCommand(`bun run ${VERIFY_SCRIPT}`, {
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("ALL CHECKS PASSED");
+	});
+});

--- a/tests/tui/screens/form/value-store-verify.ts
+++ b/tests/tui/screens/form/value-store-verify.ts
@@ -1,0 +1,34 @@
+import type { FormElement } from "../../../../src/tui/screens/form/form-element";
+import { ValueStore } from "../../../../src/tui/screens/form/value-store";
+
+const store = new ValueStore();
+
+// has returns false for unset
+if (store.has("foo")) throw new Error("FAIL: has should return false for unset key");
+console.log("PASS: has returns false for unset key");
+
+// set and has
+store.set("foo", "bar");
+if (!store.has("foo")) throw new Error("FAIL: has should return true after set");
+console.log("PASS: set and has work");
+
+// collect with set values
+const elements = [
+	{ input: { name: "foo", message: "Foo", type: "text" as const } },
+	{ input: { name: "baz", message: "Baz", type: "text" as const, default: "default-val" } },
+	{ input: { name: "empty", message: "Empty", type: "text" as const } },
+] as unknown as FormElement[];
+
+const result = store.collect(elements);
+
+if (result.foo !== "bar") throw new Error(`FAIL: foo should be 'bar', got '${result.foo}'`);
+console.log("PASS: collect returns set value");
+
+if (result.baz !== "default-val")
+	throw new Error(`FAIL: baz should be 'default-val', got '${result.baz}'`);
+console.log("PASS: collect falls back to default");
+
+if (result.empty !== "") throw new Error(`FAIL: empty should be '', got '${result.empty}'`);
+console.log("PASS: collect returns empty string for no default");
+
+console.log("ALL CHECKS PASSED");

--- a/tests/tui/screens/form/value-store.test.ts
+++ b/tests/tui/screens/form/value-store.test.ts
@@ -1,0 +1,16 @@
+import { join } from "node:path";
+import { execaCommand } from "execa";
+import { describe, expect, it } from "vitest";
+
+const VERIFY_SCRIPT = join(import.meta.dirname, "value-store-verify.ts");
+
+describe("ValueStore", () => {
+	it("manages form values correctly", async () => {
+		const result = await execaCommand(`bun run ${VERIFY_SCRIPT}`, {
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("ALL CHECKS PASSED");
+	});
+});


### PR DESCRIPTION
#### 概要

FormController の SRP 違反を解消し、3つの単一責任クラスに分離。

#### 変更内容

- `FocusManager`: フォーカスインデックスの管理とナビゲーション
- `ValueStore`: フォーム値の保存と収集
- `RenderStateManager`: ラベル表示状態の更新
- `FormElement` 型を独立ファイルに抽出
- `FormController` は薄いコーディネーターとして各クラスに委譲
- 各クラスの独立したテストを追加

Closes #395