### PR TITLE
feat: add MCP server config schema to config.toml

### DIFF
--- a/.taskp/config.schema.json
+++ b/.taskp/config.schema.json
@@ -96,6 +96,118 @@
         }
       },
       "additionalProperties": false
+    },
+    "mcp": {
+      "description": "MCP server settings",
+      "type": "object",
+      "properties": {
+        "servers": {
+          "description": "MCP server definitions keyed by server name",
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "transport": {
+                    "type": "string",
+                    "const": "stdio"
+                  },
+                  "command": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Command to execute"
+                  },
+                  "args": {
+                    "description": "Command arguments",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "env": {
+                    "description": "Environment variable names to pass",
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "transport",
+                  "command"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "transport": {
+                    "type": "string",
+                    "const": "http"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "HTTP endpoint URL"
+                  },
+                  "headers_env": {
+                    "description": "Environment variable names for HTTP headers",
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "transport",
+                  "url"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "transport": {
+                    "type": "string",
+                    "const": "sse"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "SSE endpoint URL"
+                  },
+                  "headers_env": {
+                    "description": "Environment variable names for HTTP headers",
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "transport",
+                  "url"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -39,6 +39,44 @@ export const hooksConfigSchema = z.object({
 	on_failure: z.array(z.string().min(1)).optional().describe("Commands to run on skill failure"),
 });
 
+const stdioServerSchema = z.object({
+	transport: z.literal("stdio"),
+	command: z.string().min(1).describe("Command to execute"),
+	args: z.array(z.string()).optional().describe("Command arguments"),
+	env: z.record(z.string(), z.string()).optional().describe("Environment variable names to pass"),
+});
+
+const httpServerSchema = z.object({
+	transport: z.literal("http"),
+	url: z.string().url().describe("HTTP endpoint URL"),
+	headers_env: z
+		.record(z.string(), z.string())
+		.optional()
+		.describe("Environment variable names for HTTP headers"),
+});
+
+const sseServerSchema = z.object({
+	transport: z.literal("sse"),
+	url: z.string().url().describe("SSE endpoint URL"),
+	headers_env: z
+		.record(z.string(), z.string())
+		.optional()
+		.describe("Environment variable names for HTTP headers"),
+});
+
+export const mcpServerConfigSchema = z.discriminatedUnion("transport", [
+	stdioServerSchema,
+	httpServerSchema,
+	sseServerSchema,
+]);
+
+export const mcpConfigSchema = z.object({
+	servers: z
+		.record(z.string(), mcpServerConfigSchema)
+		.optional()
+		.describe("MCP server definitions keyed by server name"),
+});
+
 export const cliConfigSchema = z.object({
 	command_timeout_ms: z
 		.number()
@@ -59,12 +97,15 @@ export const configSchema = z.object({
 	ai: aiConfigSchema.optional().describe("AI/LLM settings"),
 	hooks: hooksConfigSchema.optional().describe("Lifecycle hooks"),
 	cli: cliConfigSchema.optional().describe("CLI behavior settings"),
+	mcp: mcpConfigSchema.optional().describe("MCP server settings"),
 });
 
 export type ProviderConfig = z.infer<typeof providerConfigSchema>;
 export type AiConfig = z.infer<typeof aiConfigSchema>;
 export type HooksConfig = z.infer<typeof hooksConfigSchema>;
 export type CliConfig = z.infer<typeof cliConfigSchema>;
+export type McpServerConfig = z.infer<typeof mcpServerConfigSchema>;
+export type McpConfig = z.infer<typeof mcpConfigSchema>;
 export type Config = z.infer<typeof configSchema>;
 
 type ConfigLoaderDeps = {
@@ -180,10 +221,18 @@ export function mergeCliConfig(global: CliConfig, project: CliConfig): CliConfig
 	return mergeByProjectPriority(global, project);
 }
 
+// 同名サーバーは project 側が丸ごと上書き（フィールド単位マージしない）
+export function mergeMcpConfig(global: McpConfig, project: McpConfig): McpConfig {
+	return {
+		servers: mergeOptional(global.servers, project.servers, (g, p) => ({ ...g, ...p })),
+	};
+}
+
 function mergeConfigs(global: Config, project: Config): Config {
 	return {
 		ai: mergeOptional(global.ai, project.ai, mergeAiConfig),
 		hooks: mergeOptional(global.hooks, project.hooks, mergeHooksConfig),
 		cli: mergeOptional(global.cli, project.cli, mergeCliConfig),
+		mcp: mergeOptional(global.mcp, project.mcp, mergeMcpConfig),
 	};
 }

--- a/tests/unit/adapter/config-loader.test.ts
+++ b/tests/unit/adapter/config-loader.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import {
+	type McpConfig,
+	mcpConfigSchema,
+	mcpServerConfigSchema,
+	mergeMcpConfig,
+} from "../../../src/adapter/config-loader";
+
+describe("mcpServerConfigSchema", () => {
+	it("stdio 設定のパースが成功すること", () => {
+		const input = {
+			transport: "stdio",
+			command: "npx",
+			args: ["-y", "some-server"],
+			env: { API_KEY: "MY_API_KEY" },
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+
+	it("http 設定のパースが成功すること", () => {
+		const input = {
+			transport: "http",
+			url: "https://example.com/mcp",
+			headers_env: { Authorization: "AUTH_TOKEN" },
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+
+	it("sse 設定のパースが成功すること", () => {
+		const input = {
+			transport: "sse",
+			url: "https://example.com/sse",
+			headers_env: { Authorization: "AUTH_TOKEN" },
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+
+	it("stdio で command がない場合にバリデーションエラーになること", () => {
+		const input = {
+			transport: "stdio",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("http で url がない場合にバリデーションエラーになること", () => {
+		const input = {
+			transport: "http",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("不正な transport 値でエラーになること", () => {
+		const input = {
+			transport: "websocket",
+			url: "ws://example.com",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("stdio で command が空文字の場合にバリデーションエラーになること", () => {
+		const input = {
+			transport: "stdio",
+			command: "",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("http で url が不正な形式の場合にバリデーションエラーになること", () => {
+		const input = {
+			transport: "http",
+			url: "not-a-url",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("stdio でオプションフィールドが省略可能であること", () => {
+		const input = {
+			transport: "stdio",
+			command: "npx",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+
+	it("http でオプションフィールドが省略可能であること", () => {
+		const input = {
+			transport: "http",
+			url: "https://example.com/mcp",
+		};
+
+		const result = mcpServerConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+});
+
+describe("mcpConfigSchema", () => {
+	it("servers を持つ設定のパースが成功すること", () => {
+		const input = {
+			servers: {
+				myServer: {
+					transport: "stdio",
+					command: "npx",
+					args: ["-y", "my-server"],
+				},
+			},
+		};
+
+		const result = mcpConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+
+	it("servers が省略可能であること", () => {
+		const result = mcpConfigSchema.safeParse({});
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual({});
+	});
+
+	it("複数サーバーのパースが成功すること", () => {
+		const input = {
+			servers: {
+				stdio: {
+					transport: "stdio" as const,
+					command: "npx",
+				},
+				http: {
+					transport: "http" as const,
+					url: "https://example.com/mcp",
+				},
+				sse: {
+					transport: "sse" as const,
+					url: "https://example.com/sse",
+				},
+			},
+		};
+
+		const result = mcpConfigSchema.safeParse(input);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toEqual(input);
+	});
+});
+
+describe("mergeMcpConfig", () => {
+	it("global と project のマージで project が優先されること", () => {
+		const global: McpConfig = {
+			servers: {
+				serverA: { transport: "stdio", command: "global-cmd" },
+			},
+		};
+		const project: McpConfig = {
+			servers: {
+				serverB: { transport: "http", url: "https://project.com/mcp" },
+			},
+		};
+
+		const result = mergeMcpConfig(global, project);
+
+		expect(result.servers).toEqual({
+			serverA: { transport: "stdio", command: "global-cmd" },
+			serverB: { transport: "http", url: "https://project.com/mcp" },
+		});
+	});
+
+	it("同名サーバーの丸ごと上書きが正しく動作すること", () => {
+		const global: McpConfig = {
+			servers: {
+				shared: {
+					transport: "stdio",
+					command: "global-cmd",
+					args: ["--verbose"],
+					env: { KEY: "GLOBAL_KEY" },
+				},
+			},
+		};
+		const project: McpConfig = {
+			servers: {
+				shared: {
+					transport: "http",
+					url: "https://project.com/mcp",
+				},
+			},
+		};
+
+		const result = mergeMcpConfig(global, project);
+
+		expect(result.servers).toEqual({
+			shared: {
+				transport: "http",
+				url: "https://project.com/mcp",
+			},
+		});
+	});
+
+	it("global のみの場合は global がそのまま返ること", () => {
+		const global: McpConfig = {
+			servers: {
+				serverA: { transport: "stdio", command: "cmd" },
+			},
+		};
+		const project: McpConfig = {};
+
+		const result = mergeMcpConfig(global, project);
+
+		expect(result.servers).toEqual({
+			serverA: { transport: "stdio", command: "cmd" },
+		});
+	});
+
+	it("project のみの場合は project がそのまま返ること", () => {
+		const global: McpConfig = {};
+		const project: McpConfig = {
+			servers: {
+				serverA: { transport: "stdio", command: "cmd" },
+			},
+		};
+
+		const result = mergeMcpConfig(global, project);
+
+		expect(result.servers).toEqual({
+			serverA: { transport: "stdio", command: "cmd" },
+		});
+	});
+
+	it("両方 servers が undefined の場合は undefined が返ること", () => {
+		const result = mergeMcpConfig({}, {});
+
+		expect(result.servers).toBeUndefined();
+	});
+});


### PR DESCRIPTION
#### 概要

`config.toml` に `[mcp.servers.<name>]` セクションを追加し、MCP サーバー接続情報（stdio / http / sse）を定義できるようにした。

#### 変更内容

- `mcpServerConfigSchema` を discriminated union（stdio / http / sse）で定義
- `mcpConfigSchema` を定義し、`configSchema` に `mcp` フィールドを追加
- `mergeMcpConfig` マージ関数を実装（同名サーバーは project 側が丸ごと上書き）
- `McpServerConfig`, `McpConfig` 型をエクスポート
- ユニットテスト 18 件を追加（スキーマバリデーション・マージ動作）
- `config.schema.json` を再生成

Closes #460