### PR TITLE
refactor: rename isTruthy to parseBooleanLike for Tell Don't Ask compliance

### DIFF
--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -71,9 +71,9 @@ function resolveVariable(
 	return variables[name];
 }
 
-// confirm 型は "true"/"false"、required: false は空文字になるため、
-// 両方を自然に扱えるよう空文字と "false" を falsy とする
-function isTruthy(value: string): boolean {
+// テンプレート変数の文字列値を真偽値にパースする。
+// confirm 型の "false" と未入力の空文字を false として扱う。
+function parseBooleanLike(value: string): boolean {
 	return value !== "" && value !== "false";
 }
 
@@ -108,7 +108,7 @@ function expandConditionals(
 				undefinedConditionVars.push(name);
 				return "";
 			}
-			return isTruthy(value) ? ifBlock : (elseBlock ?? "");
+			return parseBooleanLike(value) ? ifBlock : (elseBlock ?? "");
 		},
 	);
 

--- a/tests/core/variable/template-renderer.test.ts
+++ b/tests/core/variable/template-renderer.test.ts
@@ -142,6 +142,16 @@ describe("renderTemplate", () => {
 			expect(result).toEqual({ ok: true, value: "YES" });
 		});
 
+		it("treats empty string as falsy", () => {
+			const result = renderTemplate("{{#if val}}YES{{else}}NO{{/if}}", { val: "" }, RESERVED);
+			expect(result).toEqual({ ok: true, value: "NO" });
+		});
+
+		it('treats "false" string as falsy (confirm type)', () => {
+			const result = renderTemplate("{{#if val}}YES{{else}}NO{{/if}}", { val: "false" }, RESERVED);
+			expect(result).toEqual({ ok: true, value: "NO" });
+		});
+
 		it("works with multiline content in branches", () => {
 			const template = `{{#if verbose}}
 Line 1


### PR DESCRIPTION
#### 概要

template-renderer.ts の isTruthy() を parseBooleanLike() にリネームし、Tell Don't Ask 原則に準拠させた。

#### 変更内容

- isTruthy() を parseBooleanLike() にリネーム（値の意味をパース側が定義する設計に）
- コメントをパース関数としての意図に合わせて更新
- 空文字と "false" 文字列の falsy 判定テストを追加

Closes #443