### PR TITLE
feat: add SessionId branded type

### DIFF
--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -14,3 +14,4 @@ export type { ContentPart, ImagePart, TextPart } from "./content-part.js";
 export type { ExecutionMode } from "./execution-mode.js";
 export type { McpToolRef, PartitionedToolRefs } from "./mcp-tool-ref.js";
 export { isMcpToolRef, parseMcpToolRef, partitionToolRefs } from "./mcp-tool-ref.js";
+export type { SessionId } from "./session.js";

--- a/src/core/execution/session.ts
+++ b/src/core/execution/session.ts
@@ -1,0 +1,4 @@
+/**
+ * branded type により、生の string との取り違えを型レベルで防止する
+ */
+export type SessionId = string & { readonly __brand: "SessionId" };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,3 @@
 // Core domain layer
+
+export type { SessionId } from "./execution/index.js";


### PR DESCRIPTION
#### 概要

`core/execution/session.ts` に `SessionId` branded type を追加し、生の string との取り違えを型レベルで防止する。

#### 変更内容

- `src/core/execution/session.ts` を新規作成し `SessionId` branded type を定義
- `src/core/execution/index.ts` から re-export
- `src/core/index.ts` から re-export

Closes #474