### PR TITLE
refactor: extract config merge strategies for clarity and testability

### DIFF
--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -126,7 +126,7 @@ function parseConfig(raw: string, path: string): Result<Config, ConfigError> {
 	return ok(result.data);
 }
 
-function mergeOptional<T>(
+export function mergeOptional<T>(
 	global: T | undefined,
 	project: T | undefined,
 	merge: (g: T, p: T) => T,
@@ -137,25 +137,42 @@ function mergeOptional<T>(
 	return merge(global, project);
 }
 
+export function mergeProviders(
+	global: Record<string, ProviderConfig>,
+	project: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+	const merged: Record<string, ProviderConfig> = { ...global };
+	for (const [key, value] of Object.entries(project)) {
+		merged[key] = global[key] !== undefined ? { ...global[key], ...value } : value;
+	}
+	return merged;
+}
+
+export function mergeAiConfig(global: AiConfig, project: AiConfig): AiConfig {
+	return {
+		default_provider: project.default_provider ?? global.default_provider,
+		default_model: project.default_model ?? global.default_model,
+		providers: mergeOptional(global.providers, project.providers, mergeProviders),
+	};
+}
+
+export function mergeHooksConfig(global: HooksConfig, project: HooksConfig): HooksConfig {
+	return {
+		on_success: project.on_success ?? global.on_success,
+		on_failure: project.on_failure ?? global.on_failure,
+	};
+}
+
+export function mergeCliConfig(global: CliConfig, project: CliConfig): CliConfig {
+	return {
+		command_timeout_ms: project.command_timeout_ms ?? global.command_timeout_ms,
+	};
+}
+
 function mergeConfigs(global: Config, project: Config): Config {
 	return {
-		ai: mergeOptional(global.ai, project.ai, (g, p) => ({
-			default_provider: p.default_provider ?? g.default_provider,
-			default_model: p.default_model ?? g.default_model,
-			providers: mergeOptional(g.providers, p.providers, (gp, pp) => {
-				const merged: Record<string, ProviderConfig> = { ...gp };
-				for (const [key, value] of Object.entries(pp)) {
-					merged[key] = gp[key] !== undefined ? { ...gp[key], ...value } : value;
-				}
-				return merged;
-			}),
-		})),
-		hooks: mergeOptional(global.hooks, project.hooks, (g, p) => ({
-			on_success: p.on_success ?? g.on_success,
-			on_failure: p.on_failure ?? g.on_failure,
-		})),
-		cli: mergeOptional(global.cli, project.cli, (g, p) => ({
-			command_timeout_ms: p.command_timeout_ms ?? g.command_timeout_ms,
-		})),
+		ai: mergeOptional(global.ai, project.ai, mergeAiConfig),
+		hooks: mergeOptional(global.hooks, project.hooks, mergeHooksConfig),
+		cli: mergeOptional(global.cli, project.cli, mergeCliConfig),
 	};
 }

--- a/tests/adapter/config-loader.test.ts
+++ b/tests/adapter/config-loader.test.ts
@@ -2,7 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createConfigLoader } from "../../src/adapter/config-loader";
+import {
+	createConfigLoader,
+	mergeAiConfig,
+	mergeCliConfig,
+	mergeHooksConfig,
+	mergeOptional,
+	mergeProviders,
+} from "../../src/adapter/config-loader";
 
 function writeConfig(root: string, content: string): void {
 	const dir = join(root, ".taskp");
@@ -377,5 +384,107 @@ command_timeout_ms = -1
 
 			expect(result.ok).toBe(false);
 		});
+	});
+});
+
+describe("mergeOptional", () => {
+	const concat = (a: string, b: string) => a + b;
+
+	it("returns undefined when both are undefined", () => {
+		expect(mergeOptional(undefined, undefined, concat)).toBeUndefined();
+	});
+
+	it("returns project when global is undefined", () => {
+		expect(mergeOptional(undefined, "project", concat)).toBe("project");
+	});
+
+	it("returns global when project is undefined", () => {
+		expect(mergeOptional("global", undefined, concat)).toBe("global");
+	});
+
+	it("calls merge when both are defined", () => {
+		expect(mergeOptional("global", "project", concat)).toBe("globalproject");
+	});
+});
+
+describe("mergeProviders", () => {
+	it("merges non-overlapping providers", () => {
+		const global = { anthropic: { api_key_env: "KEY" } };
+		const project = { ollama: { base_url: "http://localhost" } };
+
+		const result = mergeProviders(global, project);
+
+		expect(result).toEqual({
+			anthropic: { api_key_env: "KEY" },
+			ollama: { base_url: "http://localhost" },
+		});
+	});
+
+	it("merges overlapping provider fields", () => {
+		const global = { openai: { api_key_env: "KEY", default_model: "gpt-4" } };
+		const project = { openai: { default_model: "gpt-5" } };
+
+		const result = mergeProviders(global, project);
+
+		expect(result).toEqual({
+			openai: { api_key_env: "KEY", default_model: "gpt-5" },
+		});
+	});
+
+	it("project provider replaces global when global has no entry", () => {
+		const global = {};
+		const project = { ollama: { base_url: "http://localhost" } };
+
+		const result = mergeProviders(global, project);
+
+		expect(result).toEqual({ ollama: { base_url: "http://localhost" } });
+	});
+});
+
+describe("mergeAiConfig", () => {
+	it("project fields override global fields", () => {
+		const global = { default_provider: "anthropic" as const, default_model: "claude" };
+		const project = { default_provider: "ollama" as const };
+
+		const result = mergeAiConfig(global, project);
+
+		expect(result.default_provider).toBe("ollama");
+		expect(result.default_model).toBe("claude");
+	});
+
+	it("merges providers from both configs", () => {
+		const global = { providers: { anthropic: { api_key_env: "KEY" } } };
+		const project = { providers: { ollama: { base_url: "http://localhost" } } };
+
+		const result = mergeAiConfig(global, project);
+
+		expect(result.providers?.anthropic?.api_key_env).toBe("KEY");
+		expect(result.providers?.ollama?.base_url).toBe("http://localhost");
+	});
+});
+
+describe("mergeHooksConfig", () => {
+	it("project on_success overrides global", () => {
+		const global = { on_success: ["global"], on_failure: ["fail"] };
+		const project = { on_success: ["project"] };
+
+		const result = mergeHooksConfig(global, project);
+
+		expect(result.on_success).toEqual(["project"]);
+		expect(result.on_failure).toEqual(["fail"]);
+	});
+});
+
+describe("mergeCliConfig", () => {
+	it("project command_timeout_ms overrides global", () => {
+		const result = mergeCliConfig({ command_timeout_ms: 30000 }, { command_timeout_ms: 60000 });
+
+		expect(result.command_timeout_ms).toBe(60000);
+	});
+
+	it("falls back to global when project is undefined", () => {
+		const result = mergeCliConfig({ command_timeout_ms: 30000 }, {});
+
+		expect(result.command_timeout_ms).toBe(30000);
 	});
 });


### PR DESCRIPTION
#### 概要

`mergeConfigs` 関数のネストされたマージロジックを独立した関数に分離し、テスト容易性と可読性を向上。

#### 変更内容

- `mergeAiConfig`, `mergeHooksConfig`, `mergeCliConfig`, `mergeProviders` を独立関数として抽出
- `mergeConfigs` のネスト深度を3段→1段に削減
- 各マージ関数のユニットテストを追加（`mergeOptional`, `mergeProviders`, `mergeAiConfig`, `mergeHooksConfig`, `mergeCliConfig`）

Closes #404