### PR TITLE
refactor: move buildTools from adapter to usecase layer

### DIFF
--- a/src/adapter/agent-executor.ts
+++ b/src/adapter/agent-executor.ts
@@ -1,6 +1,5 @@
 import type { TextPart as AiSdkTextPart, ToolCallRepairFunction, ToolSet, UserContent } from "ai";
 import { stepCountIs, streamText } from "ai";
-import { buildTools } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
 import { executionError } from "../core/types/errors";
 import { err, ok } from "../core/types/result";
@@ -26,18 +25,13 @@ async function executeAgentLoop(
 	logger: Logger,
 ): ReturnType<AgentExecutorPort["execute"]> {
 	const startTime = Date.now();
-	const toolsResult = buildTools(input.toolNames, input.taskpRunDeps, input.toolDescriptions);
-	if (!toolsResult.ok) {
-		return toolsResult;
-	}
-	const tools = toolsResult.value;
 
 	try {
 		const result = streamText({
 			model: input.model,
 			system: input.systemPrompt,
 			messages: [{ role: "user", content: toAiSdkContent(input.contentParts) }],
-			tools,
+			tools: input.tools,
 			stopWhen: stepCountIs(input.maxSteps),
 			experimental_repairToolCall: createRepairToolCall(logger),
 		});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -395,6 +395,7 @@ async function runAgentMode(
 			contextCollector,
 			agentExecutor,
 			systemPromptResolver: createSystemPromptResolver(process.cwd()),
+			commandExecutor,
 			progressWriter: createCliProgressWriter(process.stdout),
 			hookExecutor,
 			hooksConfig,

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -119,6 +119,7 @@ async function executeAgentMode(
 			promptCollector: deps.promptCollectorFactory(variables),
 			contextCollector,
 			agentExecutor,
+			commandExecutor: deps.commandExecutor,
 			progressWriter,
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,

--- a/src/usecase/port/agent-executor.ts
+++ b/src/usecase/port/agent-executor.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import type { TaskpRunDeps, ToolDescriptions } from "../../core/execution/agent-tools";
+import type { ToolSet } from "ai";
 import type { ContentPart } from "../../core/execution/content-part";
 import type { ExecutionError } from "../../core/types/errors";
 import type { Result } from "../../core/types/result";
@@ -8,10 +8,8 @@ export type AgentExecutorInput = {
 	readonly model: LanguageModelV3;
 	readonly systemPrompt: string;
 	readonly contentParts: readonly ContentPart[];
-	readonly toolNames: readonly string[];
+	readonly tools: ToolSet;
 	readonly maxSteps: number;
-	readonly taskpRunDeps?: TaskpRunDeps;
-	readonly toolDescriptions?: ToolDescriptions;
 };
 
 export type AgentExecutorResult = {

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { DEFAULT_MAX_AGENT_STEPS } from "../core/constants";
-import { buildTaskpRunDescription } from "../core/execution/agent-tools";
+import type { TaskpRunDeps } from "../core/execution/agent-tools";
+import { buildTaskpRunDescription, buildTools } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
 import { resolveAgentExecution } from "../core/skill/skill-execution-resolver";
 import { type DomainError, domainErrorMessage } from "../core/types/errors";
@@ -10,6 +11,7 @@ import { buildReservedVars, renderTemplate } from "../core/variable/template-ren
 import { collectSkillContext } from "./collect-skill-context";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
+import type { CommandExecutor } from "./port/command-executor";
 import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
 import type { HookExecutorPort } from "./port/hook-executor";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
@@ -37,6 +39,7 @@ export type RunAgentSkillDeps = {
 	readonly contextCollector: ContextCollectorPort;
 	readonly agentExecutor: AgentExecutorPort;
 	readonly systemPromptResolver: SystemPromptResolver;
+	readonly commandExecutor: CommandExecutor;
 	readonly progressWriter?: ProgressWriter;
 	readonly hookExecutor?: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
@@ -116,13 +119,24 @@ export async function runAgentSkill(
 		skill.metadata.name,
 	);
 
+	const taskpRunDeps: TaskpRunDeps = {
+		skillRepository: deps.skillRepository,
+		commandExecutor: deps.commandExecutor,
+		promptCollector: deps.promptCollector,
+		callerSkillName: skill.metadata.name,
+		hookExecutor: deps.hookExecutor,
+		hooksConfig: deps.hooksConfig,
+	};
+
+	const toolsResult = buildTools(toolNames, taskpRunDeps, toolDescriptions);
+	if (!toolsResult.ok) return toolsResult;
+
 	const executeResult = await deps.agentExecutor.execute({
 		model: input.model,
 		systemPrompt,
 		contentParts,
-		toolNames,
+		tools: toolsResult.value,
 		maxSteps: input.maxAgentSteps ?? DEFAULT_MAX_AGENT_STEPS,
-		toolDescriptions,
 	});
 
 	const durationMs = Date.now() - startTime;

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Skill } from "../../src/core/skill/skill";
 import { ok } from "../../src/core/types/result";
 import type { AgentExecutorPort } from "../../src/usecase/port/agent-executor";
+import type { CommandExecutor } from "../../src/usecase/port/command-executor";
 import type { ContextCollectorPort } from "../../src/usecase/port/context-collector";
 import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
@@ -70,12 +71,17 @@ function createMockDeps(skill: Skill) {
 		resolve: vi.fn().mockResolvedValue("You are a task execution agent for taskp."),
 	};
 
+	const commandExecutor: CommandExecutor = {
+		execute: vi.fn().mockResolvedValue(ok({ stdout: "", stderr: "", exitCode: 0 })),
+	};
+
 	return {
 		skillRepository,
 		promptCollector,
 		contextCollector,
 		agentExecutor,
 		systemPromptResolver,
+		commandExecutor,
 	};
 }
 
@@ -109,7 +115,7 @@ describe("runAgentSkill", () => {
 		expect(executorCall.contentParts).toEqual([
 			{ type: "text", text: expect.stringContaining("You are a helpful assistant.") },
 		]);
-		expect(executorCall.toolNames).toEqual(["bash", "read"]);
+		expect(Object.keys(executorCall.tools)).toEqual(["bash", "read"]);
 		expect(executorCall.maxSteps).toBe(50);
 	});
 
@@ -483,7 +489,7 @@ describe("runAgentSkill", () => {
 
 			const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock
 				.calls[0][0];
-			expect(executorCall.toolNames).toEqual(["bash", "read", "write"]);
+			expect(Object.keys(executorCall.tools)).toEqual(["bash", "read", "write"]);
 		});
 
 		it("uses action-specific inputs", async () => {
@@ -535,7 +541,7 @@ describe("runAgentSkill", () => {
 			const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock
 				.calls[0][0];
 			// analyze action has no tools override, falls back to skill-level
-			expect(executorCall.toolNames).toEqual(["bash", "read"]);
+			expect(Object.keys(executorCall.tools)).toEqual(["bash", "read"]);
 			// analyze action has no context override, falls back to skill-level
 			expect(deps.contextCollector.collect).toHaveBeenCalledWith(
 				[{ type: "file", path: "global.md" }],


### PR DESCRIPTION
#### 概要

AgentExecutorInput の toolNames/taskpRunDeps/toolDescriptions を tools: ToolSet に置き換え、ツール構築の責務を UseCase 層に移動するリファクタリング。

#### 変更内容

- `AgentExecutorInput` から `toolNames`, `taskpRunDeps`, `toolDescriptions` を削除し `tools: ToolSet` に置き換え
- `run-agent-skill.ts` で `buildTools()` を呼び出し、結果の `ToolSet` を executor に渡すよう変更
- `adapter/agent-executor.ts` から `buildTools()` 呼び出しを削除し、`input.tools` をそのまま `streamText` に渡すよう変更
- `RunAgentSkillDeps` に `commandExecutor` を追加（TaskpRunDeps 構築に必要）
- CLI・TUI の呼び出し元を更新
- テストのアサーションを `toolNames` から `tools` キーの検証に更新

Closes #461