### PR TITLE
fix: hook-runner の部分失敗を検査して詳細エラーを返却

### DIFF
--- a/src/usecase/hook-runner.ts
+++ b/src/usecase/hook-runner.ts
@@ -26,7 +26,14 @@ export async function runHooks(params: RunHooksParams): Promise<Result<void, Exe
 	}
 
 	try {
-		await params.hookExecutor.execute(commands, params.context);
+		const results = await params.hookExecutor.execute(commands, params.context);
+		const failures = results.filter((r) => !r.success);
+		if (failures.length > 0) {
+			const details = failures
+				.map((f) => `"${f.command}": ${f.error ?? "unknown error"}`)
+				.join(", ");
+			return err(executionError(`Hook partially failed: ${details}`));
+		}
 		return ok(undefined);
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/tests/usecase/hook-runner.test.ts
+++ b/tests/usecase/hook-runner.test.ts
@@ -95,6 +95,69 @@ describe("runHooks", () => {
 		expect(executor.execute).not.toHaveBeenCalled();
 	});
 
+	it("returns err with details when a hook command fails", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async (commands: readonly string[]) =>
+				commands.map((cmd) =>
+					cmd === "fail-cmd"
+						? { command: cmd, success: false, error: "exit code 1" }
+						: { command: cmd, success: true },
+				),
+			),
+		};
+
+		const result = await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["echo ok", "fail-cmd"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Execution);
+			expect(result.error.message).toBe('Hook partially failed: "fail-cmd": exit code 1');
+		}
+	});
+
+	it("returns err listing all failed hooks when multiple commands fail", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async (commands: readonly string[]) =>
+				commands.map((cmd) => ({ command: cmd, success: false, error: `${cmd} broken` })),
+			),
+		};
+
+		const result = await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_failure: ["notify", "cleanup"] },
+			context: { skillName: "deploy", mode: "template", status: "failed", durationMs: 50 },
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Execution);
+			expect(result.error.message).toBe(
+				'Hook partially failed: "notify": notify broken, "cleanup": cleanup broken',
+			);
+		}
+	});
+
+	it("returns err with 'unknown error' when failed hook has no error message", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async () => [{ command: "bad-cmd", success: false }]),
+		};
+
+		const result = await runHooks({
+			hookExecutor: executor,
+			hooksConfig: { on_success: ["bad-cmd"] },
+			context: { skillName: "deploy", mode: "template", status: "success", durationMs: 100 },
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toBe('Hook partially failed: "bad-cmd": unknown error');
+		}
+	});
+
 	it("returns err with ExecutionError when executor throws", async () => {
 		const throwingExecutor: HookExecutorPort = {
 			execute: vi.fn(async () => {


### PR DESCRIPTION
#### 概要

`runHooks` が `hookExecutor.execute()` の返却する `HookResult[]` の `success` フィールドを検査していなかった問題を修正。

#### 変更内容

- `hook-runner.ts`: `HookResult.success` をチェックし、部分失敗時に失敗コマンドとエラー詳細を含む `ExecutionError` を返却
- `hook-runner.test.ts`: 部分失敗（単一/複数/エラーメッセージなし）のテストケースを追加

Closes #399