### PR TITLE
feat(cli): integrate session ID generation and display in CLI run command

### DIFF
--- a/src/adapter/stream-writer.ts
+++ b/src/adapter/stream-writer.ts
@@ -1,11 +1,14 @@
 import { getPrimaryArgKey } from "../core/execution/agent-tools";
+import type { SessionId } from "../core/execution/session";
 
 export type StreamWriterOptions = {
 	readonly verbose: boolean;
 	readonly output: NodeJS.WritableStream;
+	readonly sessionId: SessionId;
 };
 
 export type StreamWriter = {
+	readonly writeHeader: () => void;
 	readonly writeText: (text: string) => void;
 	readonly writeToolCall: (toolName: string, args: Record<string, unknown>) => void;
 	readonly writeToolResult: (toolName: string, result: unknown) => void;
@@ -14,6 +17,10 @@ export type StreamWriter = {
 
 export function createStreamWriter(options: StreamWriterOptions): StreamWriter {
 	return {
+		writeHeader(): void {
+			options.output.write(`[session: ${options.sessionId}]\n`);
+		},
+
 		writeText(text: string): void {
 			options.output.write(text);
 		},
@@ -31,7 +38,7 @@ export function createStreamWriter(options: StreamWriterOptions): StreamWriter {
 
 		writeSummary(elapsedMs: number, steps: number): void {
 			const seconds = (elapsedMs / 1000).toFixed(1);
-			options.output.write(`\nDone in ${seconds}s (${steps} steps)\n`);
+			options.output.write(`\nDone in ${seconds}s (${steps} steps) [${options.sessionId}]\n`);
 		},
 	};
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,7 @@ function formatRunOutput(output: RunOutput): string {
 	const failed = output.commands.filter((c) => c.result.exitCode !== 0);
 	lines.push("");
 	lines.push(
-		`✔ ${output.skillName} completed (${output.commands.length} steps, ${failed.length} failed)`,
+		`✔ ${output.skillName} completed (${output.commands.length} steps, ${failed.length} failed) [${output.sessionId}]`,
 	);
 
 	return lines.join("\n");
@@ -366,10 +366,15 @@ async function runAgentMode(
 
 	const languageModel = exitOnError(createLanguageModel(modelSpec, aiConfig));
 
+	const sessionId = generateSessionId();
+
 	const writer = createStreamWriter({
 		verbose: c.options.verbose ?? false,
 		output: process.stdout,
+		sessionId,
 	});
+
+	writer.writeHeader();
 
 	const logger = createConsoleLogger();
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
@@ -397,7 +402,7 @@ async function runAgentMode(
 			model: languageModel,
 			noInput: c.options.skipPrompt,
 			maxAgentSteps: config.cli?.max_agent_steps,
-			sessionId: generateSessionId(),
+			sessionId,
 		},
 		{
 			skillRepository,

--- a/src/tui/tui-stream-writer.ts
+++ b/src/tui/tui-stream-writer.ts
@@ -33,6 +33,9 @@ export function createTuiStreamWriter(view: ExecutionViewPort): StreamWriter {
 	}
 
 	return {
+		writeHeader(): void {
+			// TUI は独自のヘッダー表示を持つため、ストリームヘッダーは出力しない
+		},
 		writeText(text: string): void {
 			buffer += text;
 			scheduleFlush();

--- a/tests/adapter/agent-executor.test.ts
+++ b/tests/adapter/agent-executor.test.ts
@@ -8,6 +8,7 @@ function createMockWriter(): StreamWriter & {
 	const calls: { method: string; args: unknown[] }[] = [];
 	return {
 		calls,
+		writeHeader: vi.fn((...args) => calls.push({ method: "writeHeader", args })),
 		writeText: vi.fn((...args) => calls.push({ method: "writeText", args })),
 		writeToolCall: vi.fn((...args) => calls.push({ method: "writeToolCall", args })),
 		writeToolResult: vi.fn((...args) => calls.push({ method: "writeToolResult", args })),

--- a/tests/adapter/stream-writer.test.ts
+++ b/tests/adapter/stream-writer.test.ts
@@ -1,6 +1,9 @@
 import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { createStreamWriter } from "../../src/adapter/stream-writer";
+import type { SessionId } from "../../src/core/execution/session";
+
+const TEST_SESSION_ID = "tskp_abc123def456" as SessionId;
 
 function createTestOutput(): { output: Writable; getContent: () => string } {
 	const chunks: string[] = [];
@@ -14,10 +17,21 @@ function createTestOutput(): { output: Writable; getContent: () => string } {
 }
 
 describe("createStreamWriter", () => {
+	describe("writeHeader", () => {
+		it("outputs session ID header", () => {
+			const { output, getContent } = createTestOutput();
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
+
+			writer.writeHeader();
+
+			expect(getContent()).toBe("[session: tskp_abc123def456]\n");
+		});
+	});
+
 	describe("writeText", () => {
 		it("writes text directly to output", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeText("hello ");
 			writer.writeText("world");
@@ -29,7 +43,7 @@ describe("createStreamWriter", () => {
 	describe("writeToolCall", () => {
 		it("formats bash tool with command", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("bash", { command: "git diff --cached" });
 
@@ -38,7 +52,7 @@ describe("createStreamWriter", () => {
 
 		it("formats read tool with path", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("read", { path: "src/index.ts" });
 
@@ -47,7 +61,7 @@ describe("createStreamWriter", () => {
 
 		it("formats write tool with path", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("write", { path: "out.txt", content: "data" });
 
@@ -56,7 +70,7 @@ describe("createStreamWriter", () => {
 
 		it("formats glob tool with pattern", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("glob", { pattern: "src/**/*.ts" });
 
@@ -65,7 +79,7 @@ describe("createStreamWriter", () => {
 
 		it("formats ask_user tool with question", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("ask_user", { question: "Continue?" });
 
@@ -74,7 +88,7 @@ describe("createStreamWriter", () => {
 
 		it("formats unknown tool with JSON args", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolCall("custom", { key: "value" });
 
@@ -85,7 +99,7 @@ describe("createStreamWriter", () => {
 	describe("writeToolResult", () => {
 		it("does not output in non-verbose mode", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolResult("bash", { stdout: "output", stderr: "", exitCode: 0 });
 
@@ -94,7 +108,7 @@ describe("createStreamWriter", () => {
 
 		it("outputs result in verbose mode", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: true, output });
+			const writer = createStreamWriter({ verbose: true, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolResult("bash", "command output");
 
@@ -103,7 +117,7 @@ describe("createStreamWriter", () => {
 
 		it("outputs JSON for non-string results in verbose mode", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: true, output });
+			const writer = createStreamWriter({ verbose: true, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeToolResult("bash", { stdout: "ok", exitCode: 0 });
 
@@ -112,22 +126,22 @@ describe("createStreamWriter", () => {
 	});
 
 	describe("writeSummary", () => {
-		it("formats elapsed time and step count", () => {
+		it("formats elapsed time, step count, and session ID", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeSummary(12300, 8);
 
-			expect(getContent()).toBe("\nDone in 12.3s (8 steps)\n");
+			expect(getContent()).toBe("\nDone in 12.3s (8 steps) [tskp_abc123def456]\n");
 		});
 
 		it("handles sub-second times", () => {
 			const { output, getContent } = createTestOutput();
-			const writer = createStreamWriter({ verbose: false, output });
+			const writer = createStreamWriter({ verbose: false, output, sessionId: TEST_SESSION_ID });
 
 			writer.writeSummary(500, 1);
 
-			expect(getContent()).toBe("\nDone in 0.5s (1 steps)\n");
+			expect(getContent()).toBe("\nDone in 0.5s (1 steps) [tskp_abc123def456]\n");
 		});
 	});
 });

--- a/tests/e2e/run-command.test.ts
+++ b/tests/e2e/run-command.test.ts
@@ -69,6 +69,18 @@ describe("taskp run (E2E)", () => {
 		expect(result.stdout).toContain("hello completed");
 	});
 
+	it("includes session ID with tskp_ prefix in run output", async () => {
+		createSkillFile(projectDir, "hello", NO_INPUT_SKILL);
+
+		const result = await execaCommand(`bun run ${CLI_PATH} run hello`, {
+			cwd: projectDir,
+			reject: false,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toMatch(/\[tskp_[a-f0-9]{12}\]/);
+	});
+
 	it("shows rendered template with --dry-run", async () => {
 		createSkillFile(projectDir, "hello", NO_INPUT_SKILL);
 

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -57,6 +57,14 @@ describe("CLI E2E: init → list → run", () => {
 		expect(runResult.stdout).toContain("hello completed");
 	});
 
+	it("run output includes session ID with tskp_ prefix", async () => {
+		await run("init sid-test", projectDir);
+
+		const runResult = await run("run sid-test", projectDir);
+		expect(runResult.exitCode).toBe(0);
+		expect(runResult.stdout).toMatch(/\[tskp_[a-f0-9]{12}\]/);
+	});
+
 	it("init with --mode template creates a template skill", async () => {
 		const initResult = await run("init greet --mode template", projectDir);
 		expect(initResult.exitCode).toBe(0);

--- a/tests/tui/tui-stream-writer.test.ts
+++ b/tests/tui/tui-stream-writer.test.ts
@@ -31,6 +31,13 @@ describe("createTuiStreamWriter", () => {
 		vi.useRealTimers();
 	});
 
+	it("writeHeader does not output anything", () => {
+		const view = createMockView();
+		const writer = createTuiStreamWriter(view);
+		writer.writeHeader();
+		expect(view.calls).toEqual([]);
+	});
+
 	it("writeText buffers and flushes after interval", () => {
 		const view = createMockView();
 		const writer = createTuiStreamWriter(view);


### PR DESCRIPTION
#### 概要

CLI の `run` コマンドで生成されたセッション ID をテンプレートモード・エージェントモード両方の出力に表示する。

#### 変更内容

- `formatRunOutput` のサマリー行にセッション ID を `[tskp_xxx]` 形式で表示
- `StreamWriter` に `writeHeader()` メソッドを追加し、エージェントモード開始時にセッション ID ヘッダーを出力
- `writeSummary()` にセッション ID を含めてエージェントモード完了時にも表示
- `StreamWriterOptions` に `sessionId` フィールドを追加
- TUI ストリームライターに `writeHeader` no-op 実装を追加
- 統合テスト・E2E テストで `tskp_` プレフィックスのパターンマッチを検証

Closes #480