### PR TITLE
feat: add skillHooksSchema and SkillHooks type to skill-metadata.ts

### DIFF
--- a/src/core/skill/action.ts
+++ b/src/core/skill/action.ts
@@ -4,9 +4,15 @@ import type { ContextSource } from "./context-source";
 import { contextSourceSchema } from "./context-source";
 import type { SkillInput } from "./skill-input";
 import { skillInputSchema } from "./skill-input";
-import type { SkillMetadata } from "./skill-metadata";
+import type { SkillHooks, SkillMetadata } from "./skill-metadata";
 
 const skillModeSchema = z.enum(["template", "agent"]);
+
+const actionHooksSchema = z.object({
+	before: z.array(z.string().min(1)).optional(),
+	after: z.array(z.string().min(1)).optional(),
+	on_failure: z.array(z.string().min(1)).optional(),
+});
 
 const actionSchema = z.object({
 	description: z.string().min(1),
@@ -16,6 +22,7 @@ const actionSchema = z.object({
 	context: z.array(contextSourceSchema).optional(),
 	tools: z.array(z.string().min(1)).optional(),
 	timeout: z.number().int().positive().max(3_600_000).optional(),
+	hooks: actionHooksSchema.optional(),
 });
 
 type Action = z.infer<typeof actionSchema>;
@@ -28,6 +35,7 @@ type ResolvedActionConfig = {
 	readonly context: readonly ContextSource[];
 	readonly tools: readonly string[];
 	readonly timeout: number | undefined;
+	readonly hooks: SkillHooks | undefined;
 };
 
 function resolveActionConfig(action: Action, skill: SkillMetadata): ResolvedActionConfig {
@@ -39,6 +47,7 @@ function resolveActionConfig(action: Action, skill: SkillMetadata): ResolvedActi
 		context: action.context ?? skill.context ?? [],
 		tools: action.tools ?? skill.tools ?? DEFAULT_TOOLS,
 		timeout: action.timeout ?? skill.timeout ?? undefined,
+		hooks: action.hooks ?? skill.hooks ?? undefined,
 	};
 }
 

--- a/src/core/skill/skill-metadata.ts
+++ b/src/core/skill/skill-metadata.ts
@@ -12,6 +12,20 @@ import { skillInputSchema } from "./skill-input";
 
 const skillModeSchema = z.enum(["template", "agent"]);
 
+const skillHooksSchema = z.object({
+	before: z.array(z.string().min(1)).optional().describe("Commands to run before skill execution"),
+	after: z
+		.array(z.string().min(1))
+		.optional()
+		.describe("Commands to run after skill execution (always, regardless of success/failure)"),
+	on_failure: z
+		.array(z.string().min(1))
+		.optional()
+		.describe("Commands to run only on skill failure (after 'after' hooks)"),
+});
+
+type SkillHooks = z.infer<typeof skillHooksSchema>;
+
 const skillMetadataSchema = z
 	.object({
 		name: z.string().min(1),
@@ -29,6 +43,7 @@ const skillMetadataSchema = z
 		tools: z.array(z.string().min(1)).default([...DEFAULT_TOOLS]),
 		context: z.array(contextSourceSchema).default([]),
 		actions: z.record(z.string(), actionSchema).optional(),
+		hooks: skillHooksSchema.optional(),
 	})
 	.refine((data) => !data.actions || Object.keys(data.actions).length > 0, {
 		message: "actions must not be empty",
@@ -57,5 +72,5 @@ function parseSkillMetadata(data: unknown): Result<SkillMetadata, ParseError> {
 	return ok(result.data);
 }
 
-export type { ContextSource, SkillInput, SkillMetadata, SkillMode };
-export { parseSkillMetadata, skillInputSchema, skillMetadataSchema };
+export type { ContextSource, SkillHooks, SkillInput, SkillMetadata, SkillMode };
+export { parseSkillMetadata, skillHooksSchema, skillInputSchema, skillMetadataSchema };

--- a/tests/core/skill/action.test.ts
+++ b/tests/core/skill/action.test.ts
@@ -113,4 +113,45 @@ describe("resolveActionConfig", () => {
 
 		expect(resolved.description).toBe("Custom action description");
 	});
+
+	it("hooks 未指定のアクションはスキルの hooks を継承する", () => {
+		const skillHooks = {
+			before: ["echo 'skill before'"],
+			after: ["echo 'skill after'"],
+		};
+		const skill = baseSkill({ hooks: skillHooks });
+		const action = baseAction();
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.hooks).toStrictEqual(skillHooks);
+	});
+
+	it("アクション固有の hooks はスキルの hooks を完全に置き換える（オブジェクト単位）", () => {
+		const skillHooks = {
+			before: ["echo 'skill before'"],
+			after: ["echo 'skill after'"],
+			on_failure: ["echo 'skill failure'"],
+		};
+		const actionHooks = {
+			before: ["echo 'action before'"],
+		};
+		const skill = baseSkill({ hooks: skillHooks });
+		const action = baseAction({ hooks: actionHooks });
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.hooks).toStrictEqual(actionHooks);
+		expect(resolved.hooks?.after).toBeUndefined();
+		expect(resolved.hooks?.on_failure).toBeUndefined();
+	});
+
+	it("スキルもアクションも hooks 未指定の場合 undefined になる", () => {
+		const skill = baseSkill();
+		const action = baseAction();
+
+		const resolved = resolveActionConfig(action, skill);
+
+		expect(resolved.hooks).toBeUndefined();
+	});
 });

--- a/tests/core/skill/skill-metadata.test.ts
+++ b/tests/core/skill/skill-metadata.test.ts
@@ -282,6 +282,81 @@ describe("parseSkillMetadata", () => {
 		expect(result.error.message).toContain("actions must not be empty");
 	});
 
+	it("hooks 付きメタデータが正しくパースされる", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "デプロイする",
+			hooks: {
+				before: ["git stash --include-untracked"],
+				after: ["git stash pop"],
+				on_failure: ["echo 'deploy failed'"],
+			},
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.hooks).toStrictEqual({
+			before: ["git stash --include-untracked"],
+			after: ["git stash pop"],
+			on_failure: ["echo 'deploy failed'"],
+		});
+	});
+
+	it("hooks なしの既存スキルが後方互換で動作する", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "デプロイする",
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.hooks).toBeUndefined();
+	});
+
+	it("hooks が空オブジェクトでもパースが通る", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "デプロイする",
+			hooks: {},
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.hooks).toStrictEqual({});
+	});
+
+	it("hooks の一部フィールドのみ指定でもパースが通る", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "デプロイする",
+			hooks: {
+				before: ["echo 'starting'"],
+			},
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.hooks).toStrictEqual({
+			before: ["echo 'starting'"],
+		});
+		expect(result.value.hooks?.after).toBeUndefined();
+		expect(result.value.hooks?.on_failure).toBeUndefined();
+	});
+
+	it("hooks のコマンドが空文字列の場合エラーになる", () => {
+		const result = parseSkillMetadata({
+			name: "deploy",
+			description: "デプロイする",
+			hooks: {
+				before: [""],
+			},
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("PARSE_ERROR");
+	});
+
 	it("アクション名にコロンを含む場合エラーになる", () => {
 		const result = parseSkillMetadata({
 			name: "test",


### PR DESCRIPTION
#### 概要

SKILL.md フロントマターで `hooks` フィールドをパース可能にするため、`skillHooksSchema` と `SkillHooks` 型を追加し、アクション単位の hooks 継承を実装。

#### 変更内容

- `src/core/skill/skill-metadata.ts` に `skillHooksSchema`（before/after/on_failure）と `SkillHooks` 型を追加、`skillMetadataSchema` に `hooks` optional フィールドを追加
- `src/core/skill/action.ts` に `actionHooksSchema` を追加、`actionSchema`・`ResolvedActionConfig`・`resolveActionConfig` に `hooks` フィールドを追加（`action.hooks ?? skill.hooks ?? undefined` の継承）
- hooks パース・後方互換・オブジェクト単位置き換えのテストを追加

Closes #482