### PR TITLE
refactor: unify timeout handling across all tools

### DIFF
--- a/src/core/execution/tools/bash-tool.ts
+++ b/src/core/execution/tools/bash-tool.ts
@@ -3,6 +3,7 @@ import { execa } from "execa";
 import { z } from "zod";
 import { validateCommand } from "./command-validator";
 import { zodToJsonSchema } from "./schema-helper";
+import { DEFAULT_TOOL_TIMEOUT_MS } from "./tool-constants";
 import { type ToolResult, toolFailure, toolSuccess } from "./tool-output";
 
 export const bashParams = z.object({
@@ -29,7 +30,7 @@ export const bashTool: Tool<BashInput, ToolResult<BashData>> = {
 			const result = await execa(command, {
 				shell: true,
 				cwd: cwd ?? process.cwd(),
-				timeout: timeout ?? 30_000,
+				timeout: timeout ?? DEFAULT_TOOL_TIMEOUT_MS,
 				reject: false,
 			});
 			return toolSuccess({

--- a/src/core/execution/tools/fetch-tool.ts
+++ b/src/core/execution/tools/fetch-tool.ts
@@ -1,10 +1,10 @@
 import type { Tool } from "ai";
 import { z } from "zod";
 import { zodToJsonSchema } from "./schema-helper";
+import { DEFAULT_TOOL_TIMEOUT_MS } from "./tool-constants";
 import { type ToolResult, toolFailure, toolSuccess } from "./tool-output";
 
 export const MAX_FETCH_LENGTH = 50_000;
-const FETCH_TIMEOUT_MS = 30_000;
 
 const PRIVATE_IP_PREFIXES = ["10.", "192.168."] as const;
 const BLOCKED_HOSTNAMES = [
@@ -84,7 +84,7 @@ export const fetchTool: Tool<FetchInput, ToolResult<FetchData>> = {
 		let response: Response;
 		try {
 			response = await fetch(url, {
-				signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+				signal: AbortSignal.timeout(DEFAULT_TOOL_TIMEOUT_MS),
 				redirect: "error",
 			});
 		} catch {

--- a/src/core/execution/tools/read-tool.ts
+++ b/src/core/execution/tools/read-tool.ts
@@ -2,11 +2,16 @@ import { readFile } from "node:fs/promises";
 import type { Tool } from "ai";
 import { z } from "zod";
 import { zodToJsonSchema } from "./schema-helper";
+import { DEFAULT_TOOL_TIMEOUT_MS } from "./tool-constants";
 import { type ToolResult, toolFailure, toolSuccess } from "./tool-output";
 
 export const readParams = z.object({
 	path: z.string().describe("File path to read"),
-	encoding: z.string().optional().describe("File encoding (default: utf-8)"),
+	encoding: z
+		.enum(["utf-8", "ascii", "base64", "hex", "latin1", "utf16le"])
+		.optional()
+		.describe("File encoding (default: utf-8)"),
+	timeout: z.number().optional().describe("Timeout in milliseconds"),
 });
 
 type ReadInput = z.infer<typeof readParams>;
@@ -15,12 +20,20 @@ type ReadResult = { readonly content: string };
 export const readTool: Tool<ReadInput, ToolResult<ReadResult>> = {
 	description: "Read the contents of a file",
 	inputSchema: zodToJsonSchema(readParams),
-	execute: async ({ path }): Promise<ToolResult<ReadResult>> => {
+	execute: async ({ path, encoding, timeout }): Promise<ToolResult<ReadResult>> => {
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), timeout ?? DEFAULT_TOOL_TIMEOUT_MS);
+
 		try {
-			const content = await readFile(path, "utf-8");
+			const content = await readFile(path, {
+				encoding: encoding ?? "utf-8",
+				signal: controller.signal,
+			});
 			return toolSuccess({ content });
 		} catch {
 			return toolFailure(`Failed to read file: ${path}`);
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	},
 };

--- a/src/core/execution/tools/tool-constants.ts
+++ b/src/core/execution/tools/tool-constants.ts
@@ -1,0 +1,2 @@
+/** Shared timeout for all tool executions (milliseconds) */
+export const DEFAULT_TOOL_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
#### 概要

read-tool にタイムアウト処理を追加し、全ツールで共通のタイムアウト定数を使用するよう統一。

#### 変更内容

- `tool-constants.ts` を新規作成し `DEFAULT_TOOL_TIMEOUT_MS` を定義
- `read-tool` に `timeout` パラメータを追加（AbortController + signal パターン）
- `read-tool` の `encoding` パラメータを実際に使用するよう修正（以前は無視されていた）
- `encoding` を `z.string()` から `z.enum()` に変更し型安全性を向上
- `bash-tool` と `fetch-tool` のハードコード値を共通定数に置換

Closes #410