### PR TITLE
refactor: extract context resolution into collect-skill-context usecase

### DIFF
--- a/src/usecase/collect-skill-context.ts
+++ b/src/usecase/collect-skill-context.ts
@@ -1,0 +1,43 @@
+import {
+	type ContextSource,
+	getContextSourceValue,
+	withResolvedValue,
+} from "../core/skill/context-source";
+import type { DomainError } from "../core/types/errors";
+import type { Result } from "../core/types/result";
+import { ok } from "../core/types/result";
+import type { ReservedVars } from "../core/variable/template-renderer";
+import { renderTemplate } from "../core/variable/template-renderer";
+import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
+
+export async function collectSkillContext(
+	sources: readonly ContextSource[],
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+	contextCollector: ContextCollectorPort,
+	cwd: string,
+): Promise<Result<readonly CollectedContext[], DomainError>> {
+	const resolved = resolveContextSources(sources, variables, reserved);
+	if (!resolved.ok) return resolved;
+
+	return contextCollector.collect(resolved.value, cwd);
+}
+
+export function resolveContextSources(
+	sources: readonly ContextSource[],
+	variables: Record<string, string>,
+	reserved: ReservedVars,
+): Result<readonly ContextSource[], DomainError> {
+	const resolved: ContextSource[] = [];
+
+	for (const source of sources) {
+		const raw = getContextSourceValue(source);
+		const renderResult = renderTemplate(raw, variables, reserved);
+		if (!renderResult.ok) {
+			return renderResult;
+		}
+		resolved.push(withResolvedValue(source, renderResult.value));
+	}
+
+	return ok(resolved);
+}

--- a/src/usecase/index.ts
+++ b/src/usecase/index.ts
@@ -1,5 +1,6 @@
 // Use cases
 
+export { collectSkillContext, resolveContextSources } from "./collect-skill-context";
 export type { InitOutput, InitSkillInput } from "./init-skill";
 export { initSkill } from "./init-skill";
 export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./list-skills";

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,17 +1,12 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { buildTaskpRunDescription } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
-import {
-	type ContextSource,
-	getContextSourceValue,
-	withResolvedValue,
-} from "../core/skill/context-source";
 import { resolveAgentExecution } from "../core/skill/skill-execution-resolver";
 import { type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
 import { ok } from "../core/types/result";
-import type { ReservedVars } from "../core/variable/template-renderer";
 import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
+import { collectSkillContext } from "./collect-skill-context";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
@@ -98,13 +93,13 @@ export async function runAgentSkill(
 	if (contextSources.length > 0) {
 		progress.writeContextSources(contextSources);
 
-		// context ソース内の変数（{{__skill_dir__}} 等）を展開してからコレクタに渡す
-		// （SKILL-SPEC.md「展開タイミング」ステップ3: context のパス内の変数を展開）
-		const resolvedSources = resolveContextSources(contextSources, variables, reserved);
-		if (!resolvedSources.ok) {
-			return resolvedSources;
-		}
-		const contextResult = await deps.contextCollector.collect(resolvedSources.value, process.cwd());
+		const contextResult = await collectSkillContext(
+			contextSources,
+			variables,
+			reserved,
+			deps.contextCollector,
+			process.cwd(),
+		);
 		if (!contextResult.ok) {
 			return contextResult;
 		}
@@ -164,29 +159,6 @@ export async function runAgentSkill(
 		skillName: skill.metadata.name,
 		result: executeResult.value,
 	});
-}
-
-/**
- * context ソース内の変数（パス・コマンド等）を展開する。
- * 例: `{{__skill_dir__}}/fetch.sh` → `/abs/path/to/skill/fetch.sh`
- */
-function resolveContextSources(
-	sources: readonly ContextSource[],
-	variables: Record<string, string>,
-	reserved: ReservedVars,
-): Result<readonly ContextSource[], DomainError> {
-	const resolved: ContextSource[] = [];
-
-	for (const source of sources) {
-		const raw = getContextSourceValue(source);
-		const renderResult = renderTemplate(raw, variables, reserved);
-		if (!renderResult.ok) {
-			return renderResult;
-		}
-		resolved.push(withResolvedValue(source, renderResult.value));
-	}
-
-	return ok(resolved);
 }
 
 function toContentPart(ctx: CollectedContext): ContentPart {

--- a/tests/usecase/collect-skill-context.test.ts
+++ b/tests/usecase/collect-skill-context.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ContextSource } from "../../src/core/skill/context-source";
+import type { DomainError } from "../../src/core/types/errors";
+import type { Result } from "../../src/core/types/result";
+import { ok } from "../../src/core/types/result";
+import type { ReservedVars } from "../../src/core/variable/template-renderer";
+import {
+	collectSkillContext,
+	resolveContextSources,
+} from "../../src/usecase/collect-skill-context";
+import type {
+	CollectedContext,
+	ContextCollectorPort,
+} from "../../src/usecase/port/context-collector";
+
+const reserved: ReservedVars = {
+	cwd: "/cwd",
+	skillDir: "/path/to/skill",
+	date: "2026-03-26",
+	timestamp: "2026-03-26T00:00:00.000Z",
+};
+
+describe("resolveContextSources", () => {
+	it("resolves variables in file source paths", () => {
+		const sources: readonly ContextSource[] = [
+			{ type: "file", path: "{{__skill_dir__}}/data.txt" },
+		];
+
+		const result = resolveContextSources(sources, {}, reserved);
+
+		expect(result).toEqual(ok([{ type: "file", path: "/path/to/skill/data.txt" }]));
+	});
+
+	it("resolves variables in command sources", () => {
+		const sources: readonly ContextSource[] = [{ type: "command", run: "cat {{name}}.txt" }];
+
+		const result = resolveContextSources(sources, { name: "readme" }, reserved);
+
+		expect(result).toEqual(ok([{ type: "command", run: "cat readme.txt" }]));
+	});
+
+	it("resolves variables in glob sources", () => {
+		const sources: readonly ContextSource[] = [{ type: "glob", pattern: "{{__skill_dir__}}/*.md" }];
+
+		const result = resolveContextSources(sources, {}, reserved);
+
+		expect(result).toEqual(ok([{ type: "glob", pattern: "/path/to/skill/*.md" }]));
+	});
+
+	it("resolves variables in url sources", () => {
+		const sources: readonly ContextSource[] = [
+			{ type: "url", url: "https://example.com/{{name}}" },
+		];
+
+		const result = resolveContextSources(sources, { name: "page" }, reserved);
+
+		expect(result).toEqual(ok([{ type: "url", url: "https://example.com/page" }]));
+	});
+
+	it("resolves variables in image sources", () => {
+		const sources: readonly ContextSource[] = [
+			{ type: "image", path: "{{__skill_dir__}}/screenshot.png" },
+		];
+
+		const result = resolveContextSources(sources, {}, reserved);
+
+		expect(result).toEqual(ok([{ type: "image", path: "/path/to/skill/screenshot.png" }]));
+	});
+
+	it("returns error when template rendering fails", () => {
+		const sources: readonly ContextSource[] = [{ type: "file", path: "{{undefined_var}}" }];
+
+		const result = resolveContextSources(sources, {}, reserved);
+
+		expect(result.ok).toBe(false);
+	});
+
+	it("resolves multiple sources", () => {
+		const sources: readonly ContextSource[] = [
+			{ type: "file", path: "{{__skill_dir__}}/a.txt" },
+			{ type: "command", run: "echo {{name}}" },
+		];
+
+		const result = resolveContextSources(sources, { name: "hello" }, reserved);
+
+		expect(result).toEqual(
+			ok([
+				{ type: "file", path: "/path/to/skill/a.txt" },
+				{ type: "command", run: "echo hello" },
+			]),
+		);
+	});
+
+	it("returns empty array for empty sources", () => {
+		const result = resolveContextSources([], {}, reserved);
+
+		expect(result).toEqual(ok([]));
+	});
+});
+
+describe("collectSkillContext", () => {
+	it("resolves sources and collects context", async () => {
+		const sources: readonly ContextSource[] = [
+			{ type: "file", path: "{{__skill_dir__}}/data.txt" },
+		];
+		const collected: readonly CollectedContext[] = [
+			{ kind: "text", source: { type: "file", path: "/path/to/skill/data.txt" }, content: "data" },
+		];
+		const contextCollector: ContextCollectorPort = {
+			collect: vi.fn().mockResolvedValue(ok(collected)),
+		};
+
+		const result = await collectSkillContext(sources, {}, reserved, contextCollector, "/cwd");
+
+		expect(result).toEqual(ok(collected));
+		expect(contextCollector.collect).toHaveBeenCalledWith(
+			[{ type: "file", path: "/path/to/skill/data.txt" }],
+			"/cwd",
+		);
+	});
+
+	it("returns error when source resolution fails", async () => {
+		const sources: readonly ContextSource[] = [{ type: "file", path: "{{missing}}" }];
+		const contextCollector: ContextCollectorPort = {
+			collect: vi.fn(),
+		};
+
+		const result = await collectSkillContext(sources, {}, reserved, contextCollector, "/cwd");
+
+		expect(result.ok).toBe(false);
+		expect(contextCollector.collect).not.toHaveBeenCalled();
+	});
+
+	it("returns error when collector fails", async () => {
+		const sources: readonly ContextSource[] = [{ type: "file", path: "test.txt" }];
+		const collectorError: Result<readonly CollectedContext[], DomainError> = {
+			ok: false,
+			error: { type: "EXECUTION_ERROR", message: "file not found" },
+		};
+		const contextCollector: ContextCollectorPort = {
+			collect: vi.fn().mockResolvedValue(collectorError),
+		};
+
+		const result = await collectSkillContext(sources, {}, reserved, contextCollector, "/cwd");
+
+		expect(result).toEqual(collectorError);
+	});
+});


### PR DESCRIPTION
#### 概要

コンテキストソース解決ロジック（変数展開 → コレクタ呼び出し）を `collect-skill-context.ts` に抽出し、再利用可能なユースケースとして分離。

#### 変更内容

- `src/usecase/collect-skill-context.ts` を新規作成（`collectSkillContext` + `resolveContextSources`）
- `run-agent-skill.ts` からインライン実装を削除し、新モジュールを利用するよう変更
- `usecase/index.ts` にエクスポートを追加
- 11件の単体テストを追加（全ソースタイプ・エラーケース・結合フローをカバー）

Closes #403