### PR TITLE
refactor: extract shared action resolution logic in skill-execution-resolver

### DIFF
--- a/src/core/skill/skill-execution-resolver.ts
+++ b/src/core/skill/skill-execution-resolver.ts
@@ -2,6 +2,7 @@ import type { DomainError } from "../types/errors";
 import { executionError } from "../types/errors";
 import type { Result } from "../types/result";
 import { err, ok } from "../types/result";
+import type { ResolvedActionConfig } from "./action";
 import { resolveActionConfig } from "./action";
 import type { ContextSource } from "./context-source";
 import type { Skill } from "./skill";
@@ -22,6 +23,29 @@ export type TemplateExecutionConfig = {
 	readonly timeout: number | undefined;
 };
 
+type ActionResolution = {
+	readonly config: ResolvedActionConfig;
+	readonly content: string;
+};
+
+function resolveAction(skill: Skill, actionName: string): Result<ActionResolution, DomainError> {
+	const actions = skill.metadata.actions;
+	if (!actions?.[actionName]) {
+		return err(
+			executionError(`Action "${actionName}" is not defined in skill "${skill.metadata.name}"`),
+		);
+	}
+
+	const config = resolveActionConfig(actions[actionName], skill.metadata);
+
+	const sectionResult = skill.body.extractActionSection(actionName);
+	if (!sectionResult.ok) {
+		return sectionResult;
+	}
+
+	return ok({ config, content: sectionResult.value });
+}
+
 /**
  * エージェントモード実行に必要な設定を Skill から解決する。
  * actionName 指定時はアクション設定を優先し、未指定時はスキルレベルの設定を使用する。
@@ -39,25 +63,16 @@ export function resolveAgentExecution(
 		});
 	}
 
-	const actions = skill.metadata.actions;
-	if (!actions?.[actionName]) {
-		return err(
-			executionError(`Action "${actionName}" is not defined in skill "${skill.metadata.name}"`),
-		);
-	}
-
-	const config = resolveActionConfig(actions[actionName], skill.metadata);
-
-	const sectionResult = skill.body.extractActionSection(actionName);
-	if (!sectionResult.ok) {
-		return sectionResult;
+	const result = resolveAction(skill, actionName);
+	if (!result.ok) {
+		return result;
 	}
 
 	return ok({
-		inputs: config.inputs,
-		tools: config.tools,
-		context: config.context,
-		content: sectionResult.value,
+		inputs: result.value.config.inputs,
+		tools: result.value.config.tools,
+		context: result.value.config.context,
+		content: result.value.content,
 	});
 }
 
@@ -69,17 +84,14 @@ export function resolveTemplateExecution(
 	skill: Skill,
 	actionName: string | undefined,
 ): Result<TemplateExecutionConfig, DomainError> {
-	const hasActions = skill.metadata.actions !== undefined;
-
-	if (hasActions && !actionName) {
-		return err(
-			executionError(
-				`Skill "${skill.metadata.name}" has actions defined. Specify an action to run.`,
-			),
-		);
-	}
-
 	if (!actionName) {
+		if (skill.metadata.actions !== undefined) {
+			return err(
+				executionError(
+					`Skill "${skill.metadata.name}" has actions defined. Specify an action to run.`,
+				),
+			);
+		}
 		return ok({
 			inputs: skill.metadata.inputs,
 			content: skill.body.content,
@@ -88,29 +100,15 @@ export function resolveTemplateExecution(
 		});
 	}
 
-	const actions = skill.metadata.actions;
-	if (!actions) {
-		return err(executionError(`Skill "${skill.metadata.name}" does not define actions.`));
-	}
-
-	const actionDef = actions[actionName];
-	if (!actionDef) {
-		return err(
-			executionError(`Action "${actionName}" not found in skill "${skill.metadata.name}".`),
-		);
-	}
-
-	const config = resolveActionConfig(actionDef, skill.metadata);
-
-	const sectionResult = skill.body.extractActionSection(actionName);
-	if (!sectionResult.ok) {
-		return sectionResult;
+	const result = resolveAction(skill, actionName);
+	if (!result.ok) {
+		return result;
 	}
 
 	return ok({
-		inputs: config.inputs,
-		content: sectionResult.value,
+		inputs: result.value.config.inputs,
+		content: result.value.content,
 		codeBlocks: skill.body.extractActionCodeBlocks(actionName, "bash"),
-		timeout: config.timeout,
+		timeout: result.value.config.timeout,
 	});
 }


### PR DESCRIPTION
#### 概要

`resolveAgentExecution` と `resolveTemplateExecution` の重複ロジックを共通ヘルパー関数に抽出し、エラーメッセージの一貫性を改善。

#### 変更内容

- アクションの検証・設定解決・セクション抽出を行う `resolveAction` ヘルパー関数を抽出
- エラーメッセージを "is not defined" に統一（旧: "not found" / "does not define actions" が混在）
- 既存のテスト（723件）すべてパス確認済み

Closes #446