### PR TITLE
fix: allow symlinked skills pointing outside the skills root directory

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -1,4 +1,4 @@
-import { lstat, readdir, readFile, realpath } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Skill, SkillLogger, SkillScope } from "../core/skill/skill";
@@ -8,7 +8,6 @@ import { parseError, type SkillNotFoundError, skillNotFoundError } from "../core
 import type { Result } from "../core/types/result";
 import { err } from "../core/types/result";
 import type { SkillLoadResult, SkillRepository } from "../usecase/port/skill-repository";
-import { getBundledSkillsDirCandidates, resolveBundledSkillsDir } from "./bundled-skills-dir";
 
 const SKILL_DIR_NAME = ".taskp/skills";
 const SKILL_FILE_NAME = "SKILL.md";
@@ -24,7 +23,6 @@ type SkillLoaderDeps = {
 	readonly localRoot: string;
 	readonly globalRoot: string;
 	readonly logger?: SkillLogger;
-	readonly allowedRoots?: readonly string[];
 };
 
 export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
@@ -32,22 +30,18 @@ export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const globalSkillsDir = resolve(deps.globalRoot, SKILL_DIR_NAME);
 
 	const { logger } = deps;
-	const allowedRoots = deps.allowedRoots ?? [];
 	return {
-		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, allowedRoots, logger),
-		listAll: () => listAll(localSkillsDir, globalSkillsDir, allowedRoots, logger),
-		listLocal: () => scanDirectory(localSkillsDir, "local", allowedRoots, logger),
-		listGlobal: () => scanDirectory(globalSkillsDir, "global", allowedRoots, logger),
+		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, logger),
+		listAll: () => listAll(localSkillsDir, globalSkillsDir, logger),
+		listLocal: () => scanDirectory(localSkillsDir, "local", logger),
+		listGlobal: () => scanDirectory(globalSkillsDir, "global", logger),
 	};
 }
 
 export async function createDefaultSkillLoader(projectRoot: string): Promise<SkillRepository> {
-	const bundledSkillsDir = await resolveBundledSkillsDir(getBundledSkillsDirCandidates());
-	const allowedRoots = bundledSkillsDir ? [bundledSkillsDir] : [];
 	return createSkillLoader({
 		localRoot: projectRoot,
 		globalRoot: homedir(),
-		allowedRoots,
 	});
 }
 
@@ -55,29 +49,24 @@ async function findByName(
 	name: string,
 	localSkillsDir: string,
 	globalSkillsDir: string,
-	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<Result<Skill, SkillNotFoundError>> {
-	const localDir = join(localSkillsDir, name);
-	if (await isSymlinkOutsideRoot(localDir, localSkillsDir, allowedRoots)) {
-		logger?.warn(`Skipping symlink outside skills root: ${localDir}`);
-	} else {
-		const localPath = join(localDir, SKILL_FILE_NAME);
-		const localResult = await tryLoadSkill(localPath, "local", logger);
-		if (localResult.type === "found") {
-			return localResult;
-		}
+	const localPath = join(localSkillsDir, name, SKILL_FILE_NAME);
+	const localResult = await tryLoadSkill(localPath, "local", logger);
+	if (localResult.type === "found") {
+		return localResult;
+	}
+	if (localResult.type === "error") {
+		logger?.warn(`Failed to load skill "${name}" from local: ${localResult.error.message}`);
 	}
 
-	const globalDir = join(globalSkillsDir, name);
-	if (await isSymlinkOutsideRoot(globalDir, globalSkillsDir, allowedRoots)) {
-		logger?.warn(`Skipping symlink outside skills root: ${globalDir}`);
-	} else {
-		const globalPath = join(globalDir, SKILL_FILE_NAME);
-		const globalResult = await tryLoadSkill(globalPath, "global", logger);
-		if (globalResult.type === "found") {
-			return globalResult;
-		}
+	const globalPath = join(globalSkillsDir, name, SKILL_FILE_NAME);
+	const globalResult = await tryLoadSkill(globalPath, "global", logger);
+	if (globalResult.type === "found") {
+		return globalResult;
+	}
+	if (globalResult.type === "error") {
+		logger?.warn(`Failed to load skill "${name}" from global: ${globalResult.error.message}`);
 	}
 
 	return err(skillNotFoundError(name));
@@ -86,12 +75,11 @@ async function findByName(
 async function listAll(
 	localSkillsDir: string,
 	globalSkillsDir: string,
-	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
 	const [localResult, globalResult] = await Promise.all([
-		scanDirectory(localSkillsDir, "local", allowedRoots, logger),
-		scanDirectory(globalSkillsDir, "global", allowedRoots, logger),
+		scanDirectory(localSkillsDir, "local", logger),
+		scanDirectory(globalSkillsDir, "global", logger),
 	]);
 
 	const localNames = new Set(localResult.skills.map((s) => s.metadata.name));
@@ -106,7 +94,6 @@ async function listAll(
 async function scanDirectory(
 	skillsDir: string,
 	scope: SkillScope,
-	allowedRoots: readonly string[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
 	const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
@@ -120,11 +107,15 @@ async function scanDirectory(
 	for (const entry of entries.filter((e) => e.isDirectory() || e.isSymbolicLink())) {
 		if (entry.isSymbolicLink()) {
 			const entryPath = join(skillsDir, entry.name);
-			const withinRoot = await isWithinRoot(entryPath, skillsDir, allowedRoots);
-			if (!withinRoot) {
-				logger?.warn(`Skipping symlink outside skills root: ${entryPath}`);
-				continue;
-			}
+			const isDir = await stat(entryPath)
+				.then((s) => s.isDirectory())
+				.catch((e: unknown) => {
+					if (!isFileNotFound(e)) {
+						logger?.warn(`Failed to stat symlink: ${entryPath}`);
+					}
+					return false;
+				});
+			if (!isDir) continue;
 		}
 
 		const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
@@ -166,43 +157,4 @@ async function tryLoadSkill(
 
 function isFileNotFound(e: unknown): boolean {
 	return e instanceof Error && "code" in e && e.code === FILE_NOT_FOUND_CODE;
-}
-
-async function isWithinRoot(
-	symlinkPath: string,
-	rootDir: string,
-	allowedRoots: readonly string[],
-): Promise<boolean> {
-	try {
-		const resolved = await realpath(symlinkPath);
-		const normalizedRoot = await realpath(rootDir);
-		if (resolved.startsWith(`${normalizedRoot}/`)) {
-			return true;
-		}
-		for (const allowed of allowedRoots) {
-			const normalizedAllowed = await realpath(allowed);
-			if (resolved.startsWith(`${normalizedAllowed}/`)) {
-				return true;
-			}
-		}
-		return false;
-	} catch {
-		return false;
-	}
-}
-
-async function isSymlinkOutsideRoot(
-	path: string,
-	rootDir: string,
-	allowedRoots: readonly string[],
-): Promise<boolean> {
-	try {
-		const stat = await lstat(path);
-		if (!stat.isSymbolicLink()) {
-			return false;
-		}
-		return !(await isWithinRoot(path, rootDir, allowedRoots));
-	} catch {
-		return false;
-	}
 }

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -273,23 +273,27 @@ describe("SkillLoader", () => {
 			expect(result.value.scope).toBe("global");
 		});
 
-		it("スキルルート外へのシンボリックリンクは findByName でスキップされる", async () => {
+		it("スキルルート外へのシンボリックリンクを findByName で読み込める", async () => {
 			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
 			externalDirs.push(externalDir);
-			const externalSkillDir = join(externalDir, "evil-skill");
+			const externalSkillDir = join(externalDir, "external-skill");
 			mkdirSync(externalSkillDir, { recursive: true });
-			writeFileSync(join(externalSkillDir, "SKILL.md"), makeSkillMd("evil-skill", "外部スキル"));
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("external-skill", "外部スキル"),
+			);
 
 			const skillsDir = join(localRoot, ".taskp", "skills");
 			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
+			symlinkSync(externalSkillDir, join(skillsDir, "external-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const result = await loader.findByName("evil-skill");
+			const result = await loader.findByName("external-skill");
 
-			expect(result.ok).toBe(false);
-			if (result.ok) return;
-			expect(result.error.type).toBe("SKILL_NOT_FOUND");
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("external-skill");
+			expect(result.value.scope).toBe("local");
 		});
 
 		it("壊れたシンボリックリンクはスキップされる", async () => {
@@ -304,48 +308,128 @@ describe("SkillLoader", () => {
 			expect(failures).toHaveLength(0);
 		});
 
-		it("スキルルート外へのシンボリックリンクはスキップされる", async () => {
-			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
-			externalDirs.push(externalDir);
-			const externalSkillDir = join(externalDir, "evil-skill");
-			mkdirSync(externalSkillDir, { recursive: true });
-			writeFileSync(
-				join(externalSkillDir, "SKILL.md"),
-				makeSkillMd("evil-skill", "スキルルート外"),
-			);
-
+		it("壊れたシンボリックリンクを findByName で指定すると SKILL_NOT_FOUND を返す", async () => {
 			const skillsDir = join(localRoot, ".taskp", "skills");
 			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
+			symlinkSync("/nonexistent/path/to/skill", join(skillsDir, "broken-link"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills, failures } = await loader.listLocal();
+			const result = await loader.findByName("broken-link");
 
-			expect(skills).toHaveLength(0);
-			expect(failures).toHaveLength(0);
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("SKILL_NOT_FOUND");
 		});
 
-		it("スキルルート外へのシンボリックリンクがあっても他のスキルは読み込める", async () => {
+		it("ファイルへのシンボリックリンクを findByName で指定すると SKILL_NOT_FOUND を返す", async () => {
 			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
 			externalDirs.push(externalDir);
-			const externalSkillDir = join(externalDir, "evil-skill");
+			const externalFile = join(externalDir, "not-a-dir.md");
+			writeFileSync(externalFile, makeSkillMd("oops", "ファイルリンク"));
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalFile, join(skillsDir, "file-link"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("file-link");
+
+			expect(result.ok).toBe(false);
+			if (result.ok) return;
+			expect(result.error.type).toBe("SKILL_NOT_FOUND");
+		});
+
+		it("スキルルート外へのシンボリックリンクを読み込める", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "external-skill");
 			mkdirSync(externalSkillDir, { recursive: true });
 			writeFileSync(
 				join(externalSkillDir, "SKILL.md"),
-				makeSkillMd("evil-skill", "スキルルート外"),
+				makeSkillMd("external-skill", "スキルルート外"),
 			);
 
 			const skillsDir = join(localRoot, ".taskp", "skills");
 			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(externalSkillDir, join(skillsDir, "evil-skill"));
-			createSkillFile(localRoot, "valid-skill", makeSkillMd("valid-skill", "正常スキル"));
+			symlinkSync(externalSkillDir, join(skillsDir, "external-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
 			const { skills, failures } = await loader.listLocal();
 
 			expect(skills).toHaveLength(1);
-			expect(skills[0].metadata.name).toBe("valid-skill");
+			expect(skills[0].metadata.name).toBe("external-skill");
 			expect(failures).toHaveLength(0);
+		});
+
+		it("スキルルート外へのシンボリックリンクと通常スキルが共存できる", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "external-skill");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("external-skill", "スキルルート外"),
+			);
+
+			const skillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "external-skill"));
+			createSkillFile(localRoot, "valid-skill", makeSkillMd("valid-skill", "正常スキル"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listLocal();
+
+			expect(skills).toHaveLength(2);
+			const names = skills.map((s) => s.metadata.name);
+			expect(names).toContain("external-skill");
+			expect(names).toContain("valid-skill");
+			expect(failures).toHaveLength(0);
+		});
+
+		it("グローバル側のスキルルート外へのシンボリックリンクを listGlobal で読み込める", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "global-external");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("global-external", "グローバル外部スキル"),
+			);
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "global-external"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("global-external");
+			expect(skills[0].scope).toBe("global");
+			expect(failures).toHaveLength(0);
+		});
+
+		it("グローバル側のスキルルート外へのシンボリックリンクを findByName で読み込める", async () => {
+			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
+			externalDirs.push(externalDir);
+			const externalSkillDir = join(externalDir, "global-external");
+			mkdirSync(externalSkillDir, { recursive: true });
+			writeFileSync(
+				join(externalSkillDir, "SKILL.md"),
+				makeSkillMd("global-external", "グローバル外部スキル"),
+			);
+
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+			symlinkSync(externalSkillDir, join(skillsDir, "global-external"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("global-external");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.name).toBe("global-external");
+			expect(result.value.scope).toBe("global");
 		});
 
 		it("スキルルート内のサブディレクトリへのシンボリックリンクは読み込める", async () => {
@@ -365,7 +449,7 @@ describe("SkillLoader", () => {
 			expect(innerSkill).toBeDefined();
 		});
 
-		it("スキルルート外のファイルへのシンボリックリンクはスキップされる", async () => {
+		it("ファイルへのシンボリックリンクはスキルとして読み込まれない", async () => {
 			const externalDir = mkdtempSync(join(tmpdir(), "taskp-external-"));
 			externalDirs.push(externalDir);
 			const externalFile = join(externalDir, "not-a-dir.md");
@@ -380,118 +464,6 @@ describe("SkillLoader", () => {
 
 			expect(skills).toHaveLength(0);
 			expect(failures).toHaveLength(0);
-		});
-	});
-
-	describe("allowedRoots", () => {
-		const externalDirs: string[] = [];
-
-		afterEach(() => {
-			for (const dir of externalDirs) {
-				rmSync(dir, { recursive: true, force: true });
-			}
-			externalDirs.length = 0;
-		});
-
-		it("allowedRoots に含まれる外部ディレクトリへのシンボリックリンクは読み込める", async () => {
-			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
-			externalDirs.push(bundledDir);
-			const bundledSkillDir = join(bundledDir, "analyze-image");
-			mkdirSync(bundledSkillDir, { recursive: true });
-			writeFileSync(
-				join(bundledSkillDir, "SKILL.md"),
-				makeSkillMd("analyze-image", "バンドルスキル"),
-			);
-
-			const skillsDir = join(globalRoot, ".taskp", "skills");
-			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(bundledSkillDir, join(skillsDir, "analyze-image"));
-
-			const loader = createSkillLoader({
-				localRoot,
-				globalRoot,
-				allowedRoots: [bundledDir],
-			});
-			const { skills } = await loader.listGlobal();
-
-			expect(skills).toHaveLength(1);
-			expect(skills[0].metadata.name).toBe("analyze-image");
-		});
-
-		it("allowedRoots に含まれる外部ディレクトリへのシンボリックリンクを findByName で検索できる", async () => {
-			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
-			externalDirs.push(bundledDir);
-			const bundledSkillDir = join(bundledDir, "web-search");
-			mkdirSync(bundledSkillDir, { recursive: true });
-			writeFileSync(
-				join(bundledSkillDir, "SKILL.md"),
-				makeSkillMd("web-search", "ウェブ検索スキル"),
-			);
-
-			const skillsDir = join(globalRoot, ".taskp", "skills");
-			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(bundledSkillDir, join(skillsDir, "web-search"));
-
-			const loader = createSkillLoader({
-				localRoot,
-				globalRoot,
-				allowedRoots: [bundledDir],
-			});
-			const result = await loader.findByName("web-search");
-
-			expect(result.ok).toBe(true);
-			if (!result.ok) return;
-			expect(result.value.metadata.name).toBe("web-search");
-			expect(result.value.scope).toBe("global");
-		});
-
-		it("allowedRoots に含まれない外部ディレクトリへのシンボリックリンクは引き続きスキップされる", async () => {
-			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
-			externalDirs.push(bundledDir);
-			const evilDir = mkdtempSync(join(tmpdir(), "taskp-evil-"));
-			externalDirs.push(evilDir);
-
-			const evilSkillDir = join(evilDir, "evil-skill");
-			mkdirSync(evilSkillDir, { recursive: true });
-			writeFileSync(join(evilSkillDir, "SKILL.md"), makeSkillMd("evil-skill", "悪意のあるスキル"));
-
-			const skillsDir = join(globalRoot, ".taskp", "skills");
-			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(evilSkillDir, join(skillsDir, "evil-skill"));
-
-			const loader = createSkillLoader({
-				localRoot,
-				globalRoot,
-				allowedRoots: [bundledDir],
-			});
-			const { skills } = await loader.listGlobal();
-
-			expect(skills).toHaveLength(0);
-		});
-
-		it("allowedRoots と通常のスキルルート内リンクが共存できる", async () => {
-			const bundledDir = mkdtempSync(join(tmpdir(), "taskp-bundled-"));
-			externalDirs.push(bundledDir);
-			const bundledSkillDir = join(bundledDir, "bundled-skill");
-			mkdirSync(bundledSkillDir, { recursive: true });
-			writeFileSync(join(bundledSkillDir, "SKILL.md"), makeSkillMd("bundled-skill", "バンドル"));
-
-			const skillsDir = join(globalRoot, ".taskp", "skills");
-			mkdirSync(skillsDir, { recursive: true });
-			symlinkSync(bundledSkillDir, join(skillsDir, "bundled-skill"));
-			createSkillFile(globalRoot, "normal-skill", makeSkillMd("normal-skill", "通常スキル"));
-
-			const loader = createSkillLoader({
-				localRoot,
-				globalRoot,
-				allowedRoots: [bundledDir],
-			});
-			const { skills } = await loader.listGlobal();
-
-			expect(skills).toHaveLength(2);
-			const names = skills.map((s) => s.metadata.name);
-			expect(names).toContain("bundled-skill");
-			expect(names).toContain("normal-skill");
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- `~/.taskp/skills/` や `./.taskp/skills/` にシンボリックリンクで配置した外部スキルが読み込まれないバグを修正
- `isWithinRoot` / `isSymlinkOutsideRoot` チェックと `allowedRoots` メカニズムを完全に削除
- シンボリックリンク先がディレクトリかどうかを `stat` で検証し、ファイルへのリンクは静かにスキップ

## Changes

### `src/adapter/skill-loader.ts`
- `isWithinRoot`, `isSymlinkOutsideRoot` 関数を削除
- `SkillLoaderDeps` から `allowedRoots` プロパティを削除
- `createDefaultSkillLoader` から `bundledSkillsDir` 解決と `allowedRoots` 組み立てを削除
- `scanDirectory` でシンボリックリンク先が `stat` でディレクトリかを検証（`ENOENT` 以外のエラーは `logger.warn`）
- `findByName` で `tryLoadSkill` が `error` を返した場合に `logger.warn` で通知（以前は静かに無視されていた）

### `tests/adapter/skill-loader.test.ts`
- 「ルート外シンボリックリンクはスキップされる」テストを「ルート外でも読み込める」に変更
- `allowedRoots` テストブロックを削除（機能削除に伴い不要）
- 新規テスト追加:
  - `findByName` で壊れたシンボリックリンクを指定 → `SKILL_NOT_FOUND`
  - `findByName` でファイルへのシンボリックリンクを指定 → `SKILL_NOT_FOUND`
  - グローバル側の外部シンボリックリンクで `listGlobal` が読み込める
  - グローバル側の外部シンボリックリンクで `findByName` が読み込める

## Why

`allowedRoots` は元々バンドルスキル（`taskp setup` で作成されるシンボリックリンク）を許可するために導入されたが、ユーザーが自分で張った外部シンボリックリンクもすべてブロックしていた。taskp はローカル CLI ツールであり、スキルディレクトリにシンボリックリンクを張れる時点でそのファイルシステムへのアクセス権限がある。ルート外チェックの実質的なセキュリティ効果はなく、ユーザビリティを損なっていた。