### PR TITLE
refactor: isTruthy を parseBoolean にリネームし BooleanLike 型を導入

### DIFF
--- a/src/core/variable/template-renderer.ts
+++ b/src/core/variable/template-renderer.ts
@@ -77,9 +77,10 @@ function createVariableMap(variables: Record<string, string>, reserved: Reserved
 	return (name: string) => resolveVariable(name, variables, reserved);
 }
 
-// confirm 型は "true"/"false"、required: false は空文字になるため、
-// 両方を自然に扱えるよう空文字と "false" を falsy とする
-function isTruthy(value: string): boolean {
+// confirm 型の入力値が取りうる falsy 表現
+type BooleanLike = string;
+
+function parseBoolean(value: BooleanLike): boolean {
 	return value !== "" && value !== "false";
 }
 
@@ -110,7 +111,7 @@ function expandConditionals(template: string, varMap: VariableMap): Result<strin
 				undefinedConditionVars.push(name);
 				return "";
 			}
-			return isTruthy(value) ? ifBlock : (elseBlock ?? "");
+			return parseBoolean(value) ? ifBlock : (elseBlock ?? "");
 		},
 	);
 


### PR DESCRIPTION
#### 概要

template-renderer.ts の isTruthy 関数を parseBoolean にリネームし、BooleanLike 型エイリアスを導入。Tell Don't Ask 原則に従い、関数の意味論を名前と型で明示化。

#### 変更内容

- isTruthy(value: string) を parseBoolean(value: BooleanLike) にリネーム
- BooleanLike 型エイリアスを追加し、confirm 型入力の意味論をドキュメント化

Closes #443