### PR TITLE
feat: inject OutputFileStore and skill hooks into CLI and TUI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { createContextCollector } from "./adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "./adapter/context-collector-deps";
 import { createNodeFileSystem } from "./adapter/file-system-port";
 import { createHookExecutor } from "./adapter/hook-executor";
+import { createOutputFileStore } from "./adapter/output-file-store";
 import { createCliProgressWriter } from "./adapter/progress-formatter";
 import { createProjectInitializer } from "./adapter/project-initializer";
 import { createPromptRunner } from "./adapter/prompt-runner";
@@ -198,6 +199,7 @@ const cli = Cli.create("taskp", {
 			const hooksConfig = config?.hooks;
 			const logger = createConsoleLogger();
 			const hookExecutor = createHookExecutor(commandExecutor, logger);
+			const outputFileStore = createOutputFileStore();
 
 			const result = await runSkill(
 				{
@@ -216,6 +218,8 @@ const cli = Cli.create("taskp", {
 					progressWriter,
 					hookExecutor,
 					hooksConfig,
+					outputFileStore,
+					logger,
 				},
 			);
 
@@ -386,6 +390,7 @@ async function runAgentMode(
 	});
 	const hookExecutor = createHookExecutor(commandExecutor, logger);
 	const hooksConfig = config.hooks;
+	const outputFileStore = createOutputFileStore();
 
 	const mcpToolResolver = config.mcp?.servers
 		? (await import("./adapter/mcp-tool-resolver")).createMcpToolResolver(
@@ -415,6 +420,7 @@ async function runAgentMode(
 			hookExecutor,
 			hooksConfig,
 			mcpToolResolver,
+			outputFileStore,
 			logger,
 		},
 	);

--- a/src/core/execution/tools/taskp-run-tool.ts
+++ b/src/core/execution/tools/taskp-run-tool.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { HooksConfig } from "../../../usecase/hook-runner";
 import type { CommandExecutor } from "../../../usecase/port/command-executor";
 import type { HookExecutorPort } from "../../../usecase/port/hook-executor";
+import type { OutputFileStorePort } from "../../../usecase/port/output-file-store";
 import type { PromptCollector } from "../../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../../usecase/port/skill-repository";
 import { type RunOutput, runSkill } from "../../../usecase/run-skill";
@@ -42,6 +43,7 @@ export type TaskpRunDeps = {
 	readonly callerSkillName?: string;
 	readonly hookExecutor?: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
+	readonly outputFileStore?: OutputFileStorePort;
 	readonly sessionId: SessionId;
 };
 
@@ -124,6 +126,7 @@ async function executeTaskpRun(
 			promptCollector: deps.promptCollector,
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,
+			outputFileStore: deps.outputFileStore,
 		},
 	);
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -5,6 +5,7 @@ import { createCommandRunner } from "../adapter/command-runner";
 import { createDefaultConfigLoader, type McpServerConfig } from "../adapter/config-loader";
 import { createConsoleLogger } from "../adapter/console-logger";
 import { createHookExecutor } from "../adapter/hook-executor";
+import { createOutputFileStore } from "../adapter/output-file-store";
 import { generateSessionId } from "../adapter/session-id-generator";
 import { createDefaultSkillLoader } from "../adapter/skill-loader";
 import { createSystemPromptResolver } from "../adapter/system-prompt-resolver";
@@ -55,10 +56,12 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 		const commandExecutor = createCommandRunner({ defaultTimeoutMs: commandTimeoutMs });
 		const logger = createConsoleLogger();
 		const hookExecutor = createHookExecutor(commandExecutor, logger);
+		const outputFileStore = createOutputFileStore();
 		const executionDeps: ExecutionDeps = {
 			commandExecutor,
 			hookExecutor,
 			hooksConfig,
+			outputFileStore,
 			skillRepositoryFactory: createSingleSkillRepository,
 			promptCollectorFactory: createPresetPromptCollector,
 			systemPromptResolver: createSystemPromptResolver(process.cwd()),

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -12,6 +12,7 @@ import { ok } from "../../core/types/result";
 import type { HooksConfig } from "../../usecase/hook-runner";
 import type { CommandExecutor } from "../../usecase/port/command-executor";
 import type { HookExecutorPort } from "../../usecase/port/hook-executor";
+import type { OutputFileStorePort } from "../../usecase/port/output-file-store";
 import type { PromptCollector } from "../../usecase/port/prompt-collector";
 import type { SkillRepository } from "../../usecase/port/skill-repository";
 import type { SystemPromptResolver } from "../../usecase/port/system-prompt-resolver";
@@ -32,6 +33,7 @@ export type ExecutionDeps = {
 	readonly commandExecutor: CommandExecutor;
 	readonly hookExecutor: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
+	readonly outputFileStore?: OutputFileStorePort;
 	readonly skillRepositoryFactory: SkillRepositoryFactory;
 	readonly promptCollectorFactory: PromptCollectorFactory;
 	readonly systemPromptResolver: SystemPromptResolver;
@@ -136,6 +138,7 @@ async function executeAgentMode(
 			progressWriter,
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,
+			outputFileStore: deps.outputFileStore,
 			systemPromptResolver: deps.systemPromptResolver,
 			mcpToolResolver,
 			logger,
@@ -174,6 +177,7 @@ async function executeTemplateMode(
 			progressWriter,
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,
+			outputFileStore: deps.outputFileStore,
 		},
 	);
 

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -19,6 +19,7 @@ import type { CollectedContext, ContextCollectorPort } from "./port/context-coll
 import type { HookExecutorPort } from "./port/hook-executor";
 import type { Logger } from "./port/logger";
 import type { McpToolResolverPort, ResolvedMcpToolSet } from "./port/mcp-tool-resolver";
+import type { OutputFileStorePort } from "./port/output-file-store";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -51,6 +52,7 @@ export type RunAgentSkillDeps = {
 	readonly hookExecutor?: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
 	readonly mcpToolResolver?: McpToolResolverPort;
+	readonly outputFileStore?: OutputFileStorePort;
 	readonly logger?: Logger;
 };
 
@@ -138,6 +140,7 @@ export async function runAgentSkill(
 		callerSkillName: skill.metadata.name,
 		hookExecutor: deps.hookExecutor,
 		hooksConfig: deps.hooksConfig,
+		outputFileStore: deps.outputFileStore,
 		sessionId: input.sessionId,
 	};
 

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -13,6 +13,8 @@ import { buildReservedVars, renderTemplate } from "../core/variable/template-ren
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
 import type { HookExecutorPort } from "./port/hook-executor";
+import type { Logger } from "./port/logger";
+import type { OutputFileStorePort } from "./port/output-file-store";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
@@ -48,6 +50,8 @@ export type RunSkillDeps = {
 	readonly progressWriter?: ProgressWriter;
 	readonly hookExecutor?: HookExecutorPort;
 	readonly hooksConfig?: HooksConfig;
+	readonly outputFileStore?: OutputFileStorePort;
+	readonly logger?: Logger;
 };
 
 export async function runSkill(

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -13,6 +13,7 @@ import type { ContextCollectorPort } from "../../src/usecase/port/context-collec
 import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
 import type { Logger } from "../../src/usecase/port/logger";
 import type { McpToolResolverPort } from "../../src/usecase/port/mcp-tool-resolver";
+import type { OutputFileStorePort } from "../../src/usecase/port/output-file-store";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
 import type { SystemPromptResolver } from "../../src/usecase/port/system-prompt-resolver";
@@ -1094,6 +1095,46 @@ describe("runAgentSkill", () => {
 
 			expect(result.ok).toBe(false);
 			expect(mcpToolResolver.closeAll).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe("outputFileStore injection", () => {
+		function stubOutputFileStore(): OutputFileStorePort {
+			return {
+				prepare: vi.fn().mockResolvedValue("/tmp/taskp/test/output.txt"),
+				write: vi.fn().mockResolvedValue(undefined),
+				cleanup: vi.fn().mockResolvedValue(undefined),
+			};
+		}
+
+		it("accepts outputFileStore in deps without affecting execution", async () => {
+			const skill = createAgentSkill();
+			const outputFileStore = stubOutputFileStore();
+			const deps = {
+				...createMockDeps(skill),
+				outputFileStore,
+			};
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel, sessionId: TEST_SESSION_ID },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.skillName).toBe("test-agent");
+		});
+
+		it("works without outputFileStore (backward compatible)", async () => {
+			const skill = createAgentSkill();
+			const deps = createMockDeps(skill);
+
+			const result = await runAgentSkill(
+				{ name: "test-agent", presets: {}, model: mockModel, sessionId: TEST_SESSION_ID },
+				deps,
+			);
+
+			expect(result.ok).toBe(true);
 		});
 	});
 });

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -7,6 +7,7 @@ import { executionError, skillNotFoundError } from "../../src/core/types/errors"
 import { err, ok } from "../../src/core/types/result";
 import type { CommandExecutor } from "../../src/usecase/port/command-executor";
 import type { HookContext, HookExecutorPort } from "../../src/usecase/port/hook-executor";
+import type { OutputFileStorePort } from "../../src/usecase/port/output-file-store";
 import { createNoopProgressWriter } from "../../src/usecase/port/progress-writer";
 import type { PromptCollector } from "../../src/usecase/port/prompt-collector";
 import type { SkillRepository } from "../../src/usecase/port/skill-repository";
@@ -637,6 +638,36 @@ echo "listing tasks"
 			if (!result.ok) return;
 			expect(result.value.skillName).toBe("deploy");
 			expect(result.value.commands).toHaveLength(1);
+		});
+	});
+
+	describe("outputFileStore injection", () => {
+		function stubOutputFileStore(): OutputFileStorePort {
+			return {
+				prepare: vi.fn().mockResolvedValue("/tmp/taskp/test/output.txt"),
+				write: vi.fn().mockResolvedValue(undefined),
+				cleanup: vi.fn().mockResolvedValue(undefined),
+			};
+		}
+
+		it("accepts outputFileStore in deps without affecting execution", async () => {
+			const outputFileStore = stubOutputFileStore();
+			const deps = createDeps({ outputFileStore });
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.skillName).toBe("deploy");
+			expect(result.value.commands).toHaveLength(1);
+		});
+
+		it("works without outputFileStore (backward compatible)", async () => {
+			const deps = createDeps();
+
+			const result = await runSkill(createInput(), deps);
+
+			expect(result.ok).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
#### 概要

CLI と TUI に `OutputFileStore` を生成・注入し、スキル実行時にスキル単位フックと出力ファイルが利用可能になるようにする。

#### 変更内容

- `src/usecase/run-skill.ts`: `RunSkillDeps` に `outputFileStore` と `logger` フィールドを追加
- `src/usecase/run-agent-skill.ts`: `RunAgentSkillDeps` に `outputFileStore` フィールドを追加、`taskpRunDeps` にフォワーディング
- `src/core/execution/tools/taskp-run-tool.ts`: `TaskpRunDeps` に `outputFileStore` フィールドを追加、`runSkill` 呼び出しにフォワーディング
- `src/cli.ts`: `createOutputFileStore()` で生成し、template モードと agent モード両方の deps に注入
- `src/tui/app.ts`: `createOutputFileStore()` で生成し、`ExecutionDeps` に注入
- `src/tui/screens/execution-runner.ts`: `ExecutionDeps` に `outputFileStore` フィールドを追加、`runSkill`/`runAgentSkill` にフォワーディング
- テスト: `outputFileStore` 注入と後方互換性のテストを追加

Closes #487