### PR TITLE
feat: add skill-hook-runner with before/after/on_failure execution

### DIFF
--- a/src/adapter/hook-executor.ts
+++ b/src/adapter/hook-executor.ts
@@ -4,6 +4,7 @@ import type {
 	BeforeHookContext,
 	HookContext,
 	HookExecutorPort,
+	HookPhase,
 	HookResult,
 } from "../usecase/port/hook-executor";
 import type { Logger } from "../usecase/port/logger";
@@ -68,6 +69,31 @@ export function buildAfterEnvVars(
 	};
 }
 
+function isSkillHookContext(
+	context: HookContext | BeforeHookContext | AfterHookContext,
+): context is BeforeHookContext | AfterHookContext {
+	return "outputFile" in context;
+}
+
+function isAfterHookContext(
+	context: BeforeHookContext | AfterHookContext,
+): context is AfterHookContext {
+	return "status" in context;
+}
+
+function buildEnvVarsForContext(
+	context: HookContext | BeforeHookContext | AfterHookContext,
+	phase: string,
+): Record<string, string> {
+	if (!isSkillHookContext(context)) {
+		return buildEnvVars(context);
+	}
+	if (isAfterHookContext(context)) {
+		return buildAfterEnvVars(context, phase);
+	}
+	return buildBaseEnvVars(context, phase);
+}
+
 export function createHookExecutor(
 	commandExecutor: CommandExecutor,
 	logger: Logger,
@@ -75,13 +101,17 @@ export function createHookExecutor(
 	return {
 		async execute(
 			commands: readonly string[],
-			context: HookContext,
+			context: HookContext | BeforeHookContext | AfterHookContext,
+			phase?: HookPhase,
 		): Promise<readonly HookResult[]> {
 			if (commands.length === 0) {
 				return [];
 			}
 
-			const mergedEnv = { ...getParentEnv(), ...buildEnvVars(context) };
+			const mergedEnv = {
+				...getParentEnv(),
+				...buildEnvVarsForContext(context, phase ?? ""),
+			};
 			const results: HookResult[] = [];
 
 			for (const command of commands) {

--- a/src/usecase/port/hook-executor.ts
+++ b/src/usecase/port/hook-executor.ts
@@ -40,6 +40,14 @@ export type HookResult = {
 	readonly error?: string;
 };
 
+export type SkillHookContext = BeforeHookContext | AfterHookContext;
+
+export type HookPhase = "before" | "after" | "on_failure";
+
 export interface HookExecutorPort {
-	execute(commands: readonly string[], context: HookContext): Promise<readonly HookResult[]>;
+	execute(
+		commands: readonly string[],
+		context: HookContext | SkillHookContext,
+		phase?: HookPhase,
+	): Promise<readonly HookResult[]>;
 }

--- a/src/usecase/port/index.ts
+++ b/src/usecase/port/index.ts
@@ -1,7 +1,15 @@
 export type { AgentExecutorInput, AgentExecutorPort, AgentExecutorResult } from "./agent-executor";
 export type { CommandExecutor, ExecOptions, ExecResult } from "./command-executor";
 export type { ContextCollectorPort } from "./context-collector";
-export type { HookContext, HookExecutorPort, HookResult } from "./hook-executor";
+export type {
+	AfterHookContext,
+	BeforeHookContext,
+	HookContext,
+	HookExecutorPort,
+	HookPhase,
+	HookResult,
+	SkillHookContext,
+} from "./hook-executor";
 export type { Logger } from "./logger";
 export type { McpToolResolverPort, ResolvedMcpToolSet } from "./mcp-tool-resolver";
 export type { OutputFileStorePort } from "./output-file-store";

--- a/src/usecase/skill-hook-runner.ts
+++ b/src/usecase/skill-hook-runner.ts
@@ -1,0 +1,100 @@
+import type { SkillHooks } from "../core/skill/skill-metadata";
+import { type ExecutionError, executionError } from "../core/types/errors";
+import { err, ok, type Result } from "../core/types/result";
+import type { AfterHookContext, BeforeHookContext, HookExecutorPort } from "./port/hook-executor";
+import type { Logger } from "./port/logger";
+
+type RunBeforeHooksParams = {
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooks?: SkillHooks;
+	readonly context: BeforeHookContext;
+	readonly logger: Logger;
+};
+
+type RunAfterHooksParams = {
+	readonly hookExecutor?: HookExecutorPort;
+	readonly hooks?: SkillHooks;
+	readonly context: AfterHookContext;
+	readonly logger: Logger;
+};
+
+export async function runBeforeHooks(
+	params: RunBeforeHooksParams,
+): Promise<Result<void, ExecutionError>> {
+	const commands = params.hooks?.before;
+	if (
+		params.hookExecutor === undefined ||
+		params.hooks === undefined ||
+		commands === undefined ||
+		commands.length === 0
+	) {
+		return ok(undefined);
+	}
+
+	try {
+		const results = await params.hookExecutor.execute(commands, params.context, "before");
+		const failures = results.filter((r) => !r.success);
+		if (failures.length > 0) {
+			const details = failures
+				.map((f) => `"${f.command}": ${f.error ?? "unknown error"}`)
+				.join(", ");
+			return err(executionError(`Skill before hook failed: ${details}`));
+		}
+		return ok(undefined);
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		return err(executionError(`Skill before hook failed: ${message}`));
+	}
+}
+
+export async function runAfterHooks(params: RunAfterHooksParams): Promise<void> {
+	const commands = params.hooks?.after;
+	if (
+		params.hookExecutor === undefined ||
+		params.hooks === undefined ||
+		commands === undefined ||
+		commands.length === 0
+	) {
+		return;
+	}
+
+	try {
+		const results = await params.hookExecutor.execute(commands, params.context, "after");
+		const failures = results.filter((r) => !r.success);
+		if (failures.length > 0) {
+			const details = failures
+				.map((f) => `"${f.command}": ${f.error ?? "unknown error"}`)
+				.join(", ");
+			params.logger.warn(`Skill after hook warning: ${details}`);
+		}
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		params.logger.warn(`Skill after hook warning: ${message}`);
+	}
+}
+
+export async function runOnFailureHooks(params: RunAfterHooksParams): Promise<void> {
+	const commands = params.hooks?.on_failure;
+	if (
+		params.hookExecutor === undefined ||
+		params.hooks === undefined ||
+		commands === undefined ||
+		commands.length === 0
+	) {
+		return;
+	}
+
+	try {
+		const results = await params.hookExecutor.execute(commands, params.context, "on_failure");
+		const failures = results.filter((r) => !r.success);
+		if (failures.length > 0) {
+			const details = failures
+				.map((f) => `"${f.command}": ${f.error ?? "unknown error"}`)
+				.join(", ");
+			params.logger.warn(`Skill on_failure hook warning: ${details}`);
+		}
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		params.logger.warn(`Skill on_failure hook warning: ${message}`);
+	}
+}

--- a/tests/usecase/skill-hook-runner.test.ts
+++ b/tests/usecase/skill-hook-runner.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionId } from "../../src/core/execution/session";
+import { ErrorType } from "../../src/core/types/errors";
+import type {
+	AfterHookContext,
+	BeforeHookContext,
+	HookExecutorPort,
+	HookResult,
+} from "../../src/usecase/port/hook-executor";
+import type { Logger } from "../../src/usecase/port/logger";
+import {
+	runAfterHooks,
+	runBeforeHooks,
+	runOnFailureHooks,
+} from "../../src/usecase/skill-hook-runner";
+
+const TEST_SESSION_ID = "tskp_test000001" as SessionId;
+
+function createMockExecutor(
+	results?: (commands: readonly string[]) => readonly HookResult[],
+): HookExecutorPort & {
+	calls: { commands: readonly string[]; phase?: string }[];
+} {
+	const calls: { commands: readonly string[]; phase?: string }[] = [];
+	return {
+		calls,
+		execute: vi.fn(async (commands, _context, phase) => {
+			calls.push({ commands, phase });
+			if (results) {
+				return results(commands);
+			}
+			return commands.map((cmd: string) => ({ command: cmd, success: true }));
+		}),
+	};
+}
+
+function createSpyLogger(): Logger & {
+	warnings: string[];
+	errors: string[];
+} {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	return {
+		warnings,
+		errors,
+		debug: vi.fn(),
+		warn: vi.fn((msg: string) => warnings.push(msg)),
+		error: vi.fn((msg: string) => errors.push(msg)),
+	};
+}
+
+const beforeContext: BeforeHookContext = {
+	skillName: "deploy",
+	mode: "template",
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+const afterSuccessContext: AfterHookContext = {
+	skillName: "deploy",
+	mode: "template",
+	status: "success",
+	durationMs: 1234,
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+const afterFailedContext: AfterHookContext = {
+	skillName: "deploy",
+	mode: "agent",
+	status: "failed",
+	durationMs: 5678,
+	error: "Command failed: exit 1",
+	outputFile: "/tmp/taskp/tskp_test000001/output.txt",
+	sessionId: TEST_SESSION_ID,
+};
+
+describe("runBeforeHooks", () => {
+	it("returns ok when hooks is undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: undefined,
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("returns ok when hookExecutor is undefined", async () => {
+		const logger = createSpyLogger();
+		const result = await runBeforeHooks({
+			hookExecutor: undefined,
+			hooks: { before: ["echo ok"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("returns ok when before commands are undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { after: ["echo after"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("returns ok when before commands are empty", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: [] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("returns ok when all before hooks succeed", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: ["echo one", "echo two"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo one", "echo two"]);
+	});
+
+	it("passes 'before' phase to executor", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: ["echo ok"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(executor.calls[0].phase).toBe("before");
+	});
+
+	it("returns err when a before hook fails", async () => {
+		const executor = createMockExecutor((commands) =>
+			commands.map((cmd) =>
+				cmd === "fail-cmd"
+					? { command: cmd, success: false, error: "exit code 1" }
+					: { command: cmd, success: true },
+			),
+		);
+		const logger = createSpyLogger();
+
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: ["echo ok", "fail-cmd"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Execution);
+			expect(result.error.message).toBe('Skill before hook failed: "fail-cmd": exit code 1');
+		}
+	});
+
+	it("returns err with 'unknown error' when failed hook has no error message", async () => {
+		const executor = createMockExecutor(() => [{ command: "bad-cmd", success: false }]);
+		const logger = createSpyLogger();
+
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: ["bad-cmd"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.message).toBe('Skill before hook failed: "bad-cmd": unknown error');
+		}
+	});
+
+	it("returns err when executor throws", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async () => {
+				throw new Error("network error");
+			}),
+		};
+		const logger = createSpyLogger();
+
+		const result = await runBeforeHooks({
+			hookExecutor: executor,
+			hooks: { before: ["echo ok"] },
+			context: beforeContext,
+			logger,
+		});
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.type).toBe(ErrorType.Execution);
+			expect(result.error.message).toBe("Skill before hook failed: network error");
+		}
+	});
+});
+
+describe("runAfterHooks", () => {
+	it("does nothing when hooks is undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: undefined,
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when hookExecutor is undefined", async () => {
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: undefined,
+			hooks: { after: ["echo done"] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(0);
+	});
+
+	it("does nothing when after commands are undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { before: ["echo before"] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when after commands are empty", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { after: [] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("executes after hooks and returns void on success", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { after: ["echo done", "echo cleanup"] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo done", "echo cleanup"]);
+		expect(logger.warnings).toHaveLength(0);
+	});
+
+	it("passes 'after' phase to executor", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { after: ["echo ok"] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(executor.calls[0].phase).toBe("after");
+	});
+
+	it("logs warning and does not throw when after hook fails", async () => {
+		const executor = createMockExecutor((commands) =>
+			commands.map((cmd) => ({ command: cmd, success: false, error: "hook error" })),
+		);
+		const logger = createSpyLogger();
+
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { after: ["cleanup"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(1);
+		expect(logger.warnings[0]).toBe('Skill after hook warning: "cleanup": hook error');
+	});
+
+	it("logs warning and does not throw when executor throws", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async () => {
+				throw new Error("crash");
+			}),
+		};
+		const logger = createSpyLogger();
+
+		await runAfterHooks({
+			hookExecutor: executor,
+			hooks: { after: ["echo ok"] },
+			context: afterSuccessContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(1);
+		expect(logger.warnings[0]).toBe("Skill after hook warning: crash");
+	});
+});
+
+describe("runOnFailureHooks", () => {
+	it("does nothing when hooks is undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: undefined,
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when hookExecutor is undefined", async () => {
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: undefined,
+			hooks: { on_failure: ["echo recover"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(0);
+	});
+
+	it("does nothing when on_failure commands are undefined", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { after: ["echo after"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("does nothing when on_failure commands are empty", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { on_failure: [] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(executor.execute).not.toHaveBeenCalled();
+	});
+
+	it("executes on_failure hooks and returns void on success", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { on_failure: ["echo recover", "notify-admin"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(executor.execute).toHaveBeenCalledOnce();
+		expect(executor.calls[0].commands).toEqual(["echo recover", "notify-admin"]);
+		expect(logger.warnings).toHaveLength(0);
+	});
+
+	it("passes 'on_failure' phase to executor", async () => {
+		const executor = createMockExecutor();
+		const logger = createSpyLogger();
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { on_failure: ["echo recover"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(executor.calls[0].phase).toBe("on_failure");
+	});
+
+	it("logs warning and does not throw when on_failure hook fails", async () => {
+		const executor = createMockExecutor((commands) =>
+			commands.map((cmd) => ({ command: cmd, success: false, error: "failed to recover" })),
+		);
+		const logger = createSpyLogger();
+
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { on_failure: ["recover"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(1);
+		expect(logger.warnings[0]).toBe('Skill on_failure hook warning: "recover": failed to recover');
+	});
+
+	it("logs warning and does not throw when executor throws", async () => {
+		const executor: HookExecutorPort = {
+			execute: vi.fn(async () => {
+				throw new Error("fatal");
+			}),
+		};
+		const logger = createSpyLogger();
+
+		await runOnFailureHooks({
+			hookExecutor: executor,
+			hooks: { on_failure: ["recover"] },
+			context: afterFailedContext,
+			logger,
+		});
+
+		expect(logger.warnings).toHaveLength(1);
+		expect(logger.warnings[0]).toBe("Skill on_failure hook warning: fatal");
+	});
+});


### PR DESCRIPTION
#### 概要

スキル単位の before / after / on_failure フック実行ロジックを `src/usecase/skill-hook-runner.ts` に実装。

#### 変更内容

- `src/usecase/skill-hook-runner.ts` を新規作成: `runBeforeHooks`（Result返却）、`runAfterHooks`（void、警告ログ）、`runOnFailureHooks`（void、警告ログ）
- `HookExecutorPort.execute` の context パラメータを `HookContext | SkillHookContext` に拡張（後方互換）
- `HookPhase` 型と optional `phase` パラメータを追加
- `createHookExecutor` アダプタを `BeforeHookContext` / `AfterHookContext` のenv変数構築に対応
- 25件のユニットテストを追加

Closes #485