### PR TITLE
feat: integrate skill hooks and OutputFileStore into run-skill and run-agent-skill

### DIFF
--- a/src/usecase/port/logger.ts
+++ b/src/usecase/port/logger.ts
@@ -3,3 +3,7 @@ export type Logger = {
 	readonly warn: (message: string) => void;
 	readonly error: (message: string) => void;
 };
+
+export function createNoopLogger(): Logger {
+	return { debug: () => {}, warn: () => {}, error: () => {} };
+}

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -16,14 +16,20 @@ import { type HooksConfig, runHooks } from "./hook-runner";
 import type { AgentExecutorPort, AgentExecutorResult } from "./port/agent-executor";
 import type { CommandExecutor } from "./port/command-executor";
 import type { CollectedContext, ContextCollectorPort } from "./port/context-collector";
-import type { HookExecutorPort } from "./port/hook-executor";
-import type { Logger } from "./port/logger";
+import type { AfterHookContext, BeforeHookContext, HookExecutorPort } from "./port/hook-executor";
+import { createNoopLogger, type Logger } from "./port/logger";
 import type { McpToolResolverPort, ResolvedMcpToolSet } from "./port/mcp-tool-resolver";
 import type { OutputFileStorePort } from "./port/output-file-store";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
 import type { SystemPromptResolver } from "./port/system-prompt-resolver";
+import {
+	resolveSkillHooks,
+	runAfterHooks,
+	runBeforeHooks,
+	runOnFailureHooks,
+} from "./skill-hook-runner";
 
 export type RunAgentSkillInput = {
 	readonly name: string;
@@ -153,6 +159,70 @@ export async function runAgentSkill(
 		return err(configError("MCP tool references found but mcpToolResolver is not configured"));
 	}
 
+	const hooks = resolveSkillHooks(skill, input.action);
+	const logger = deps.logger ?? createNoopLogger();
+
+	let outputFile = "";
+	if (hooks !== undefined && deps.outputFileStore !== undefined) {
+		outputFile = await deps.outputFileStore.prepare(input.sessionId);
+	}
+
+	const beforeContext: BeforeHookContext = {
+		skillName: skill.metadata.name,
+		actionName: input.action,
+		mode: "agent",
+		outputFile,
+		callerSkill: undefined,
+		sessionId: input.sessionId,
+	};
+
+	// ① skill hooks.before
+	const beforeResult = await runBeforeHooks({
+		hookExecutor: deps.hookExecutor,
+		hooks,
+		context: beforeContext,
+		logger,
+	});
+
+	if (!beforeResult.ok) {
+		const afterContext: AfterHookContext = {
+			...beforeContext,
+			status: "failed",
+			durationMs: 0,
+			error: domainErrorMessage(beforeResult.error),
+		};
+
+		// ③ skill hooks.after（常に）
+		await runAfterHooks({ hookExecutor: deps.hookExecutor, hooks, context: afterContext, logger });
+		// ④ skill hooks.on_failure
+		await runOnFailureHooks({
+			hookExecutor: deps.hookExecutor,
+			hooks,
+			context: afterContext,
+			logger,
+		});
+		// ⑤ global hooks
+		await runHooks({
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
+			context: {
+				skillName: skill.metadata.name,
+				actionName: input.action,
+				mode: "agent",
+				status: "failed",
+				durationMs: 0,
+				error: domainErrorMessage(beforeResult.error),
+				sessionId: input.sessionId,
+			},
+		});
+
+		if (outputFile && deps.outputFileStore !== undefined) {
+			await deps.outputFileStore.cleanup(input.sessionId);
+		}
+		await deps.mcpToolResolver?.closeAll();
+		return beforeResult;
+	}
+
 	try {
 		let toolSet: ToolSet;
 
@@ -167,8 +237,7 @@ export async function runAgentSkill(
 			toolSet = builtinToolsResult.value;
 		}
 
-		// durationMs は LLM エージェントの実行時間のみを測定する
-		// （コンテキスト収集時間は含めない — hooks に渡す情報として実行コストを正確に反映するため）
+		// ② スキル本体実行
 		const startTime = Date.now();
 
 		const executeResult = await deps.agentExecutor.execute({
@@ -181,23 +250,33 @@ export async function runAgentSkill(
 
 		const durationMs = Date.now() - startTime;
 
-		if (!executeResult.ok) {
-			await runHooks({
-				hookExecutor: deps.hookExecutor,
-				hooksConfig: deps.hooksConfig,
-				context: {
-					skillName: skill.metadata.name,
-					actionName: input.action,
-					mode: "agent",
-					status: "failed",
-					durationMs,
-					error: domainErrorMessage(executeResult.error),
-					sessionId: input.sessionId,
-				},
-			});
-			return executeResult;
+		if (outputFile && deps.outputFileStore !== undefined) {
+			if (executeResult.ok) {
+				await deps.outputFileStore.write(outputFile, executeResult.value.output);
+			}
 		}
 
+		const afterContext: AfterHookContext = {
+			...beforeContext,
+			status: executeResult.ok ? "success" : "failed",
+			durationMs,
+			error: executeResult.ok ? undefined : domainErrorMessage(executeResult.error),
+		};
+
+		// ③ skill hooks.after（常に）
+		await runAfterHooks({ hookExecutor: deps.hookExecutor, hooks, context: afterContext, logger });
+
+		// ④ skill hooks.on_failure（失敗時のみ）
+		if (!executeResult.ok) {
+			await runOnFailureHooks({
+				hookExecutor: deps.hookExecutor,
+				hooks,
+				context: afterContext,
+				logger,
+			});
+		}
+
+		// ⑤ global hooks
 		await runHooks({
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,
@@ -205,11 +284,16 @@ export async function runAgentSkill(
 				skillName: skill.metadata.name,
 				actionName: input.action,
 				mode: "agent",
-				status: "success",
+				status: executeResult.ok ? "success" : "failed",
 				durationMs,
+				error: executeResult.ok ? undefined : domainErrorMessage(executeResult.error),
 				sessionId: input.sessionId,
 			},
 		});
+
+		if (!executeResult.ok) {
+			return executeResult;
+		}
 
 		return ok({
 			skillName: skill.metadata.name,
@@ -217,6 +301,9 @@ export async function runAgentSkill(
 			sessionId: input.sessionId,
 		});
 	} finally {
+		if (outputFile && deps.outputFileStore !== undefined) {
+			await deps.outputFileStore.cleanup(input.sessionId);
+		}
 		await deps.mcpToolResolver?.closeAll();
 	}
 }

--- a/src/usecase/run-skill.ts
+++ b/src/usecase/run-skill.ts
@@ -12,12 +12,18 @@ import type { ReservedVars } from "../core/variable/template-renderer";
 import { buildReservedVars, renderTemplate } from "../core/variable/template-renderer";
 import { type HooksConfig, runHooks } from "./hook-runner";
 import type { CommandExecutor, ExecResult } from "./port/command-executor";
-import type { HookExecutorPort } from "./port/hook-executor";
-import type { Logger } from "./port/logger";
+import type { AfterHookContext, BeforeHookContext, HookExecutorPort } from "./port/hook-executor";
+import { createNoopLogger, type Logger } from "./port/logger";
 import type { OutputFileStorePort } from "./port/output-file-store";
 import { createNoopProgressWriter, type ProgressWriter } from "./port/progress-writer";
 import type { PromptCollector } from "./port/prompt-collector";
 import type { SkillRepository } from "./port/skill-repository";
+import {
+	resolveSkillHooks,
+	runAfterHooks,
+	runBeforeHooks,
+	runOnFailureHooks,
+} from "./skill-hook-runner";
 
 export type RunSkillInput = {
 	readonly name: string;
@@ -120,6 +126,13 @@ async function executeSkill(
 	);
 }
 
+function buildTemplateOutput(commandResults: readonly CommandResult[]): string {
+	return commandResults
+		.map((cmd) => cmd.result.stdout)
+		.filter(Boolean)
+		.join("\n");
+}
+
 async function executeAndReport(
 	skill: Skill,
 	codeBlocks: readonly CodeBlock[],
@@ -130,19 +143,53 @@ async function executeAndReport(
 	rendered: string,
 	timeout: number | undefined,
 ): Promise<Result<RunOutput, DomainError>> {
-	const startTime = Date.now();
+	const hooks = resolveSkillHooks(skill, input.action);
+	const logger = deps.logger ?? createNoopLogger();
 
-	const commandResults = await executeCommands(
-		codeBlocks,
-		variables,
-		reserved,
-		deps.commandExecutor,
-		{ force: input.force, timeout },
-	);
+	// 出力ファイル準備（hooks がある場合のみ）
+	let outputFile = "";
+	if (hooks !== undefined && deps.outputFileStore !== undefined) {
+		outputFile = await deps.outputFileStore.prepare(input.sessionId);
+	}
 
-	const durationMs = Date.now() - startTime;
+	const beforeContext: BeforeHookContext = {
+		skillName: skill.metadata.name,
+		actionName: input.action,
+		mode: "template",
+		outputFile,
+		callerSkill: input.callerSkill,
+		sessionId: input.sessionId,
+	};
 
-	if (!commandResults.ok) {
+	// ① skill hooks.before
+	const beforeResult = await runBeforeHooks({
+		hookExecutor: deps.hookExecutor,
+		hooks,
+		context: beforeContext,
+		logger,
+	});
+
+	let finalResult: Result<RunOutput, DomainError>;
+
+	if (!beforeResult.ok) {
+		// before 失敗 → 本体スキップ
+		const afterContext: AfterHookContext = {
+			...beforeContext,
+			status: "failed",
+			durationMs: 0,
+			error: domainErrorMessage(beforeResult.error),
+		};
+
+		// ③ skill hooks.after（常に — リソース解放）
+		await runAfterHooks({ hookExecutor: deps.hookExecutor, hooks, context: afterContext, logger });
+		// ④ skill hooks.on_failure
+		await runOnFailureHooks({
+			hookExecutor: deps.hookExecutor,
+			hooks,
+			context: afterContext,
+			logger,
+		});
+		// ⑤ global hooks
 		await runHooks({
 			hookExecutor: deps.hookExecutor,
 			hooksConfig: deps.hooksConfig,
@@ -151,36 +198,88 @@ async function executeAndReport(
 				actionName: input.action,
 				mode: "template",
 				status: "failed",
-				durationMs,
-				error: domainErrorMessage(commandResults.error),
+				durationMs: 0,
+				error: domainErrorMessage(beforeResult.error),
 				callerSkill: input.callerSkill,
 				sessionId: input.sessionId,
 			},
 		});
-		return commandResults;
+
+		finalResult = beforeResult;
+	} else {
+		// ② スキル本体実行
+		const startTime = Date.now();
+		const commandResults = await executeCommands(
+			codeBlocks,
+			variables,
+			reserved,
+			deps.commandExecutor,
+			{ force: input.force, timeout },
+		);
+		const durationMs = Date.now() - startTime;
+
+		// 出力ファイルに書き込み
+		if (outputFile && deps.outputFileStore !== undefined) {
+			if (commandResults.ok) {
+				await deps.outputFileStore.write(outputFile, buildTemplateOutput(commandResults.value));
+			}
+		}
+
+		const afterContext: AfterHookContext = {
+			...beforeContext,
+			status: commandResults.ok ? "success" : "failed",
+			durationMs,
+			error: commandResults.ok ? undefined : domainErrorMessage(commandResults.error),
+		};
+
+		// ③ skill hooks.after（常に）
+		await runAfterHooks({ hookExecutor: deps.hookExecutor, hooks, context: afterContext, logger });
+
+		// ④ skill hooks.on_failure（失敗時のみ）
+		if (!commandResults.ok) {
+			await runOnFailureHooks({
+				hookExecutor: deps.hookExecutor,
+				hooks,
+				context: afterContext,
+				logger,
+			});
+		}
+
+		// ⑤ global hooks
+		await runHooks({
+			hookExecutor: deps.hookExecutor,
+			hooksConfig: deps.hooksConfig,
+			context: {
+				skillName: skill.metadata.name,
+				actionName: input.action,
+				mode: "template",
+				status: commandResults.ok ? "success" : "failed",
+				durationMs,
+				error: commandResults.ok ? undefined : domainErrorMessage(commandResults.error),
+				callerSkill: input.callerSkill,
+				sessionId: input.sessionId,
+			},
+		});
+
+		if (commandResults.ok) {
+			finalResult = ok({
+				skillName: skill.metadata.name,
+				rendered,
+				commands: commandResults.value,
+				dryRun: false,
+				sessionId: input.sessionId,
+			});
+		} else {
+			finalResult = commandResults;
+		}
 	}
 
-	await runHooks({
-		hookExecutor: deps.hookExecutor,
-		hooksConfig: deps.hooksConfig,
-		context: {
-			skillName: skill.metadata.name,
-			actionName: input.action,
-			mode: "template",
-			status: "success",
-			durationMs,
-			callerSkill: input.callerSkill,
-			sessionId: input.sessionId,
-		},
-	});
+	// クリーンアップ
+	if (outputFile && deps.outputFileStore !== undefined) {
+		await deps.outputFileStore.cleanup(input.sessionId);
+	}
 
-	return ok({
-		skillName: skill.metadata.name,
-		rendered,
-		commands: commandResults.value,
-		dryRun: false,
-		sessionId: input.sessionId,
-	});
+	return finalResult;
 }
 
 type ExecuteCommandsOptions = {

--- a/src/usecase/skill-hook-runner.ts
+++ b/src/usecase/skill-hook-runner.ts
@@ -1,8 +1,20 @@
+import { resolveActionConfig } from "../core/skill/action";
+import type { Skill } from "../core/skill/skill";
 import type { SkillHooks } from "../core/skill/skill-metadata";
 import { type ExecutionError, executionError } from "../core/types/errors";
 import { err, ok, type Result } from "../core/types/result";
 import type { AfterHookContext, BeforeHookContext, HookExecutorPort } from "./port/hook-executor";
 import type { Logger } from "./port/logger";
+
+export function resolveSkillHooks(
+	skill: Skill,
+	actionName: string | undefined,
+): SkillHooks | undefined {
+	if (!actionName) return skill.metadata.hooks;
+	const action = skill.metadata.actions?.[actionName];
+	if (!action) return skill.metadata.hooks;
+	return resolveActionConfig(action, skill.metadata).hooks;
+}
 
 type RunBeforeHooksParams = {
 	readonly hookExecutor?: HookExecutorPort;


### PR DESCRIPTION
## Summary

- **Issue #486 の未統合を修正**: `skill-hook-runner.ts` の `runBeforeHooks` / `runAfterHooks` / `runOnFailureHooks` を `run-skill.ts`（template モード）と `run-agent-skill.ts`（agent モード）に統合
- **OutputFileStore のライフサイクルを実装**: `prepare` → スキル実行 → `write` → hooks → `cleanup` の完全なフロー
- **DRY 違反を解消**: `resolveSkillHooks` を `skill-hook-runner.ts` に、`createNoopLogger` を `port/logger.ts` に集約

## 実行順序（設計書準拠）

```
① skill hooks.before → ② スキル本体 → ③ skill hooks.after → ④ skill hooks.on_failure → ⑤ global hooks → cleanup
```

- before 失敗時: 本体スキップ、after は実行（リソース解放）、on_failure 実行、global hooks 実行
- dry-run 時: フック非実行（既存挙動維持）
- 出力ファイル: template stdout / agent output を書き込み、after hook から `$TASKP_OUTPUT_FILE` で参照可能

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/usecase/run-skill.ts` | before/after/on_failure フック呼び出し、出力ファイル管理 |
| `src/usecase/run-agent-skill.ts` | 同上（出力内容は `AgentExecutorResult.output`） |
| `src/usecase/skill-hook-runner.ts` | `resolveSkillHooks` を export として追加 |
| `src/usecase/port/logger.ts` | `createNoopLogger` を export として追加 |

## 検証

- `bun run typecheck` ✅
- `bun run test` ✅ (851 passed)
- `bun run check` ✅
- pre-push hooks 全パス（build, lint, test, typecheck, verify-config-schema）