### PR TITLE
refactor: extract toError helper to eliminate DRY violation in tryCatch/tryCatchSync

### DIFF
--- a/src/adapter/error-handler-utils.ts
+++ b/src/adapter/error-handler-utils.ts
@@ -7,6 +7,10 @@ export function toErrorMessage(error: unknown): string {
 	return String(error);
 }
 
+function toError(e: unknown): Error {
+	return e instanceof Error ? e : new Error(String(e));
+}
+
 export async function tryCatch<T, E>(
 	fn: () => Promise<T>,
 	errorFactory: (e: Error) => E,
@@ -14,8 +18,7 @@ export async function tryCatch<T, E>(
 	try {
 		return ok(await fn());
 	} catch (e) {
-		const error = e instanceof Error ? e : new Error(String(e));
-		return err(errorFactory(error));
+		return err(errorFactory(toError(e)));
 	}
 }
 
@@ -23,7 +26,6 @@ export function tryCatchSync<T, E>(fn: () => T, errorFactory: (e: Error) => E): 
 	try {
 		return ok(fn());
 	} catch (e) {
-		const error = e instanceof Error ? e : new Error(String(e));
-		return err(errorFactory(error));
+		return err(errorFactory(toError(e)));
 	}
 }


### PR DESCRIPTION
#### 概要

`tryCatch` と `tryCatchSync` で重複していた Error ラッピングロジックを `toError` ヘルパーに抽出し、DRY 原則に準拠させた。

#### 変更内容

- `toError(e: unknown): Error` ヘルパー関数を追加（非公開）
- `tryCatch` / `tryCatchSync` の catch ブロックで `toError` を使用するよう変更
- 公開 API に変更なし

Closes #398