### PR TITLE
fix: handle partial failures in glob context collection

### DIFF
--- a/src/adapter/context-collector-deps.ts
+++ b/src/adapter/context-collector-deps.ts
@@ -1,9 +1,9 @@
 import { executionError } from "../core/types/errors";
 import { err, ok } from "../core/types/result";
-import type { ContextCollectorDeps } from "./context-collector";
+import type { ContextCollectorIoDeps } from "./context-collector";
 import { toErrorMessage, tryCatch } from "./error-handler-utils";
 
-export async function createDefaultContextCollectorDeps(): Promise<ContextCollectorDeps> {
+export async function createDefaultContextCollectorDeps(): Promise<ContextCollectorIoDeps> {
 	const { execa } = await import("execa");
 	const { glob } = await import("node:fs/promises");
 

--- a/src/adapter/context-collector/glob-collector.ts
+++ b/src/adapter/context-collector/glob-collector.ts
@@ -23,11 +23,30 @@ export const collectGlob: SourceCollector = async (source: ContextSource, cwd, d
 	);
 
 	const collected: CollectedContext[] = [];
-	for (const result of results) {
-		if (!result.ok) {
-			return result;
+	const failures: string[] = [];
+
+	for (let i = 0; i < results.length; i++) {
+		const result = results[i];
+		if (result.ok) {
+			collected.push(result.value);
+		} else {
+			failures.push(`${paths[i]}: ${result.error.message}`);
 		}
-		collected.push(result.value);
+	}
+
+	if (failures.length > 0 && collected.length === 0) {
+		return {
+			ok: false,
+			error: executionError(
+				`All glob matches failed for "${source.pattern}":\n${failures.join("\n")}`,
+			),
+		};
+	}
+
+	if (failures.length > 0) {
+		deps.logger.warn(
+			`${failures.length} of ${total} glob matches failed for "${source.pattern}":\n${failures.join("\n")}`,
+		);
 	}
 
 	return ok(collected);

--- a/src/adapter/context-collector/index.ts
+++ b/src/adapter/context-collector/index.ts
@@ -10,7 +10,7 @@ import { collectImage } from "./image-collector";
 import type { ContextCollectorDeps, SourceCollector } from "./types";
 import { collectUrl } from "./url-collector";
 
-export type { ContextCollectorDeps } from "./types";
+export type { ContextCollectorDeps, ContextCollectorIoDeps } from "./types";
 
 const sourceCollectors: ReadonlyMap<ContextSource["type"], SourceCollector> = new Map([
 	["file", collectFile],

--- a/src/adapter/context-collector/types.ts
+++ b/src/adapter/context-collector/types.ts
@@ -2,8 +2,9 @@ import type { ContextSource } from "../../core/skill/context-source";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
 import type { CollectedContext } from "../../usecase/port/context-collector";
+import type { Logger } from "../../usecase/port/logger";
 
-export type ContextCollectorDeps = {
+export type ContextCollectorIoDeps = {
 	readonly executeCommand: (
 		command: string,
 		cwd: string,
@@ -18,6 +19,10 @@ export type ContextCollectorDeps = {
 		pattern: string,
 		cwd: string,
 	) => Promise<Result<readonly string[], ExecutionError>>;
+};
+
+export type ContextCollectorDeps = ContextCollectorIoDeps & {
+	readonly logger: Logger;
 };
 
 export type SourceCollector = (

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -359,10 +359,9 @@ async function runAgentMode(
 		output: process.stdout,
 	});
 
-	const contextCollectorDeps = await createDefaultContextCollectorDeps();
-	const contextCollector = createContextCollector(contextCollectorDeps);
-
 	const logger = createConsoleLogger();
+	const contextCollectorDeps = await createDefaultContextCollectorDeps();
+	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
 	const agentExecutor = createAgentExecutor(writer, logger);
 
 	const commandExecutor = createCommandRunner({

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -103,7 +103,7 @@ async function executeAgentMode(
 	const agentExecutor = createAgentExecutor(writer, logger);
 
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
-	const contextCollector = createContextCollector(contextCollectorDeps);
+	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
 
 	const result = await runAgentSkill(
 		{ name: skill.metadata.name, action: actionName, presets: variables, model },

--- a/tests/adapter/context-collector.test.ts
+++ b/tests/adapter/context-collector.test.ts
@@ -1,13 +1,21 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createContextCollector } from "../../src/adapter/context-collector";
 import type { ContextSource } from "../../src/core/skill/context-source";
 import type { ExecutionError } from "../../src/core/types/errors";
 import { executionError } from "../../src/core/types/errors";
 import type { Result } from "../../src/core/types/result";
 import { err, ok } from "../../src/core/types/result";
+
+function createSpyLogger() {
+	return {
+		debug: vi.fn<(message: string) => void>(),
+		warn: vi.fn<(message: string) => void>(),
+		error: vi.fn<(message: string) => void>(),
+	};
+}
 
 function stubDeps(overrides?: {
 	executeCommand?: (command: string, cwd: string) => Promise<Result<string, ExecutionError>>;
@@ -18,6 +26,7 @@ function stubDeps(overrides?: {
 		Result<{ readonly data: Uint8Array; readonly mediaType: string | undefined }, ExecutionError>
 	>;
 	scanGlob?: (pattern: string, cwd: string) => Promise<Result<readonly string[], ExecutionError>>;
+	logger?: ReturnType<typeof createSpyLogger>;
 }) {
 	return {
 		executeCommand: overrides?.executeCommand ?? (async () => ok("")),
@@ -25,6 +34,7 @@ function stubDeps(overrides?: {
 		fetchBinary:
 			overrides?.fetchBinary ?? (async () => ok({ data: new Uint8Array(), mediaType: undefined })),
 		scanGlob: overrides?.scanGlob ?? (async () => ok([] as readonly string[])),
+		logger: overrides?.logger ?? createSpyLogger(),
 	};
 }
 
@@ -147,11 +157,36 @@ describe("ContextCollector", () => {
 			expect(result.error.message).toBe("glob scan failed");
 		});
 
-		it("includes progress counter in error for unreadable file", async () => {
+		it("returns successful results and warns on partial failure", async () => {
 			await writeFile(join(tempDir, "a.md"), "aaa");
+			const logger = createSpyLogger();
 			const collector = createContextCollector(
 				stubDeps({
-					scanGlob: async () => ok(["a.md", "missing.md", "c.md"]),
+					scanGlob: async () => ok(["a.md", "missing.md"]),
+					logger,
+				}),
+			);
+			const sources: ContextSource[] = [{ type: "glob", pattern: "*.md" }];
+
+			const result = await collector.collect(sources, tempDir);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value).toHaveLength(1);
+			expect(result.value[0]).toEqual({
+				kind: "text",
+				source: { type: "glob", pattern: "*.md" },
+				content: "aaa",
+			});
+			expect(logger.warn).toHaveBeenCalledOnce();
+			expect(logger.warn.mock.calls[0][0]).toContain("1 of 2 glob matches failed");
+			expect(logger.warn.mock.calls[0][0]).toContain("missing.md");
+		});
+
+		it("returns error when all glob matches fail", async () => {
+			const collector = createContextCollector(
+				stubDeps({
+					scanGlob: async () => ok(["missing1.md", "missing2.md"]),
 				}),
 			);
 			const sources: ContextSource[] = [{ type: "glob", pattern: "*.md" }];
@@ -161,8 +196,9 @@ describe("ContextCollector", () => {
 			expect(result.ok).toBe(false);
 			if (result.ok) return;
 			expect(result.error.type).toBe("EXECUTION_ERROR");
-			expect(result.error.message).toContain("Failed to read glob match (2/3):");
-			expect(result.error.message).toContain("missing.md");
+			expect(result.error.message).toContain('All glob matches failed for "*.md"');
+			expect(result.error.message).toContain("missing1.md");
+			expect(result.error.message).toContain("missing2.md");
 		});
 	});
 


### PR DESCRIPTION
#### 概要

glob コンテキスト収集で1ファイルの読み込み失敗時に全体が失敗扱いになる問題を修正。部分的な失敗を許容し、成功したファイルのみ収集するように変更。

#### 変更内容

- `collectGlob` の fail-fast ループを部分成功ロジックに置換（成功ファイルは収集、失敗は警告）
- `ContextCollectorDeps` に `Logger` を追加し、部分失敗時に `logger.warn` で詳細を記録
- IO依存のみの `ContextCollectorIoDeps` 型を分離（`createDefaultContextCollectorDeps` 用）
- 全ファイル失敗時は全失敗情報を含むエラーを返却
- テストを更新：部分失敗テスト・全失敗テストを追加

Closes #401