### PR TITLE
refactor: remove redundant chunk buffering in agent-loop

### DIFF
--- a/src/core/execution/agent-loop.ts
+++ b/src/core/execution/agent-loop.ts
@@ -48,21 +48,17 @@ async function executeAgentLoop(
 			stopWhen: stepCountIs(MAX_STEPS),
 		});
 
-		const chunks: string[] = [];
 		for await (const chunk of result.textStream) {
-			chunks.push(chunk);
 			process.stdout.write(chunk);
 		}
 
-		const finalResult = await result;
-		const steps = await finalResult.steps;
-		const stepCount = steps.length;
+		const [output, steps] = await Promise.all([result.text, result.steps]);
 
 		if (isMaxStepsExceeded(steps)) {
 			return err(executionError(`Agent loop exceeded maximum steps (${MAX_STEPS}). Aborting.`));
 		}
 
-		return ok({ output: chunks.join(""), steps: stepCount });
+		return ok({ output, steps: steps.length });
 	} catch (error) {
 		return err(
 			executionError(


### PR DESCRIPTION
#### 概要

agent-loop のストリーム処理で冗長なメモリバッファリングを除去し、AI SDK の `result.text` を直接使用するように変更。

#### 変更内容

- `chunks` 配列による手動バッファリングを削除
- AI SDK の `result.text` プロミスで最終テキストを取得
- `Promise.all` で `result.text` と `result.steps` を並行取得

Closes #400