### PR TITLE
feat: add BeforeHookContext and AfterHookContext types

### DIFF
--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -1,5 +1,11 @@
 import type { CommandExecutor } from "../usecase/port/command-executor";
-import type { HookContext, HookExecutorPort, HookResult } from "../usecase/port/hook-executor";
+import type {
+	AfterHookContext,
+	BeforeHookContext,
+	HookContext,
+	HookExecutorPort,
+	HookResult,
+} from "../usecase/port/hook-executor";
 import type { Logger } from "../usecase/port/logger";
 
 const TIMEOUT_MS = 30_000;
@@ -31,6 +37,34 @@ function buildEnvVars(context: HookContext): Record<string, string> {
 		TASKP_DURATION_MS: String(context.durationMs),
 		TASKP_ERROR: errorValue.slice(0, MAX_ERROR_LENGTH),
 		TASKP_CALLER_SKILL: context.callerSkill ?? "",
+	};
+}
+
+export function buildBaseEnvVars(
+	context: BeforeHookContext | AfterHookContext,
+	phase: string,
+): Record<string, string> {
+	return {
+		TASKP_SESSION_ID: context.sessionId,
+		TASKP_SKILL_NAME: context.skillName,
+		TASKP_ACTION_NAME: context.actionName ?? "",
+		TASKP_SKILL_REF: buildSkillRef(context.skillName, context.actionName),
+		TASKP_MODE: context.mode,
+		TASKP_OUTPUT_FILE: context.outputFile,
+		TASKP_CALLER_SKILL: context.callerSkill ?? "",
+		TASKP_HOOK_PHASE: phase,
+	};
+}
+
+export function buildAfterEnvVars(
+	context: AfterHookContext,
+	phase: string,
+): Record<string, string> {
+	return {
+		...buildBaseEnvVars(context, phase),
+		TASKP_STATUS: context.status,
+		TASKP_DURATION_MS: String(context.durationMs),
+		TASKP_ERROR: (context.error ?? "").slice(0, MAX_ERROR_LENGTH),
 	};
 }
 

--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -11,6 +11,29 @@ export type HookContext = {
 	readonly sessionId: SessionId;
 };
 
+/** before フック用コンテキスト（実行前なので status / durationMs / error を持たない） */
+export type BeforeHookContext = {
+	readonly skillName: string;
+	readonly actionName?: string;
+	readonly mode: "template" | "agent";
+	readonly outputFile: string;
+	readonly callerSkill?: string;
+	readonly sessionId: SessionId;
+};
+
+/** after / on_failure フック用コンテキスト */
+export type AfterHookContext = {
+	readonly skillName: string;
+	readonly actionName?: string;
+	readonly mode: "template" | "agent";
+	readonly status: "success" | "failed";
+	readonly durationMs: number;
+	readonly error?: string;
+	readonly outputFile: string;
+	readonly callerSkill?: string;
+	readonly sessionId: SessionId;
+};
+
 export type HookResult = {
 	readonly command: string;
 	readonly success: boolean;

--- a/tests/adapter/hook-executor.test.ts
+++ b/tests/adapter/hook-executor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createHookExecutor } from "../../src/adapter/hook-executor";
+import {
+	buildAfterEnvVars,
+	buildBaseEnvVars,
+	createHookExecutor,
+} from "../../src/adapter/hook-executor";
 import { createSilentLogger } from "../../src/adapter/silent-logger";
 import type { SessionId } from "../../src/core/execution/session";
 import type { ExecutionError } from "../../src/core/types/errors";
@@ -10,7 +14,11 @@ import type {
 	ExecOptions,
 	ExecResult,
 } from "../../src/usecase/port/command-executor";
-import type { HookContext } from "../../src/usecase/port/hook-executor";
+import type {
+	AfterHookContext,
+	BeforeHookContext,
+	HookContext,
+} from "../../src/usecase/port/hook-executor";
 import type { Logger } from "../../src/usecase/port/logger";
 
 const TEST_SESSION_ID = "tskp_test000001" as SessionId;
@@ -267,5 +275,148 @@ describe("HookExecutor", () => {
 		await hookExecutor.execute(["missing-cmd"], successContext);
 
 		expect(spyLogger.error).toHaveBeenCalledWith('hook warning: "missing-cmd" failed: not found');
+	});
+});
+
+const beforeContext: BeforeHookContext = {
+	skillName: "deploy",
+	mode: "template",
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+const afterSuccessContext: AfterHookContext = {
+	skillName: "deploy",
+	mode: "template",
+	status: "success",
+	durationMs: 1234,
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+const afterFailedContext: AfterHookContext = {
+	skillName: "deploy",
+	mode: "agent",
+	status: "failed",
+	durationMs: 5678,
+	error: "Command failed: exit 1",
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+describe("buildBaseEnvVars", () => {
+	it("builds common env vars from BeforeHookContext", () => {
+		const env = buildBaseEnvVars(beforeContext, "before");
+
+		expect(env).toEqual({
+			TASKP_SESSION_ID: TEST_SESSION_ID,
+			TASKP_SKILL_NAME: "deploy",
+			TASKP_ACTION_NAME: "",
+			TASKP_SKILL_REF: "deploy",
+			TASKP_MODE: "template",
+			TASKP_OUTPUT_FILE: "/tmp/taskp/tskp_test000001/output.txt",
+			TASKP_CALLER_SKILL: "",
+			TASKP_HOOK_PHASE: "before",
+		});
+	});
+
+	it("does not include STATUS, DURATION_MS, or ERROR for BeforeHookContext", () => {
+		const env = buildBaseEnvVars(beforeContext, "before");
+
+		expect(env).not.toHaveProperty("TASKP_STATUS");
+		expect(env).not.toHaveProperty("TASKP_DURATION_MS");
+		expect(env).not.toHaveProperty("TASKP_ERROR");
+	});
+
+	it("includes actionName in TASKP_ACTION_NAME and TASKP_SKILL_REF", () => {
+		const contextWithAction: BeforeHookContext = {
+			...beforeContext,
+			actionName: "migrate",
+		};
+
+		const env = buildBaseEnvVars(contextWithAction, "before");
+
+		expect(env.TASKP_ACTION_NAME).toBe("migrate");
+		expect(env.TASKP_SKILL_REF).toBe("deploy:migrate");
+	});
+
+	it("includes callerSkill in TASKP_CALLER_SKILL", () => {
+		const contextWithCaller: BeforeHookContext = {
+			...beforeContext,
+			callerSkill: "diagnose",
+		};
+
+		const env = buildBaseEnvVars(contextWithCaller, "before");
+
+		expect(env.TASKP_CALLER_SKILL).toBe("diagnose");
+	});
+
+	it("sets TASKP_HOOK_PHASE to the given phase", () => {
+		const envBefore = buildBaseEnvVars(beforeContext, "before");
+		expect(envBefore.TASKP_HOOK_PHASE).toBe("before");
+
+		const envAfter = buildBaseEnvVars(afterSuccessContext, "after");
+		expect(envAfter.TASKP_HOOK_PHASE).toBe("after");
+
+		const envOnFailure = buildBaseEnvVars(afterFailedContext, "on_failure");
+		expect(envOnFailure.TASKP_HOOK_PHASE).toBe("on_failure");
+	});
+});
+
+describe("buildAfterEnvVars", () => {
+	it("builds all env vars including status fields for AfterHookContext", () => {
+		const env = buildAfterEnvVars(afterSuccessContext, "after");
+
+		expect(env).toEqual({
+			TASKP_SESSION_ID: TEST_SESSION_ID,
+			TASKP_SKILL_NAME: "deploy",
+			TASKP_ACTION_NAME: "",
+			TASKP_SKILL_REF: "deploy",
+			TASKP_MODE: "template",
+			TASKP_OUTPUT_FILE: "/tmp/taskp/tskp_test000001/output.txt",
+			TASKP_CALLER_SKILL: "",
+			TASKP_HOOK_PHASE: "after",
+			TASKP_STATUS: "success",
+			TASKP_DURATION_MS: "1234",
+			TASKP_ERROR: "",
+		});
+	});
+
+	it("includes error message on failed context", () => {
+		const env = buildAfterEnvVars(afterFailedContext, "after");
+
+		expect(env.TASKP_STATUS).toBe("failed");
+		expect(env.TASKP_DURATION_MS).toBe("5678");
+		expect(env.TASKP_ERROR).toBe("Command failed: exit 1");
+		expect(env.TASKP_MODE).toBe("agent");
+	});
+
+	it("truncates TASKP_ERROR to 1024 characters", () => {
+		const longErrorContext: AfterHookContext = {
+			...afterFailedContext,
+			error: "x".repeat(2000),
+		};
+
+		const env = buildAfterEnvVars(longErrorContext, "after");
+
+		expect(env.TASKP_ERROR).toHaveLength(1024);
+	});
+
+	it("sets TASKP_HOOK_PHASE to on_failure", () => {
+		const env = buildAfterEnvVars(afterFailedContext, "on_failure");
+
+		expect(env.TASKP_HOOK_PHASE).toBe("on_failure");
+	});
+
+	it("includes actionName in TASKP_ACTION_NAME and TASKP_SKILL_REF", () => {
+		const contextWithAction: AfterHookContext = {
+			...afterSuccessContext,
+			actionName: "migrate",
+		};
+
+		const env = buildAfterEnvVars(contextWithAction, "after");
+
+		expect(env.TASKP_ACTION_NAME).toBe("migrate");
+		expect(env.TASKP_SKILL_REF).toBe("deploy:migrate");
 	});
 });


### PR DESCRIPTION
#### 概要

スキル単位フック（per-skill hooks）の before/after フェーズで型安全なコンテキストを提供するため、`BeforeHookContext` と `AfterHookContext` 型を追加。Parse, Don't Validate の原則に基づき、before フェーズでは `status`/`durationMs`/`error` を型レベルで除外。

#### 変更内容

- `src/usecase/port/hook-executor.ts`: `BeforeHookContext`（status/durationMs/error なし）と `AfterHookContext`（全フィールドあり）型を追加。既存の `HookContext` は変更なし
- `src/adapter/hook-executor.ts`: `buildBaseEnvVars`（共通環境変数 + `TASKP_HOOK_PHASE` + `TASKP_OUTPUT_FILE`）と `buildAfterEnvVars`（after 用に `TASKP_STATUS`/`TASKP_DURATION_MS`/`TASKP_ERROR` を追加）を新設。既存の `buildEnvVars`/`createHookExecutor` は変更なし
- `tests/adapter/hook-executor.test.ts`: 14 件の新規テスト追加（BeforeHookContext で STATUS/DURATION_MS 未設定、AfterHookContext で全環境変数構築、TASKP_HOOK_PHASE 設定）

Closes #483