### PR TITLE
fix: prevent hanging subprocesses from inheriting stdin

### DIFF
--- a/src/adapter/command-runner.ts
+++ b/src/adapter/command-runner.ts
@@ -23,6 +23,7 @@ export function createCommandRunner(deps?: CommandRunnerDeps): CommandExecutor {
 				async () => {
 					const result = await execaCommand(command, {
 						shell: true,
+						stdin: "ignore",
 						cwd: options?.cwd,
 						env: options?.env ? { ...options.env } : undefined,
 						timeout: options?.timeout ?? timeoutMs,

--- a/src/adapter/context-collector-deps.ts
+++ b/src/adapter/context-collector-deps.ts
@@ -12,6 +12,7 @@ export async function createDefaultContextCollectorDeps(): Promise<ContextCollec
 			try {
 				const result = await execa(command, {
 					shell: true,
+					stdin: "ignore",
 					cwd,
 					reject: false,
 				});

--- a/src/core/execution/tools/bash-tool.ts
+++ b/src/core/execution/tools/bash-tool.ts
@@ -29,6 +29,7 @@ export const bashTool: Tool<BashInput, ToolResult<BashData>> = {
 		try {
 			const result = await execa(command, {
 				shell: true,
+				stdin: "ignore",
 				cwd: cwd ?? process.cwd(),
 				timeout: timeout ?? DEFAULT_TOOL_TIMEOUT_MS,
 				reject: false,

--- a/tests/adapter/command-runner-stdin.test.ts
+++ b/tests/adapter/command-runner-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createCommandRunner } from "../../src/adapter/command-runner";
+
+const EOF_SENSITIVE_COMMAND = "read ignored; echo stdin-closed";
+
+describe("CommandRunner stdin handling", () => {
+	it("lets EOF-sensitive commands complete promptly", async () => {
+		const runner = createCommandRunner();
+
+		const result = await runner.execute(EOF_SENSITIVE_COMMAND, { timeout: 500 });
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.stdout).toBe("stdin-closed");
+	});
+});

--- a/tests/adapter/context-collector-deps-stdin.test.ts
+++ b/tests/adapter/context-collector-deps-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultContextCollectorDeps } from "../../src/adapter/context-collector-deps";
+
+const EOF_SENSITIVE_COMMAND = "read ignored; echo stdin-closed";
+
+describe("createDefaultContextCollectorDeps stdin handling", () => {
+	it("lets EOF-sensitive context commands complete promptly", async () => {
+		const deps = await createDefaultContextCollectorDeps();
+
+		const result = await deps.executeCommand(EOF_SENSITIVE_COMMAND, "/tmp");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value).toBe("stdin-closed");
+	});
+});

--- a/tests/core/execution/tools/bash-tool.test.ts
+++ b/tests/core/execution/tools/bash-tool.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { bashTool } from "../../../../src/core/execution/tools/bash-tool";
+
+const EOF_SENSITIVE_COMMAND = "read ignored; echo stdin-closed";
+
+describe("bashTool stdin handling", () => {
+	it("lets EOF-sensitive commands complete promptly", async () => {
+		expect(bashTool.execute).toBeDefined();
+		if (!bashTool.execute) {
+			throw new Error("bashTool.execute is undefined");
+		}
+
+		const result = await bashTool.execute(
+			{ command: EOF_SENSITIVE_COMMAND, timeout: 500 },
+			{} as never,
+		);
+
+		expect(Symbol.asyncIterator in result).toBe(false);
+		if (Symbol.asyncIterator in result) {
+			throw new Error("bashTool.execute returned a stream unexpectedly");
+		}
+
+		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.stdout).toBe("stdin-closed");
+	});
+});


### PR DESCRIPTION
## Summary
- add `stdin: \"ignore\"` to template command execution, context collection, and agent bash tool subprocess launches
- add behavioral regression tests that run EOF-sensitive commands and verify they complete promptly instead of hanging
- verify the full project in pre-push checks, including build, biome, vitest, typecheck, and config schema validation