### PR TITLE
fix: add max_agent_steps to mergeCliConfig

### DIFF
--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -173,6 +173,7 @@ export function mergeHooksConfig(global: HooksConfig, project: HooksConfig): Hoo
 export function mergeCliConfig(global: CliConfig, project: CliConfig): CliConfig {
 	return {
 		command_timeout_ms: project.command_timeout_ms ?? global.command_timeout_ms,
+		max_agent_steps: project.max_agent_steps ?? global.max_agent_steps,
 	};
 }
 

--- a/tests/adapter/config-loader.test.ts
+++ b/tests/adapter/config-loader.test.ts
@@ -531,4 +531,16 @@ describe("mergeCliConfig", () => {
 
 		expect(result.command_timeout_ms).toBe(30000);
 	});
+
+	it("project max_agent_steps overrides global", () => {
+		const result = mergeCliConfig({ max_agent_steps: 50 }, { max_agent_steps: 100 });
+
+		expect(result.max_agent_steps).toBe(100);
+	});
+
+	it("falls back to global max_agent_steps when project is undefined", () => {
+		const result = mergeCliConfig({ max_agent_steps: 50 }, {});
+
+		expect(result.max_agent_steps).toBe(50);
+	});
 });


### PR DESCRIPTION
#### 概要

mergeCliConfig 関数に max_agent_steps フィールドのマージ処理を追加し、型定義と実装の不一致を修正。

#### 変更内容

- mergeCliConfig に max_agent_steps のマージロジックを追加（project ?? global パターン）
- max_agent_steps のマージに対するユニットテストを追加（override / fallback）

Closes #440