### PR TITLE
feat: add OutputFileStorePort and adapter implementation

### DIFF
--- a/src/adapter/output-file-store.ts
+++ b/src/adapter/output-file-store.ts
@@ -1,0 +1,35 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { OutputFileStorePort } from "../usecase/port/output-file-store";
+
+const BASE_DIR = "/tmp/taskp";
+const OUTPUT_FILENAME = "output.txt";
+
+function buildSessionDir(sessionId: string): string {
+	return join(BASE_DIR, sessionId);
+}
+
+function buildOutputPath(sessionId: string): string {
+	return join(buildSessionDir(sessionId), OUTPUT_FILENAME);
+}
+
+export function createOutputFileStore(): OutputFileStorePort {
+	return {
+		async prepare(sessionId: string): Promise<string> {
+			const sessionDir = buildSessionDir(sessionId);
+			await mkdir(sessionDir, { recursive: true });
+			const outputPath = buildOutputPath(sessionId);
+			await writeFile(outputPath, "", "utf-8");
+			return outputPath;
+		},
+
+		async write(filePath: string, content: string): Promise<void> {
+			await writeFile(filePath, content, "utf-8");
+		},
+
+		async cleanup(sessionId: string): Promise<void> {
+			const sessionDir = buildSessionDir(sessionId);
+			await rm(sessionDir, { recursive: true, force: true });
+		},
+	};
+}

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -4,6 +4,7 @@ export type { ContextCollectorPort } from "./context-collector";
 export type { HookContext, HookExecutorPort, HookResult } from "./hook-executor";
 export type { Logger } from "./logger";
 export type { McpToolResolverPort, ResolvedMcpToolSet } from "./mcp-tool-resolver";
+export type { OutputFileStorePort } from "./output-file-store";
 export type { PromptCollector } from "./prompt-collector";
 export type { InitOptions, SkillInitializer } from "./skill-initializer";
 export type { SkillRepository } from "./skill-repository";

--- a/src/usecase/port/output-file-store.ts
+++ b/src/usecase/port/output-file-store.ts
@@ -1,0 +1,8 @@
+export type OutputFileStorePort = {
+	/** セッション用ディレクトリと空の出力ファイルを作成。ファイルパスを返す */
+	readonly prepare: (sessionId: string) => Promise<string>;
+	/** 出力内容をファイルに書き込み */
+	readonly write: (filePath: string, content: string) => Promise<void>;
+	/** セッション用ディレクトリごとクリーンアップ */
+	readonly cleanup: (sessionId: string) => Promise<void>;
+};

--- a/tests/adapter/output-file-store.test.ts
+++ b/tests/adapter/output-file-store.test.ts
@@ -1,0 +1,103 @@
+import { existsSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createOutputFileStore } from "../../src/adapter/output-file-store";
+
+const TEST_SESSION_ID = "tskp_test_output_001";
+const SESSION_DIR = join("/tmp/taskp", TEST_SESSION_ID);
+
+describe("OutputFileStore", () => {
+	const store = createOutputFileStore();
+
+	afterEach(async () => {
+		await store.cleanup(TEST_SESSION_ID).catch(() => {});
+	});
+
+	describe("prepare", () => {
+		it("セッションディレクトリを作成する", async () => {
+			await store.prepare(TEST_SESSION_ID);
+
+			const dirStat = await stat(SESSION_DIR);
+			expect(dirStat.isDirectory()).toBe(true);
+		});
+
+		it("空の output.txt を作成する", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			const content = await readFile(outputPath, "utf-8");
+			expect(content).toBe("");
+		});
+
+		it("出力ファイルのパスを返す", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			expect(outputPath).toBe(join(SESSION_DIR, "output.txt"));
+		});
+
+		it("既にディレクトリが存在しても成功する", async () => {
+			await store.prepare(TEST_SESSION_ID);
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			expect(outputPath).toBe(join(SESSION_DIR, "output.txt"));
+		});
+	});
+
+	describe("write", () => {
+		it("内容をファイルに書き込む", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			await store.write(outputPath, "hello world");
+
+			const content = await readFile(outputPath, "utf-8");
+			expect(content).toBe("hello world");
+		});
+
+		it("既存の内容を上書きする", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			await store.write(outputPath, "first");
+			await store.write(outputPath, "second");
+
+			const content = await readFile(outputPath, "utf-8");
+			expect(content).toBe("second");
+		});
+
+		it("マルチバイト文字を正しく書き込む", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+
+			await store.write(outputPath, "日本語テスト 🎉");
+
+			const content = await readFile(outputPath, "utf-8");
+			expect(content).toBe("日本語テスト 🎉");
+		});
+	});
+
+	describe("cleanup", () => {
+		it("セッションディレクトリを削除する", async () => {
+			await store.prepare(TEST_SESSION_ID);
+
+			await store.cleanup(TEST_SESSION_ID);
+
+			expect(existsSync(SESSION_DIR)).toBe(false);
+		});
+
+		it("存在しないセッションでもエラーにならない", async () => {
+			await expect(store.cleanup("tskp_nonexistent")).resolves.toBeUndefined();
+		});
+	});
+
+	describe("lifecycle", () => {
+		it("prepare → write → cleanup の完全なライフサイクル", async () => {
+			const outputPath = await store.prepare(TEST_SESSION_ID);
+			expect(existsSync(outputPath)).toBe(true);
+
+			await store.write(outputPath, "lifecycle test content");
+			const content = await readFile(outputPath, "utf-8");
+			expect(content).toBe("lifecycle test content");
+
+			await store.cleanup(TEST_SESSION_ID);
+			expect(existsSync(SESSION_DIR)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
#### 概要

スキル出力を一時ファイルに書き出す `OutputFileStorePort`（UseCase port）とその Adapter 実装を追加。

#### 変更内容

- `src/usecase/port/output-file-store.ts` — `OutputFileStorePort` インターフェース定義
- `src/adapter/output-file-store.ts` — `/tmp/taskp/<session_id>/output.txt` の管理実装（`createOutputFileStore` ファクトリ）
- `src/usecase/port/index.ts` — エクスポート追加
- `tests/adapter/output-file-store.test.ts` — prepare/write/cleanup ライフサイクルテスト（10件）

Closes #484