### PR TITLE
refactor: remove unnecessary spread operator for DEFAULT_TOOLS

### DIFF
--- a/src/core/skill/action.ts
+++ b/src/core/skill/action.ts
@@ -37,7 +37,7 @@ function resolveActionConfig(action: Action, skill: SkillMetadata): ResolvedActi
 		model: action.model ?? skill.model ?? undefined,
 		inputs: action.inputs ?? skill.inputs,
 		context: action.context ?? skill.context ?? [],
-		tools: action.tools ?? skill.tools ?? [...DEFAULT_TOOLS],
+		tools: action.tools ?? skill.tools ?? DEFAULT_TOOLS,
 		timeout: action.timeout ?? skill.timeout ?? undefined,
 	};
 }


### PR DESCRIPTION
#### 概要

`action.ts` の `resolveActionConfig` で `DEFAULT_TOOLS` に対する不要なスプレッド演算子を削除。

#### 変更内容

- `src/core/skill/action.ts`: `[...DEFAULT_TOOLS]` → `DEFAULT_TOOLS` に変更（`ResolvedActionConfig.tools` は `readonly string[]` のため、readonly tuple をそのまま代入可能）
- `src/core/skill/skill-metadata.ts` のスプレッドは zod の `.default()` が mutable array を要求するため維持

Closes #445