### PR TITLE
fix: allowedRoots で setup --global のバンドルスキルシンボリックリンクを許可

### DIFF
--- a/src/adapter/bundled-skills-dir.ts
+++ b/src/adapter/bundled-skills-dir.ts
@@ -1,0 +1,31 @@
+import { stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * taskp パッケージに同梱されたデフォルトスキルのディレクトリ候補を返す。
+ *
+ * - 開発時: src/adapter/ → ../../skills
+ * - ビルド後: dist/ → ../skills
+ */
+export function getBundledSkillsDirCandidates(): readonly string[] {
+	const currentDir =
+		typeof import.meta.dirname === "string"
+			? import.meta.dirname
+			: dirname(fileURLToPath(import.meta.url));
+	return [resolve(currentDir, "..", "skills"), resolve(currentDir, "..", "..", "skills")];
+}
+
+export async function resolveBundledSkillsDir(
+	candidates: readonly string[],
+): Promise<string | undefined> {
+	for (const candidate of candidates) {
+		try {
+			await stat(candidate);
+			return candidate;
+		} catch {
+			// candidate does not exist
+		}
+	}
+	return undefined;
+}

--- a/src/adapter/project-initializer.ts
+++ b/src/adapter/project-initializer.ts
@@ -1,5 +1,4 @@
-import { dirname, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
 import { z } from "zod";
 import type { Result } from "../core/types/result";
 import type {
@@ -8,6 +7,7 @@ import type {
 	SetupLocation,
 	SetupResult,
 } from "../usecase/port/project-initializer";
+import { getBundledSkillsDirCandidates } from "./bundled-skills-dir";
 import { configSchema } from "./config-loader";
 import { tryCatch } from "./error-handler-utils";
 import type { FileSystemPort } from "./file-system-port";
@@ -120,21 +120,6 @@ async function createDirIfNeeded(
 	if (!existed) {
 		created.push(relative(baseDir, entry.path));
 	}
-}
-
-/**
- * taskp パッケージに同梱されたデフォルトスキルのディレクトリ候補を返す。
- * 呼び出し元で非同期に存在確認を行う。
- *
- * - 開発時: src/adapter/ → ../../skills
- * - ビルド後: dist/ → ../skills
- */
-function getBundledSkillsDirCandidates(): readonly string[] {
-	const currentDir =
-		typeof import.meta.dirname === "string"
-			? import.meta.dirname
-			: dirname(fileURLToPath(import.meta.url));
-	return [resolve(currentDir, "..", "skills"), resolve(currentDir, "..", "..", "skills")];
 }
 
 async function resolveBundledSkillsDir(

--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -8,6 +8,7 @@ import { parseError, type SkillNotFoundError, skillNotFoundError } from "../core
 import type { Result } from "../core/types/result";
 import { err } from "../core/types/result";
 import type { SkillLoadResult, SkillRepository } from "../usecase/port/skill-repository";
+import { getBundledSkillsDirCandidates, resolveBundledSkillsDir } from "./bundled-skills-dir";
 
 const SKILL_DIR_NAME = ".taskp/skills";
 const SKILL_FILE_NAME = "SKILL.md";
@@ -23,6 +24,7 @@ type SkillLoaderDeps = {
 	readonly localRoot: string;
 	readonly globalRoot: string;
 	readonly logger?: SkillLogger;
+	readonly allowedRoots?: readonly string[];
 };
 
 export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
@@ -30,18 +32,22 @@ export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const globalSkillsDir = resolve(deps.globalRoot, SKILL_DIR_NAME);
 
 	const { logger } = deps;
+	const allowedRoots = deps.allowedRoots ?? [];
 	return {
-		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, logger),
-		listAll: () => listAll(localSkillsDir, globalSkillsDir, logger),
-		listLocal: () => scanDirectory(localSkillsDir, "local", logger),
-		listGlobal: () => scanDirectory(globalSkillsDir, "global", logger),
+		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, allowedRoots, logger),
+		listAll: () => listAll(localSkillsDir, globalSkillsDir, allowedRoots, logger),
+		listLocal: () => scanDirectory(localSkillsDir, "local", allowedRoots, logger),
+		listGlobal: () => scanDirectory(globalSkillsDir, "global", allowedRoots, logger),
 	};
 }
 
-export function createDefaultSkillLoader(projectRoot: string): SkillRepository {
+export async function createDefaultSkillLoader(projectRoot: string): Promise<SkillRepository> {
+	const bundledSkillsDir = await resolveBundledSkillsDir(getBundledSkillsDirCandidates());
+	const allowedRoots = bundledSkillsDir ? [bundledSkillsDir] : [];
 	return createSkillLoader({
 		localRoot: projectRoot,
 		globalRoot: homedir(),
+		allowedRoots,
 	});
 }
 
@@ -49,10 +55,11 @@ async function findByName(
 	name: string,
 	localSkillsDir: string,
 	globalSkillsDir: string,
+	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<Result<Skill, SkillNotFoundError>> {
 	const localDir = join(localSkillsDir, name);
-	if (await isSymlinkOutsideRoot(localDir, localSkillsDir)) {
+	if (await isSymlinkOutsideRoot(localDir, localSkillsDir, allowedRoots)) {
 		logger?.warn(`Skipping symlink outside skills root: ${localDir}`);
 	} else {
 		const localPath = join(localDir, SKILL_FILE_NAME);
@@ -63,7 +70,7 @@ async function findByName(
 	}
 
 	const globalDir = join(globalSkillsDir, name);
-	if (await isSymlinkOutsideRoot(globalDir, globalSkillsDir)) {
+	if (await isSymlinkOutsideRoot(globalDir, globalSkillsDir, allowedRoots)) {
 		logger?.warn(`Skipping symlink outside skills root: ${globalDir}`);
 	} else {
 		const globalPath = join(globalDir, SKILL_FILE_NAME);
@@ -79,11 +86,12 @@ async function findByName(
 async function listAll(
 	localSkillsDir: string,
 	globalSkillsDir: string,
+	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
 	const [localResult, globalResult] = await Promise.all([
-		scanDirectory(localSkillsDir, "local", logger),
-		scanDirectory(globalSkillsDir, "global", logger),
+		scanDirectory(localSkillsDir, "local", allowedRoots, logger),
+		scanDirectory(globalSkillsDir, "global", allowedRoots, logger),
 	]);
 
 	const localNames = new Set(localResult.skills.map((s) => s.metadata.name));
@@ -98,6 +106,7 @@ async function listAll(
 async function scanDirectory(
 	skillsDir: string,
 	scope: SkillScope,
+	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
 	const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
@@ -111,7 +120,7 @@ async function scanDirectory(
 	for (const entry of entries.filter((e) => e.isDirectory() || e.isSymbolicLink())) {
 		if (entry.isSymbolicLink()) {
 			const entryPath = join(skillsDir, entry.name);
-			const withinRoot = await isWithinRoot(entryPath, skillsDir);
+			const withinRoot = await isWithinRoot(entryPath, skillsDir, allowedRoots);
 			if (!withinRoot) {
 				logger?.warn(`Skipping symlink outside skills root: ${entryPath}`);
 				continue;
@@ -159,23 +168,40 @@ function isFileNotFound(e: unknown): boolean {
 	return e instanceof Error && "code" in e && e.code === FILE_NOT_FOUND_CODE;
 }
 
-async function isWithinRoot(symlinkPath: string, rootDir: string): Promise<boolean> {
+async function isWithinRoot(
+	symlinkPath: string,
+	rootDir: string,
+	allowedRoots: readonly string[],
+): Promise<boolean> {
 	try {
 		const resolved = await realpath(symlinkPath);
 		const normalizedRoot = await realpath(rootDir);
-		return resolved.startsWith(`${normalizedRoot}/`);
+		if (resolved.startsWith(`${normalizedRoot}/`)) {
+			return true;
+		}
+		for (const allowed of allowedRoots) {
+			const normalizedAllowed = await realpath(allowed);
+			if (resolved.startsWith(`${normalizedAllowed}/`)) {
+				return true;
+			}
+		}
+		return false;
 	} catch {
 		return false;
 	}
 }
 
-async function isSymlinkOutsideRoot(path: string, rootDir: string): Promise<boolean> {
+async function isSymlinkOutsideRoot(
+	path: string,
+	rootDir: string,
+	allowedRoots: readonly string[],
+): Promise<boolean> {
 	try {
 		const stat = await lstat(path);
 		if (!stat.isSymbolicLink()) {
 			return false;
 		}
-		return !(await isWithinRoot(path, rootDir));
+		return !(await isWithinRoot(path, rootDir, allowedRoots));
 	} catch {
 		return false;
 	}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -161,7 +161,7 @@ const cli = Cli.create("taskp", {
 			const ref = exitOnError(parseSkillRef(c.args.skill));
 
 			const presets = parsePresets(c.options.set ?? []);
-			const skillRepository = createDefaultSkillLoader(process.cwd());
+			const skillRepository = await createDefaultSkillLoader(process.cwd());
 			const promptCollector = createPromptRunner();
 
 			const skill = exitOnError(await skillRepository.findByName(ref.name));
@@ -228,7 +228,7 @@ const cli = Cli.create("taskp", {
 		}),
 		async run(c) {
 			const scope = resolveScope(c.options.global, c.options.local);
-			const repository = createDefaultSkillLoader(process.cwd());
+			const repository = await createDefaultSkillLoader(process.cwd());
 			const usecase = createListSkillsUseCase(repository);
 			const { skills } = await usecase.execute({ scope });
 
@@ -263,7 +263,7 @@ const cli = Cli.create("taskp", {
 				? c.options.actions.split(",").map((a) => a.trim())
 				: undefined;
 
-			const skillRepository = createDefaultSkillLoader(process.cwd());
+			const skillRepository = await createDefaultSkillLoader(process.cwd());
 			const skillInitializer = createSkillInitializer({ baseDir });
 
 			const result = await initSkill(
@@ -282,7 +282,7 @@ const cli = Cli.create("taskp", {
 		async run(c) {
 			const ref = exitOnError(parseSkillRef(c.args.skill));
 
-			const repository = createDefaultSkillLoader(process.cwd());
+			const repository = await createDefaultSkillLoader(process.cwd());
 			const result = await showSkill(ref.name, repository, ref.action);
 
 			console.log(formatShowOutput(exitOnError(result)));
@@ -348,7 +348,7 @@ type RunCommandContext = {
 async function runAgentMode(
 	c: RunCommandContext,
 	presets: Readonly<Record<string, string>>,
-	skillRepository: ReturnType<typeof createDefaultSkillLoader>,
+	skillRepository: Awaited<ReturnType<typeof createDefaultSkillLoader>>,
 	promptCollector: ReturnType<typeof createPromptRunner>,
 ): Promise<void> {
 	const configLoader = createDefaultConfigLoader(process.cwd());

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -40,7 +40,7 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 			}
 		});
 
-		const skillRepository = createDefaultSkillLoader(process.cwd());
+		const skillRepository = await createDefaultSkillLoader(process.cwd());
 		const { skills } = await skillRepository.listAll();
 
 		if (skills.length === 0) {

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -382,4 +382,116 @@ describe("SkillLoader", () => {
 			expect(failures).toHaveLength(0);
 		});
 	});
+
+	describe("allowedRoots", () => {
+		const externalDirs: string[] = [];
+
+		afterEach(() => {
+			for (const dir of externalDirs) {
+				rmSync(dir, { recursive: true, force: true });
+			}
+			externalDirs.length = 0;
+		});
+
+		it("allowedRoots に含まれる外部ディレクトリへのシンボリックリンクは読み込める", async () => {
+			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
+			externalDirs.push(bundledDir);
+			const bundledSkillDir = join(bundledDir, "analyze-image");
+			mkdirSync(bundledSkillDir, { recursive: true });
+			writeFileSync(
+				join(bundledSkillDir, "SKILL.md"),
+				makeSkillMd("analyze-image", "バンドルスキル"),
+			);
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(bundledSkillDir, join(skillsDir, "analyze-image"));
+
+			const loader = createSkillLoader({
+				localRoot,
+				globalRoot,
+				allowedRoots: [bundledDir],
+			});
+			const { skills } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("analyze-image");
+		});
+
+		it("allowedRoots に含まれる外部ディレクトリへのシンボリックリンクを findByName で検索できる", async () => {
+			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
+			externalDirs.push(bundledDir);
+			const bundledSkillDir = join(bundledDir, "web-search");
+			mkdirSync(bundledSkillDir, { recursive: true });
+			writeFileSync(
+				join(bundledSkillDir, "SKILL.md"),
+				makeSkillMd("web-search", "ウェブ検索スキル"),
+			);
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(bundledSkillDir, join(skillsDir, "web-search"));
+
+			const loader = createSkillLoader({
+				localRoot,
+				globalRoot,
+				allowedRoots: [bundledDir],
+			});
+			const result = await loader.findByName("web-search");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("web-search");
+			expect(result.value.scope).toBe("global");
+		});
+
+		it("allowedRoots に含まれない外部ディレクトリへのシンボリックリンクは引き続きスキップされる", async () => {
+			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
+			externalDirs.push(bundledDir);
+			const evilDir = mkdtempSync(join(tmpdir(), "taskp-evil-"));
+			externalDirs.push(evilDir);
+
+			const evilSkillDir = join(evilDir, "evil-skill");
+			mkdirSync(evilSkillDir, { recursive: true });
+			writeFileSync(join(evilSkillDir, "SKILL.md"), makeSkillMd("evil-skill", "悪意のあるスキル"));
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(evilSkillDir, join(skillsDir, "evil-skill"));
+
+			const loader = createSkillLoader({
+				localRoot,
+				globalRoot,
+				allowedRoots: [bundledDir],
+			});
+			const { skills } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(0);
+		});
+
+		it("allowedRoots と通常のスキルルート内リンクが共存できる", async () => {
+			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
+			externalDirs.push(bundledDir);
+			const bundledSkillDir = join(bundledDir, "bundled-skill");
+			mkdirSync(bundledSkillDir, { recursive: true });
+			writeFileSync(join(bundledSkillDir, "SKILL.md"), makeSkillMd("bundled-skill", "バンドル"));
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(bundledSkillDir, join(skillsDir, "bundled-skill"));
+			createSkillFile(globalRoot, "normal-skill", makeSkillMd("normal-skill", "通常スキル"));
+
+			const loader = createSkillLoader({
+				localRoot,
+				globalRoot,
+				allowedRoots: [bundledDir],
+			});
+			const { skills } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(2);
+			const names = skills.map((s) => s.metadata.name);
+			expect(names).toContain("bundled-skill");
+			expect(names).toContain("normal-skill");
+		});
+	});
 });


### PR DESCRIPTION
#### 概要

`taskp setup --global` が作成するシンボリックリンクが `isWithinRoot` チェックで拒否される問題を修正。

#### 変更内容

- `bundled-skills-dir.ts` をバンドルスキルディレクトリ解決の共有ユーティリティとして抽出
- `SkillLoaderDeps` に `allowedRoots` パラメータを追加し、`isWithinRoot` がバンドルスキルディレクトリへのシンボリックリンクを許可するように変更
- `createDefaultSkillLoader` を `async` 化し、バンドルスキルパスを自動解決して `allowedRoots` に設定
- 呼び出し側 (`cli.ts`, `tui/app.ts`) に `await` を追加
- `allowedRoots` に関するテストを4件追加

Closes #455