### PR TITLE
feat(tui): display session ID in execution view title bar

### DIFF
--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -5,6 +5,7 @@ import { createCommandRunner } from "../adapter/command-runner";
 import { createDefaultConfigLoader, type McpServerConfig } from "../adapter/config-loader";
 import { createConsoleLogger } from "../adapter/console-logger";
 import { createHookExecutor } from "../adapter/hook-executor";
+import { generateSessionId } from "../adapter/session-id-generator";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import { createSystemPromptResolver } from "../adapter/system-prompt-resolver";
 import { resolveActionConfig } from "../core/skill/action";
@@ -75,9 +76,10 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 			const variables = await showInputForm(renderer, skill, actionInputs);
 			if (!variables) continue;
 
+			const sessionId = generateSessionId();
 			const navAction = await showExecution(
 				renderer,
-				{ skill, variables, model, modelSpec, actionName },
+				{ skill, variables, model, modelSpec, actionName, sessionId },
 				executionDeps,
 			);
 			if (navAction === "exit") break;

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -4,7 +4,7 @@ import type { McpServerConfig } from "../../adapter/config-loader";
 import { createConsoleLogger } from "../../adapter/console-logger";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
-import { generateSessionId } from "../../adapter/session-id-generator";
+import type { SessionId } from "../../core/execution/session";
 import { resolveActionConfig } from "../../core/skill/action";
 import type { Skill } from "../../core/skill/skill";
 import { domainErrorMessage } from "../../core/types/errors";
@@ -45,7 +45,8 @@ export async function runExecution(
 	model: LanguageModelV3 | null,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
-	actionName?: string,
+	actionName: string | undefined,
+	sessionId: SessionId,
 ): Promise<void> {
 	const effectiveMode = resolveEffectiveMode(skill, actionName);
 
@@ -58,9 +59,9 @@ export async function runExecution(
 
 	try {
 		if (effectiveMode === "agent" && model !== null) {
-			await executeAgentMode(skill, variables, model, viewPort, deps, actionName);
+			await executeAgentMode(skill, variables, model, viewPort, deps, actionName, sessionId);
 		} else {
-			await executeTemplateMode(skill, variables, viewPort, deps, actionName);
+			await executeTemplateMode(skill, variables, viewPort, deps, actionName, sessionId);
 		}
 	} catch (error: unknown) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -99,7 +100,8 @@ async function executeAgentMode(
 	model: LanguageModelV3,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
-	actionName?: string,
+	actionName: string | undefined,
+	sessionId: SessionId,
 ): Promise<void> {
 	const writer = createTuiStreamWriter(viewPort);
 	const progressWriter = createTuiProgressWriter(viewPort);
@@ -123,7 +125,7 @@ async function executeAgentMode(
 			presets: variables,
 			model,
 			maxAgentSteps: deps.maxAgentSteps,
-			sessionId: generateSessionId(),
+			sessionId,
 		},
 		{
 			skillRepository: deps.skillRepositoryFactory(skill),
@@ -151,7 +153,8 @@ async function executeTemplateMode(
 	variables: Readonly<Record<string, string>>,
 	viewPort: ExecutionViewPort,
 	deps: ExecutionDeps,
-	actionName?: string,
+	actionName: string | undefined,
+	sessionId: SessionId,
 ): Promise<void> {
 	const progressWriter = createTuiProgressWriter(viewPort);
 
@@ -162,7 +165,7 @@ async function executeTemplateMode(
 			presets: variables,
 			dryRun: false,
 			force: false,
-			sessionId: generateSessionId(),
+			sessionId,
 		},
 		{
 			skillRepository: deps.skillRepositoryFactory(skill),

--- a/src/tui/screens/execution-view.ts
+++ b/src/tui/screens/execution-view.ts
@@ -9,6 +9,7 @@ import {
 	TextRenderable,
 } from "@opentui/core";
 import type { ModelSpec } from "../../adapter/ai-provider";
+import type { SessionId } from "../../core/execution/session";
 import type { Skill } from "../../core/skill/skill";
 import { KeyHelp } from "../components/key-help";
 import { SPINNER_FRAMES, SPINNER_INTERVAL_MS } from "../components/spinner";
@@ -32,6 +33,7 @@ export type ExecutionParams = {
 	readonly model: LanguageModelV3 | null;
 	readonly modelSpec: ModelSpec | null;
 	readonly actionName?: string;
+	readonly sessionId: SessionId;
 };
 
 export async function showExecution(
@@ -39,7 +41,7 @@ export async function showExecution(
 	params: ExecutionParams,
 	deps: ExecutionDeps,
 ): Promise<"back" | "exit"> {
-	const { skill, variables, model, modelSpec, actionName } = params;
+	const { skill, variables, model, modelSpec, actionName, sessionId } = params;
 	return new Promise((resolve) => {
 		clearScreen(renderer);
 
@@ -51,7 +53,7 @@ export async function showExecution(
 			width: "100%",
 			height: "100%",
 			borderStyle: "rounded",
-			title: `${skillLabel} [Running]${modelLabel}`,
+			title: `${skillLabel} [Running] ${sessionId}${modelLabel}`,
 			padding: 1,
 			flexDirection: "column",
 			justifyContent: "flex-start",
@@ -141,12 +143,12 @@ export async function showExecution(
 				stopSpinner();
 				const seconds = (elapsedMs / 1000).toFixed(1);
 				summaryText.content = `Done in ${seconds}s (${steps} steps)`;
-				container.title = `${skillLabel} [Done]${modelLabel}`;
+				container.title = `${skillLabel} [Done] ${sessionId}${modelLabel}`;
 				helpBox.visible = true;
 			},
 		};
 
-		runExecution(skill, variables, model, viewPort, deps, actionName).then(() => {
+		runExecution(skill, variables, model, viewPort, deps, actionName, sessionId).then(() => {
 			const doneHandler = (key: KeyEvent) => {
 				if (key.name === "return") {
 					cleanup(doneHandler);

--- a/tests/tui/screens/execution-view.test.ts
+++ b/tests/tui/screens/execution-view.test.ts
@@ -132,7 +132,7 @@ describe("runExecution", () => {
 		const view = createMockViewPort();
 		const deps = createMockDeps();
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:Error: LLM model not configured.\n");
 		expect(view.calls).toContain(
@@ -148,7 +148,7 @@ describe("runExecution", () => {
 
 		mockedRunSkill.mockRejectedValueOnce(new Error("unexpected failure"));
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\nError: unexpected failure\n");
 		expect(view.calls).toContain("showSummary:0:0");
@@ -161,7 +161,7 @@ describe("runExecution", () => {
 
 		mockedRunSkill.mockRejectedValueOnce("string error");
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\nError: string error\n");
 		expect(view.calls).toContain("showSummary:0:0");
@@ -187,7 +187,7 @@ describe("runExecution", () => {
 			}),
 		);
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\n$ echo hello\n");
 		expect(view.calls).toContain("appendOutput:hello\n");
@@ -214,7 +214,7 @@ describe("runExecution", () => {
 			}),
 		);
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:not found\n");
 	});
@@ -228,7 +228,7 @@ describe("runExecution", () => {
 			err({ type: "SKILL_NOT_FOUND" as const, name: "tmpl-skill" }),
 		);
 
-		await runExecution(skill, {}, null, view, deps);
+		await runExecution(skill, {}, null, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\nError: Skill not found: tmpl-skill\n");
 		expect(view.calls).toContain("showSummary:0:0");
@@ -244,7 +244,7 @@ describe("runExecution", () => {
 			err({ type: "EXECUTION_ERROR" as const, message: "LLM unavailable" }),
 		);
 
-		await runExecution(skill, {}, fakeModel, view, deps);
+		await runExecution(skill, {}, fakeModel, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\nError: LLM unavailable\n");
 		expect(view.calls).toContain("showSummary:0:0");
@@ -258,7 +258,7 @@ describe("runExecution", () => {
 
 		mockedRunAgentSkill.mockRejectedValueOnce(new Error("network error"));
 
-		await runExecution(skill, {}, fakeModel, view, deps);
+		await runExecution(skill, {}, fakeModel, view, deps, undefined, TEST_SESSION_ID);
 
 		expect(view.calls).toContain("appendOutput:\nError: network error\n");
 		expect(view.calls).toContain("showSummary:0:0");


### PR DESCRIPTION
#### 概要

TUI の実行画面タイトルバーにセッション ID を表示するようにした。

#### 変更内容

- `ExecutionParams` に `sessionId: SessionId` フィールドを追加
- タイトルバーに [Running] / [Done] 状態でセッション ID を表示
- `generateSessionId()` の呼び出しを `execution-runner.ts` から `app.ts` に移動し、実行ループごとに新しいセッション ID を発行
- `runExecution` の引数に `sessionId` を追加し、UseCase 層まで伝搬
- テストファイルの `runExecution` 呼び出しを新しいシグネチャに対応

Closes #481