### PR TITLE
fix: skill-loader の symlink パストラバーサル脆弱性を修正

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { lstat, readdir, readFile, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Skill, SkillLogger, SkillScope } from "../core/skill/skill";
@@ -51,16 +51,26 @@ async function findByName(
 	globalSkillsDir: string,
 	logger?: SkillLogger,
 ): Promise<Result<Skill, SkillNotFoundError>> {
-	const localPath = join(localSkillsDir, name, SKILL_FILE_NAME);
-	const localResult = await tryLoadSkill(localPath, "local", logger);
-	if (localResult.type === "found") {
-		return localResult;
+	const localDir = join(localSkillsDir, name);
+	if (await isSymlinkOutsideRoot(localDir, localSkillsDir)) {
+		logger?.warn(`Skipping symlink outside skills root: ${localDir}`);
+	} else {
+		const localPath = join(localDir, SKILL_FILE_NAME);
+		const localResult = await tryLoadSkill(localPath, "local", logger);
+		if (localResult.type === "found") {
+			return localResult;
+		}
 	}
 
-	const globalPath = join(globalSkillsDir, name, SKILL_FILE_NAME);
-	const globalResult = await tryLoadSkill(globalPath, "global", logger);
-	if (globalResult.type === "found") {
-		return globalResult;
+	const globalDir = join(globalSkillsDir, name);
+	if (await isSymlinkOutsideRoot(globalDir, globalSkillsDir)) {
+		logger?.warn(`Skipping symlink outside skills root: ${globalDir}`);
+	} else {
+		const globalPath = join(globalDir, SKILL_FILE_NAME);
+		const globalResult = await tryLoadSkill(globalPath, "global", logger);
+		if (globalResult.type === "found") {
+			return globalResult;
+		}
 	}
 
 	return err(skillNotFoundError(name));
@@ -98,9 +108,16 @@ async function scanDirectory(
 	// Node.js の readdir({ withFileTypes: true }) はシンボリックリンクを stat-follow しないため、
 	// symlink 先がディレクトリでも isDirectory() が false を返す。isSymbolicLink() を併用して
 	// symlink 先ディレクトリも走査対象に含める。
-	// Note: symlink はスキルディレクトリ外の任意パスを指せるが、開発者が自身の環境で
-	// 配置する CLI ツールのため、パスの制限は行わない。
 	for (const entry of entries.filter((e) => e.isDirectory() || e.isSymbolicLink())) {
+		if (entry.isSymbolicLink()) {
+			const entryPath = join(skillsDir, entry.name);
+			const withinRoot = await isWithinRoot(entryPath, skillsDir);
+			if (!withinRoot) {
+				logger?.warn(`Skipping symlink outside skills root: ${entryPath}`);
+				continue;
+			}
+		}
+
 		const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
 		const result = await tryLoadSkill(skillPath, scope, logger);
 		if (result.type === "not_found") {
@@ -140,4 +157,26 @@ async function tryLoadSkill(
 
 function isFileNotFound(e: unknown): boolean {
 	return e instanceof Error && "code" in e && e.code === FILE_NOT_FOUND_CODE;
+}
+
+async function isWithinRoot(symlinkPath: string, rootDir: string): Promise<boolean> {
+	try {
+		const resolved = await realpath(symlinkPath);
+		const normalizedRoot = await realpath(rootDir);
+		return resolved.startsWith(`${normalizedRoot}/`);
+	} catch {
+		return false;
+	}
+}
+
+async function isSymlinkOutsideRoot(path: string, rootDir: string): Promise<boolean> {
+	try {
+		const stat = await lstat(path);
+		if (!stat.isSymbolicLink()) {
+			return false;
+		}
+		return !(await isWithinRoot(path, rootDir));
+	} catch {
+		return false;
+	}
 }

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -237,37 +237,32 @@ describe("SkillLoader", () => {
 			externalDirs.length = 0;
 		});
 
-		it("シンボリックリンクされたスキルディレクトリを読み込める", async () => {
-			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
-			externalDirs.push(externalDir);
-			const externalSkillDir = join(externalDir, "my-skill");
-			mkdirSync(externalSkillDir, { recursive: true });
-			writeFileSync(join(externalSkillDir, "SKILL.md"), makeSkillMd("my-skill", "外部スキル"));
-
+		it("スキルルート内へのシンボリックリンクされたディレクトリを読み込める", async () => {
 			const skillsDir = join(localRoot, ".taskp", "skills");
 			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(externalSkillDir, join(skillsDir, "my-skill"));
+
+			const actualDir = join(skillsDir, "_source", "my-skill");
+			mkdirSync(actualDir, { recursive: true });
+			writeFileSync(join(actualDir, "SKILL.md"), makeSkillMd("my-skill", "内部スキル"));
+
+			symlinkSync(actualDir, join(skillsDir, "my-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
 			const { skills } = await loader.listLocal();
 
-			expect(skills).toHaveLength(1);
-			expect(skills[0].metadata.name).toBe("my-skill");
+			const mySkill = skills.find((s) => s.metadata.name === "my-skill");
+			expect(mySkill).toBeDefined();
 		});
 
-		it("シンボリックリンクされたスキルを findByName で検索できる", async () => {
-			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
-			externalDirs.push(externalDir);
-			const externalSkillDir = join(externalDir, "linked-skill");
-			mkdirSync(externalSkillDir, { recursive: true });
-			writeFileSync(
-				join(externalSkillDir, "SKILL.md"),
-				makeSkillMd("linked-skill", "リンクスキル"),
-			);
-
+		it("スキルルート内へのシンボリックリンクを findByName で検索できる", async () => {
 			const skillsDir = join(globalRoot, ".taskp", "skills");
 			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(externalSkillDir, join(skillsDir, "linked-skill"));
+
+			const actualDir = join(skillsDir, "_source", "linked-skill");
+			mkdirSync(actualDir, { recursive: true });
+			writeFileSync(join(actualDir, "SKILL.md"), makeSkillMd("linked-skill", "リンクスキル"));
+
+			symlinkSync(actualDir, join(skillsDir, "linked-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
 			const result = await loader.findByName("linked-skill");
@@ -276,6 +271,25 @@ describe("SkillLoader", () => {
 			if (!result.ok) return;
 			expect(result.value.metadata.name).toBe("linked-skill");
 			expect(result.value.scope).toBe("global");
+		});
+
+		it("スキルルート外へのシンボリックリンクは findByName でスキップされる", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "evil-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(join(externalSkillDir, "SKILL.md"), makeSkillMd("evil-skill", "外部スキル"));
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("evil-skill");
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("SKILL_NOT_FOUND");
 		});
 
 		it("壊れたシンボリックリンクはスキップされる", async () => {
@@ -290,7 +304,68 @@ describe("SkillLoader", () => {
 			expect(failures).toHaveLength(0);
 		});
 
-		it("ファイルへのシンボリックリンクは failures に記録される", async () => {
+		it("スキルルート外へのシンボリックリンクはスキップされる", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "evil-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("evil-skill", "スキルルート外"),
+			);
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listLocal();
+
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(0);
+		});
+
+		it("スキルルート外へのシンボリックリンクがあっても他のスキルは読み込める", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "evil-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("evil-skill", "スキルルート外"),
+			);
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
+			createSkillFile(localRoot, "valid-skill", makeSkillMd("valid-skill", "正常スキル"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listLocal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("valid-skill");
+			expect(failures).toHaveLength(0);
+		});
+
+		it("スキルルート内のサブディレクトリへのシンボリックリンクは読み込める", async () => {
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+
+			const innerDir = join(skillsDir, "_shared", "inner-skill");
+			mkdirSync(innerDir, { recursive: true });
+			writeFileSync(join(innerDir, "SKILL.md"), makeSkillMd("inner-skill", "内部リンク"));
+
+			symlinkSync(innerDir, join(skillsDir, "inner-skill"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listLocal();
+
+			const innerSkill = skills.find((s) => s.metadata.name === "inner-skill");
+			expect(innerSkill).toBeDefined();
+		});
+
+		it("スキルルート外のファイルへのシンボリックリンクはスキップされる", async () => {
 			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
 			externalDirs.push(externalDir);
 			const externalFile = join(externalDir, "not-a-dir.md");
@@ -303,10 +378,8 @@ describe("SkillLoader", () => {
 			const loader = createSkillLoader({ localRoot, globalRoot });
 			const { skills, failures } = await loader.listLocal();
 
-			// ファイルへの symlink は file-link/SKILL.md を readFile → ENOTDIR で失敗する
 			expect(skills).toHaveLength(0);
-			expect(failures).toHaveLength(1);
-			expect(failures[0].path).toMatch(/file-link/);
+			expect(failures).toHaveLength(0);
 		});
 	});
 });


### PR DESCRIPTION
#### 概要

skill-loader の scanDirectory および findByName で symlink 先が skills root 配下にあることを realpath で検証し、パストラバーサル攻撃を防止する。

#### 変更内容

- `scanDirectory` で symlink エントリの realpath を検証し、skills root 外への symlink をスキップ
- `findByName` で symlink ディレクトリの realpath を検証し、skills root 外への symlink をスキップ
- `isWithinRoot` / `isSymlinkOutsideRoot` ヘルパー関数を追加
- テストを追加: skills root 外への symlink のブロック、内部 symlink の許可、findByName での検証

Closes #396