### PR TITLE
fix: suppress MCP server stderr from leaking into TUI

### DIFF
--- a/src/adapter/mcp-tool-resolver.ts
+++ b/src/adapter/mcp-tool-resolver.ts
@@ -60,15 +60,19 @@ export function createMcpToolResolver(
 
 function connectByTransport(config: McpServerConfig, logger: Logger): Promise<MCPClient> {
 	switch (config.transport) {
-		case "stdio":
+		case "stdio": {
 			logger.debug(`Connecting to MCP server via stdio: ${config.command}`);
-			return createMCPClient({
-				transport: new StdioClientTransport({
-					command: config.command,
-					args: config.args,
-					env: resolveEnvMap(config.env),
-				}),
+			// MCP サーバーの stderr を inherit するとターミナル（TUI 画面）に
+			// ログが漏れるため、pipe で受けて破棄する
+			const transport = new StdioClientTransport({
+				command: config.command,
+				args: config.args,
+				env: resolveEnvMap(config.env),
+				stderr: "pipe",
 			});
+			transport.stderr?.on("data", () => {});
+			return createMCPClient({ transport });
+		}
 		case "http":
 			logger.debug(`Connecting to MCP server via HTTP: ${config.url}`);
 			return createMCPClient({


### PR DESCRIPTION
## Summary

- MCP サーバーの stderr 出力が TUI 画面に漏れて表示が崩れる問題を修正

## 原因

`@modelcontextprotocol/sdk` の `StdioClientTransport` は `stderr` オプション未指定時にデフォルトで `'inherit'` を使用。MCP サーバープロセスの stderr がそのまま親プロセスの stderr に流れ、TUI 画面に混入していた。

## Changes

- `src/adapter/mcp-tool-resolver.ts`: `StdioClientTransport` に `stderr: 'pipe'` を指定し、noop data リスナーで drain して破棄