### PR TITLE
refactor: extract isRecord to shared type-guards module

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -4,6 +4,7 @@ import { buildTools } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
 import { executionError } from "../core/types/errors";
 import { err, ok } from "../core/types/result";
+import { isRecord } from "../core/types/type-guards";
 import type {
 	AgentExecutorInput,
 	AgentExecutorPort,
@@ -12,10 +13,6 @@ import type {
 import type { Logger } from "../usecase/port/logger";
 import { classifyAgentError, toExecutionError } from "./agent-error-handler";
 import type { StreamWriter } from "./stream-writer";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 export function createAgentExecutor(writer: StreamWriter, logger: Logger): AgentExecutorPort {
 	return {

--- a/src/core/types/type-guards.ts
+++ b/src/core/types/type-guards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
#### 概要

`isRecord` 型ガード関数を `agent-executor.ts` のローカル定義から `src/core/types/type-guards.ts` に抽出し、共通ユーティリティとして一元管理できるようにした。

#### 変更内容

- `src/core/types/type-guards.ts` を新規作成し、`isRecord` 関数を定義
- `src/adapter/agent-executor.ts` からローカルの `isRecord` 定義を削除し、共通モジュールからインポート

Closes #406