### PR TITLE
feat: add McpToolRef type and parser for MCP tool references

### DIFF
--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -12,3 +12,5 @@ export type {
 export { buildTaskpRunDescription, buildTools, TOOL_NAMES } from "./agent-tools.js";
 export type { ContentPart, ImagePart, TextPart } from "./content-part.js";
 export type { ExecutionMode } from "./execution-mode.js";
+export type { McpToolRef, PartitionedToolRefs } from "./mcp-tool-ref.js";
+export { isMcpToolRef, parseMcpToolRef, partitionToolRefs } from "./mcp-tool-ref.js";

--- a/src/core/execution/mcp-tool-ref.ts
+++ b/src/core/execution/mcp-tool-ref.ts
@@ -1,0 +1,63 @@
+import { type ParseError, parseError } from "../types/errors";
+import { err, ok, type Result } from "../types/result";
+
+const MCP_PREFIX = "mcp:";
+
+export type McpToolRef =
+	| { readonly type: "all"; readonly server: string }
+	| { readonly type: "specific"; readonly server: string; readonly tool: string };
+
+export function isMcpToolRef(value: string): boolean {
+	return value.startsWith(MCP_PREFIX);
+}
+
+export function parseMcpToolRef(value: string): Result<McpToolRef, ParseError> {
+	const body = value.slice(MCP_PREFIX.length);
+	const slashIndex = body.indexOf("/");
+
+	if (slashIndex === -1) {
+		if (body === "") {
+			return err(parseError(`Invalid MCP tool reference "${value}": empty server name`));
+		}
+		return ok({ type: "all", server: body });
+	}
+
+	const server = body.slice(0, slashIndex);
+	const tool = body.slice(slashIndex + 1);
+
+	if (server === "") {
+		return err(parseError(`Invalid MCP tool reference "${value}": empty server name`));
+	}
+	if (tool === "") {
+		return err(parseError(`Invalid MCP tool reference "${value}": empty tool name`));
+	}
+
+	return ok({ type: "specific", server, tool });
+}
+
+export type PartitionedToolRefs = {
+	readonly builtins: readonly string[];
+	readonly mcpRefs: readonly McpToolRef[];
+};
+
+export function partitionToolRefs(
+	tools: readonly string[],
+): Result<PartitionedToolRefs, ParseError> {
+	const builtins: string[] = [];
+	const mcpRefs: McpToolRef[] = [];
+
+	for (const tool of tools) {
+		if (!isMcpToolRef(tool)) {
+			builtins.push(tool);
+			continue;
+		}
+
+		const result = parseMcpToolRef(tool);
+		if (!result.ok) {
+			return result;
+		}
+		mcpRefs.push(result.value);
+	}
+
+	return ok({ builtins, mcpRefs });
+}

--- a/tests/core/execution/mcp-tool-ref.test.ts
+++ b/tests/core/execution/mcp-tool-ref.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+	isMcpToolRef,
+	parseMcpToolRef,
+	partitionToolRefs,
+} from "../../../src/core/execution/mcp-tool-ref";
+
+describe("isMcpToolRef", () => {
+	it("mcp: プレフィックスを持つ文字列に true を返す", () => {
+		expect(isMcpToolRef("mcp:github")).toBe(true);
+	});
+
+	it("mcp:server/tool 形式に true を返す", () => {
+		expect(isMcpToolRef("mcp:slack/post_message")).toBe(true);
+	});
+
+	it("mcp: プレフィックスのない文字列に false を返す", () => {
+		expect(isMcpToolRef("bash")).toBe(false);
+	});
+
+	it("空文字列に false を返す", () => {
+		expect(isMcpToolRef("")).toBe(false);
+	});
+
+	it("mcp を含むが mcp: で始まらない文字列に false を返す", () => {
+		expect(isMcpToolRef("my-mcp:test")).toBe(false);
+	});
+});
+
+describe("parseMcpToolRef", () => {
+	it("mcp:server を all 型としてパースする", () => {
+		const result = parseMcpToolRef("mcp:github");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({ type: "all", server: "github" });
+	});
+
+	it("mcp:server/tool を specific 型としてパースする", () => {
+		const result = parseMcpToolRef("mcp:slack/post_message");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({
+			type: "specific",
+			server: "slack",
+			tool: "post_message",
+		});
+	});
+
+	it("空サーバー名 mcp: でエラーを返す", () => {
+		const result = parseMcpToolRef("mcp:");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("empty server name");
+	});
+
+	it("空サーバー名・空ツール名 mcp:/ でエラーを返す", () => {
+		const result = parseMcpToolRef("mcp:/");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("empty server name");
+	});
+
+	it("空ツール名 mcp:github/ でエラーを返す", () => {
+		const result = parseMcpToolRef("mcp:github/");
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("empty tool name");
+	});
+});
+
+describe("partitionToolRefs", () => {
+	it("組み込みツールと MCP 参照を分離する", () => {
+		const result = partitionToolRefs(["bash", "read", "mcp:github"]);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({
+			builtins: ["bash", "read"],
+			mcpRefs: [{ type: "all", server: "github" }],
+		});
+	});
+
+	it("MCP 参照のみの配列を正しく分離する", () => {
+		const result = partitionToolRefs(["mcp:github", "mcp:slack/post_message"]);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({
+			builtins: [],
+			mcpRefs: [
+				{ type: "all", server: "github" },
+				{ type: "specific", server: "slack", tool: "post_message" },
+			],
+		});
+	});
+
+	it("組み込みツールのみの配列を正しく処理する", () => {
+		const result = partitionToolRefs(["bash", "read", "write"]);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({
+			builtins: ["bash", "read", "write"],
+			mcpRefs: [],
+		});
+	});
+
+	it("空配列を正しく処理する", () => {
+		const result = partitionToolRefs([]);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toStrictEqual({
+			builtins: [],
+			mcpRefs: [],
+		});
+	});
+
+	it("不正な MCP 参照でエラーを返す", () => {
+		const result = partitionToolRefs(["bash", "mcp:", "read"]);
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+		expect(result.error.message).toContain("empty server name");
+	});
+});


### PR DESCRIPTION
#### 概要

MCP ツール参照（`mcp:github`, `mcp:slack/post_message`）の型定義とパーサーを Domain 層に追加する。

#### 変更内容

- `McpToolRef` discriminated union 型（`all` / `specific`）を定義
- `parseMcpToolRef` パーサー関数を実装（`Result<McpToolRef, ParseError>` を返す）
- `isMcpToolRef` 判定関数を実装
- `partitionToolRefs` で tools 配列を組み込み名と MCP 参照に分離
- `core/execution/index.ts` から re-export
- 15 件のユニットテストを追加

Closes #459