### PR TITLE
docs: add skill hooks, session ID, and output forwarding to READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,8 @@
 - **2つの実行モード** — テンプレート展開（LLM 不要）と AI エージェント実行
 - **マルチアクション** — 関連する操作（追加/削除/一覧）を1つのスキルにまとめられる
 - **マルチプロバイダ対応** — Anthropic / OpenAI / Google / Ollama をサポート
+- **スキルフック** — スキル実行前後にセットアップ/クリーンアップコマンドを実行可能
+- **セッション ID & 出力フォワーディング** — 実行のトラッキングとフックへの結果連携
 - **MCP サーバー** — Claude Code や pi などの AI ツールからも利用可能
 
 ## インストール
@@ -182,7 +184,7 @@ taskp run task:add --set title="買い物"
 taskp tui                          # TUI でアクションを選択
 ```
 
-各アクションは独自の `mode`、`model`、`inputs`、`tools`、`context` を持てます。1つのスキル内で template と agent モードを混在できます。
+各アクションは独自の `mode`、`model`、`inputs`、`tools`、`context`、`hooks` を持てます。1つのスキル内で template と agent モードを混在できます。
 
 ## コマンド一覧
 
@@ -329,6 +331,13 @@ context:                # 自動的にコンテキストに含めるソース（
     run: "git diff --cached"
   - type: image
     path: "docs/diagram.png"
+hooks:                  # ライフサイクルフック（省略可）
+  before:
+    - "git stash --include-untracked"
+  after:
+    - "git stash pop || true"
+  on_failure:
+    - "echo 'Failed: $TASKP_ERROR'"
 actions:                # マルチアクション定義（省略可）
   build:
     description: プロジェクトをビルドする
@@ -444,6 +453,89 @@ context:
 ```
 
 対応フォーマット: PNG, JPEG, GIF, WebP。画像はバイナリデータとして直接 LLM に送信されます。
+
+## スキルフック
+
+`hooks` フィールドで `before`、`after`、`on_failure` コマンドを定義し、スキル実行前後にセットアップ/クリーンアップ処理を実行できます。
+
+```yaml
+hooks:
+  before:
+    - "git stash --include-untracked"
+  after:
+    - "git stash pop || true"
+  on_failure:
+    - "curl -X POST https://slack.example.com/webhook -d '{\"text\": \"失敗: $TASKP_ERROR\"}'"
+```
+
+### 実行順序
+
+```
+skill hooks.before → スキル本体 → skill hooks.after → skill hooks.on_failure → global hooks
+```
+
+- **`before`** — ブロッキング。いずれかが失敗するとスキル本体をスキップ（ただし `after` はリソース解放のため実行される）
+- **`after`** — スキル本体の後に常に実行（成功・失敗問わず）。失敗しても警告のみ
+- **`on_failure`** — スキル本体または `before` が失敗した場合のみ実行。`after` の後に実行される
+
+`config.toml` で定義されるグローバル hooks はスキル hooks の後に独立して実行されます。詳細は [設定ファイル仕様](docs/CONFIG-SPEC.md#hooks--ライフサイクルフック設定) を参照。
+
+アクションも独自の `hooks` を定義でき、スキルレベルの hooks を完全に置き換えます（マージされません）。
+
+`--dry-run` 指定時はフックは実行されません。
+
+### フック環境変数
+
+[グローバルフックの環境変数](docs/CONFIG-SPEC.md#フックに渡される環境変数)に加え、スキルフックでは以下が利用可能です:
+
+| 環境変数 | 説明 |
+|---------|------|
+| `TASKP_HOOK_PHASE` | 現在のフェーズ（`before` / `after` / `on_failure`） |
+| `TASKP_OUTPUT_FILE` | 出力ファイルの絶対パス（[出力フォワーディング](#出力フォワーディング)参照） |
+
+## セッション ID
+
+スキル実行ごとに `tskp_<ランダム文字列>` 形式の一意なセッション ID が自動発行されます（例: `tskp_a1b2c3d4e5f6`）。
+
+- 予約変数 `{{__session_id__}}` としてテンプレート内で利用可能
+- フック実行時に環境変数 `TASKP_SESSION_ID` として参照可能
+- agent モードのシステムプロンプトにも含まれる
+- `taskp_run` でのネスト呼び出しでは親のセッション ID が伝搬される
+
+```yaml
+---
+name: deploy
+mode: template
+---
+```
+
+```markdown
+# Deploy (Session: {{__session_id__}})
+
+｀｀｀bash
+curl -X POST https://api.example.com/deploy \
+  --header "X-Session-Id: {{__session_id__}}"
+｀｀｀
+```
+
+## 出力フォワーディング
+
+スキルの実行結果は一時ファイルに書き出され、フックコマンドから `$TASKP_OUTPUT_FILE` で参照できます。
+
+- **template モード**: 全コマンドの stdout を改行区切りで連結
+- **agent モード**: LLM の最終テキスト出力
+
+```bash
+# after hook: 出力をログに保存
+cp "$TASKP_OUTPUT_FILE" "logs/${TASKP_SKILL_REF}_$(date +%Y%m%d).txt"
+
+# after hook: 出力を次のスキルの入力として利用
+taskp run summarize --set content="$(cat $TASKP_OUTPUT_FILE)"
+```
+
+出力ファイルは実行前に作成され、全フック完了後にディレクトリごとクリーンアップされます。
+
+詳細は [スキル仕様 — 出力フォワーディング](docs/SKILL-SPEC.md#出力フォワーディング) を参照してください。
 
 ## カスタムシステムプロンプト
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A CLI tool that runs skills (task procedures) defined in Markdown — collecting
 - **Two execution modes** — Template rendering (no LLM required) and AI agent execution
 - **Multi-action skills** — Group related operations (add/delete/list) into a single skill
 - **Multi-provider support** — Anthropic / OpenAI / Google / Ollama
+- **Skill hooks** — Run setup/teardown commands before and after skill execution
+- **Session ID & output forwarding** — Track executions and pipe results to hooks
 - **MCP server** — Usable from AI tools like Claude Code and pi
 - **MCP client** — Use external MCP server tools (GitHub, Slack, etc.) in agent mode
 
@@ -183,7 +185,7 @@ taskp run task:add --set title="Buy milk"
 taskp tui                          # Select actions interactively
 ```
 
-Each action can have its own `mode`, `model`, `inputs`, `tools`, and `context` — mixing template and agent mode within a single skill.
+Each action can have its own `mode`, `model`, `inputs`, `tools`, `context`, and `hooks` — mixing template and agent mode within a single skill.
 
 ## Commands
 
@@ -330,6 +332,13 @@ context:                # Sources auto-included in context (optional)
     run: "git diff --cached"
   - type: image
     path: "docs/diagram.png"
+hooks:                  # Lifecycle hooks (optional)
+  before:
+    - "git stash --include-untracked"
+  after:
+    - "git stash pop || true"
+  on_failure:
+    - "echo 'Failed: $TASKP_ERROR'"
 actions:                # Multi-action definitions (optional)
   build:
     description: Build the project
@@ -468,6 +477,89 @@ context:
 ```
 
 Supported formats: PNG, JPEG, GIF, WebP. The image is sent as binary data directly to the LLM.
+
+## Skill Hooks
+
+Define `before`, `after`, and `on_failure` commands in the `hooks` field to run setup/teardown logic around skill execution.
+
+```yaml
+hooks:
+  before:
+    - "git stash --include-untracked"
+  after:
+    - "git stash pop || true"
+  on_failure:
+    - "curl -X POST https://slack.example.com/webhook -d '{\"text\": \"Failed: $TASKP_ERROR\"}'"
+```
+
+### Execution Order
+
+```
+skill hooks.before → skill body → skill hooks.after → skill hooks.on_failure → global hooks
+```
+
+- **`before`** — Blocking. If any command fails, the skill body is skipped (but `after` still runs for cleanup).
+- **`after`** — Always runs after the skill body (success or failure). Failures are warnings only.
+- **`on_failure`** — Runs only when the skill body or `before` failed. Runs after `after`.
+
+Global hooks defined in `config.toml` run independently after skill hooks. See [Config Spec](docs/CONFIG-SPEC.md#hooks--ライフサイクルフック設定) for details.
+
+Actions can also define their own `hooks`, which completely override the skill-level hooks (no merging).
+
+Hooks are skipped when `--dry-run` is specified.
+
+### Hook Environment Variables
+
+In addition to the [global hook environment variables](docs/CONFIG-SPEC.md#フックに渡される環境変数), skill hooks receive:
+
+| Variable | Description |
+|----------|-------------|
+| `TASKP_HOOK_PHASE` | Current phase (`before` / `after` / `on_failure`) |
+| `TASKP_OUTPUT_FILE` | Absolute path to the output file (see [Output Forwarding](#output-forwarding)) |
+
+## Session ID
+
+Each skill execution is assigned a unique session ID in the format `tskp_<random>` (e.g., `tskp_a1b2c3d4e5f6`).
+
+- Available as the reserved variable `{{__session_id__}}` in skill templates
+- Passed to hooks via the `TASKP_SESSION_ID` environment variable
+- Included in the agent mode system prompt
+- Nested `taskp_run` calls share the parent's session ID
+
+```yaml
+---
+name: deploy
+mode: template
+---
+```
+
+```markdown
+# Deploy (Session: {{__session_id__}})
+
+｀｀｀bash
+curl -X POST https://api.example.com/deploy \
+  --header "X-Session-Id: {{__session_id__}}"
+｀｀｀
+```
+
+## Output Forwarding
+
+Skill execution output is written to a temporary file, accessible from hook commands via `$TASKP_OUTPUT_FILE`.
+
+- **Template mode**: stdout from all commands, concatenated with newlines
+- **Agent mode**: final LLM text output
+
+```bash
+# after hook: save output to a log file
+cp "$TASKP_OUTPUT_FILE" "logs/${TASKP_SKILL_REF}_$(date +%Y%m%d).txt"
+
+# after hook: feed output into another skill
+taskp run summarize --set content="$(cat $TASKP_OUTPUT_FILE)"
+```
+
+The output file is created before execution and cleaned up (directory deleted) after all hooks complete.
+
+For full details, see [Skill Spec — Output Forwarding](docs/SKILL-SPEC.md#出力フォワーディング).
 
 ## Custom System Prompt
 


### PR DESCRIPTION
## Summary

- Add documentation for skill hooks (`before`/`after`/`on_failure`), session ID, and output forwarding to both README.md and README.ja.md
- These features were implemented in issues #474–#487 but README had not been updated

## Changes

- **Features list**: Added "Skill hooks" and "Session ID & output forwarding"
- **Frontmatter example**: Added `hooks` field
- **Actions description**: Noted `hooks` as an action-level override option
- **New sections**: Skill Hooks, Session ID, Output Forwarding (with examples, execution order, env vars, and links to detailed specs)

Closes #474 #475 #476 #477 #478 #479 #480 #481 #482 #483 #484 #485 #486 #487