### PR TITLE
fix: resolveActionConfig で inputs がスキルから継承されるよう修正

### DIFF
--- a/src/core/skill/action.ts
+++ b/src/core/skill/action.ts
@@ -35,7 +35,7 @@ function resolveActionConfig(action: Action, skill: SkillMetadata): ResolvedActi
 		description: action.description,
 		mode: action.mode ?? skill.mode ?? "template",
 		model: action.model ?? skill.model ?? undefined,
-		inputs: action.inputs ?? [],
+		inputs: action.inputs ?? skill.inputs,
 		context: action.context ?? skill.context ?? [],
 		tools: action.tools ?? skill.tools ?? [...DEFAULT_TOOLS],
 		timeout: action.timeout ?? skill.timeout ?? undefined,

--- a/tests/core/skill/action.test.ts
+++ b/tests/core/skill/action.test.ts
@@ -80,7 +80,7 @@ describe("resolveActionConfig", () => {
 		expect(resolved.timeout).toBeUndefined();
 	});
 
-	it("inputs はスキルから継承しない", () => {
+	it("アクション未指定の inputs はスキルから継承される", () => {
 		const skill = baseSkill({
 			inputs: [{ name: "target", type: "text", message: "Target?" }],
 		});
@@ -88,7 +88,7 @@ describe("resolveActionConfig", () => {
 
 		const resolved = resolveActionConfig(action, skill);
 
-		expect(resolved.inputs).toStrictEqual([]);
+		expect(resolved.inputs).toStrictEqual([{ name: "target", type: "text", message: "Target?" }]);
 	});
 
 	it("アクション固有の inputs が使用される", () => {


### PR DESCRIPTION
#### 概要

`resolveActionConfig` の `inputs` フィールドが、アクション未指定時にスキルの `inputs` を継承せず空配列を返していた問題を修正。

#### 変更内容

- `action.inputs ?? []` → `action.inputs ?? skill.inputs` に修正し、他フィールドと同じ継承パターンに統一
- テストを更新し、inputs のスキル継承を検証

Closes #439