### PR TITLE
feat(core): add Session ID to agent system prompt environment section

### DIFF
--- a/src/adapter/system-prompt-resolver.ts
+++ b/src/adapter/system-prompt-resolver.ts
@@ -32,7 +32,7 @@ export function createSystemPromptResolver(projectRoot: string): SystemPromptRes
 			return [
 				customPrompt,
 				`# Available tools\n\n${formatToolsList(options.toolNames)}`,
-				formatEnvironment(options.cwd, options.date),
+				formatEnvironment(options.cwd, options.date, options.sessionId),
 			].join("\n\n");
 		},
 	};

--- a/src/core/execution/system-prompt.ts
+++ b/src/core/execution/system-prompt.ts
@@ -4,6 +4,7 @@
  */
 
 import { getToolDescription } from "./agent-tools";
+import type { SessionId } from "./session";
 
 export type SystemPromptOptions = {
 	/** スキルで有効化されたツール名 */
@@ -12,6 +13,8 @@ export type SystemPromptOptions = {
 	readonly cwd: string;
 	/** 現在の日付（ISO 8601 日付文字列） */
 	readonly date: string;
+	/** セッション ID */
+	readonly sessionId: SessionId;
 };
 
 /** ツール名の一覧をシステムプロンプト用の文字列に整形する */
@@ -27,16 +30,17 @@ export function formatToolsList(toolNames: readonly string[]): string {
 }
 
 /** 環境情報セクションを生成する */
-export function formatEnvironment(cwd: string, date: string): string {
+export function formatEnvironment(cwd: string, date: string, sessionId: SessionId): string {
 	return `# Environment
 
 - Working directory: ${cwd}
 - Date: ${date}
-- Platform: ${process.platform}`;
+- Platform: ${process.platform}
+- Session ID: ${sessionId}`;
 }
 
 export function buildSystemPrompt(options: SystemPromptOptions): string {
-	const { toolNames, cwd, date } = options;
+	const { toolNames, cwd, date, sessionId } = options;
 
 	return `You are a task execution agent for taskp, a markdown-defined skill runner.
 You execute the skill task described in the user message accurately and efficiently.
@@ -55,5 +59,5 @@ ${formatToolsList(toolNames)}
 - Do not modify or extend the task beyond what is described
 - When multiple independent tool calls are possible, prefer making them in parallel
 
-${formatEnvironment(cwd, date)}`;
+${formatEnvironment(cwd, date, sessionId)}`;
 }

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -96,6 +96,7 @@ export async function runAgentSkill(
 		toolNames,
 		cwd: process.cwd(),
 		date: reserved.date,
+		sessionId: input.sessionId,
 	});
 
 	// prompt: SKILL.md 本文（タスク指示）を先頭に、context ソース出力（データ）を続けて配置

--- a/tests/adapter/system-prompt-resolver.test.ts
+++ b/tests/adapter/system-prompt-resolver.test.ts
@@ -3,11 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSystemPromptResolver } from "../../src/adapter/system-prompt-resolver";
+import type { SessionId } from "../../src/core/execution/session";
 
 const defaultOptions = {
 	toolNames: ["bash", "write"] as readonly string[],
 	cwd: "/test/project",
 	date: "2026-03-22",
+	sessionId: "tskp_test000001" as SessionId,
 };
 
 describe("SystemPromptResolver", () => {

--- a/tests/core/execution/system-prompt.test.ts
+++ b/tests/core/execution/system-prompt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { SessionId } from "../../../src/core/execution/session";
 import {
 	buildSystemPrompt,
 	formatEnvironment,
@@ -35,12 +36,17 @@ describe("formatToolsList", () => {
 });
 
 describe("formatEnvironment", () => {
-	it("includes cwd, date, and platform", () => {
-		const result = formatEnvironment("/home/user/project", "2026-03-22");
+	it("includes cwd, date, platform, and session ID", () => {
+		const result = formatEnvironment(
+			"/home/user/project",
+			"2026-03-22",
+			"tskp_test000001" as SessionId,
+		);
 
 		expect(result).toContain("Working directory: /home/user/project");
 		expect(result).toContain("Date: 2026-03-22");
 		expect(result).toContain(`Platform: ${process.platform}`);
+		expect(result).toContain("Session ID: tskp_test000001");
 	});
 });
 
@@ -49,6 +55,7 @@ describe("buildSystemPrompt", () => {
 		toolNames: ["bash", "read", "write"] as readonly string[],
 		cwd: "/home/user/project",
 		date: "2026-03-22",
+		sessionId: "tskp_test000001" as SessionId,
 	};
 
 	it("includes role definition", () => {


### PR DESCRIPTION
#### 概要

agent モードのシステムプロンプトの環境情報セクションにセッション ID を追加する。LLM がツール呼び出し時にセッション ID を識別子として利用できるようにする。

#### 変更内容

- `SystemPromptOptions` に `sessionId: SessionId` フィールドを追加
- `formatEnvironment` にセッション ID の出力を追加
- `run-agent-skill.ts` の `resolve()` 呼び出しに `sessionId` を伝搬
- `adapter/system-prompt-resolver.ts` のカスタム SYSTEM.md パスにも `sessionId` を伝搬
- 既存テストを更新し、セッション ID の出力を検証

Closes #479