### PR TITLE
refactor: rename undefined_ to undefinedVars in template-renderer

### DIFF
--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -125,14 +125,14 @@ function findUndefinedVariables(
 	variables: Record<string, string>,
 	reserved: ReservedVars,
 ): readonly string[] {
-	const undefined_: string[] = [];
+	const undefinedVars: string[] = [];
 	for (const match of template.matchAll(VARIABLE_PATTERN)) {
 		const name = match[1];
 		if (resolveVariable(name, variables, reserved) === undefined) {
-			undefined_.push(name);
+			undefinedVars.push(name);
 		}
 	}
-	return [...new Set(undefined_)];
+	return [...new Set(undefinedVars)];
 }
 
 export function renderTemplate(


### PR DESCRIPTION
#### 概要

`findUndefinedVariables` 関数内の変数名 `undefined_` を `undefinedVars` に変更し、可読性とコーディング規約への準拠を改善。

#### 変更内容

- `src/core/variable/template-renderer.ts`: 変数名 `undefined_` → `undefinedVars` にリネーム

Closes #442