### PR TITLE
feat: add bounded hierarchical skill discovery

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -235,6 +235,10 @@ taskp list --global
 taskp list --local
 ```
 
+- `taskp list` は現在の作業ディレクトリから `.taskp/skills` を探索します。作業ディレクトリがホーム/グローバル境界の配下にある場合は、その境界まで親ディレクトリも探索し、最後に `~/.taskp/skills` を探索します。
+- `taskp list --local` は現在の作業ディレクトリから見つかったプロジェクトスコープのみを表示します。
+- `taskp list --global` は `~/.taskp/skills` のみを表示します。
+
 ### `taskp init <name>`
 
 スキルの雛形を生成します。
@@ -300,10 +304,12 @@ MCP サーバーとして起動します（詳細は [MCP サーバーとして�
 
 | 場所 | スコープ | 用途 |
 |------|---------|------|
-| `.taskp/skills/<name>/SKILL.md` | プロジェクトローカル | プロジェクト固有のタスク |
+| `<cwd>/.taskp/skills/<name>/SKILL.md` | local | 現在の作業ディレクトリ固有のタスク |
+| `<ancestor>/.taskp/skills/<name>/SKILL.md` | parent | 親プロジェクトやワークスペースで共有するタスク |
 | `~/.taskp/skills/<name>/SKILL.md` | グローバル | 個人で共通利用するタスク |
 
-プロジェクトローカルが優先されます。
+探索順序は近いスコープが優先され、`local` → `parent` → `global` の順に解決されます。
+親ディレクトリのスコープは、現在の作業ディレクトリが同じホーム/グローバル境界の配下にある場合のみ探索対象になります。
 
 ### フロントマター
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ taskp list --global
 taskp list --local
 ```
 
+- `taskp list` discovers `.taskp/skills` from the current working directory. When the working directory is under the home/global boundary, it also walks ancestor directories up to that boundary, then falls back to `~/.taskp/skills`.
+- `taskp list --local` shows only project scopes discovered from the current working directory.
+- `taskp list --global` shows only `~/.taskp/skills`.
+
 ### `taskp init <name>`
 
 Generate a skill scaffold.
@@ -301,10 +305,12 @@ Skills are defined as Markdown files named `SKILL.md`.
 
 | Location | Scope | Use Case |
 |----------|-------|----------|
-| `.taskp/skills/<name>/SKILL.md` | Project-local | Project-specific tasks |
+| `<cwd>/.taskp/skills/<name>/SKILL.md` | Local | Tasks specific to the current working directory |
+| `<ancestor>/.taskp/skills/<name>/SKILL.md` | Parent | Tasks shared by a parent project or workspace |
 | `~/.taskp/skills/<name>/SKILL.md` | Global | Personal tasks shared across projects |
 
-Project-local skills take priority.
+Discovery prefers nearer scopes first: `local` → `parent` → `global`.
+Ancestor scopes are included only when the current working directory is inside the same home/global boundary.
 
 ### Frontmatter
 

--- a/docs/CLI-SPEC.md
+++ b/docs/CLI-SPEC.md
@@ -96,19 +96,27 @@ taskp list --local
 | オプション | 型 | デフォルト | 説明 |
 |-----------|-----|----------|------|
 | `--global` | `boolean` | `false` | グローバルスキルのみ表示 |
-| `--local` | `boolean` | `false` | プロジェクトローカルスキルのみ表示 |
+| `--local` | `boolean` | `false` | 現在の作業ディレクトリから見つかったプロジェクトスコープを表示 |
 
 #### 出力
 
 ```
-Name          Description                    Location
-task          タスクを管理する                ./.taskp/skills/task
+task (local)
+  タスクを管理する
+  Source: ./.taskp/skills/task
   Actions: add, delete, list
-deploy        アプリをデプロイする             ./.taskp/skills/deploy
-code-review   コードレビューを実行する         ~/.taskp/skills/code-review
+deploy (parent)
+  パッケージ専用のデプロイスキル
+  Source: ../.taskp/skills/deploy
+code-review (global)
+  コードレビューを実行する
+  Source: ~/.taskp/skills/code-review
 ```
 
 アクション付きスキルは `Actions` 行にアクション一覧を表示する。
+`local` は cwd 直下の `.taskp/skills`、`parent` は親ディレクトリで見つかったプロジェクトスキル、`global` は `~/.taskp/skills` を表す。
+`Source` 行には実際に採用されたスキルディレクトリを表示するため、複数の親ディレクトリで同名スキルが競合した場合でも、どこから解決されたかを確認できる。
+ホーム配下のパスは `~/...` で短縮表示し、それ以外はカレントディレクトリからの相対パスで表示する。
 
 ### taskp init \<name\>
 
@@ -241,7 +249,7 @@ taskp show task:add          # アクションの詳細を表示
 Skill: deploy
 Description: アプリケーションをデプロイする
 Mode: template
-Location: ./.taskp/skills/deploy/SKILL.md
+Location: ../.taskp/skills/deploy/SKILL.md
 
 Inputs:
   environment  select   デプロイ先を選んでください  [staging, production]

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -50,8 +50,9 @@ taskp run code-review
 
 ```bash
 taskp list
-# → deploy     - アプリをデプロイする        (~/.taskp/skills/deploy)
-# → review     - コードレビューを実行する     (./.taskp/skills/review)
+# → deploy (parent) - パッケージ専用のデプロイスキル
+# → review (local)  - 現在地直下のレビュー用スキル
+# → lint   (global) - 個人用の共通スキル
 ```
 
 ### UC-4: スキルの雛形生成
@@ -100,9 +101,14 @@ agent:    マークダウン全体を LLM に渡し、ツール呼び出しで�
 
 ```
 探索順序:
-  1. ./.taskp/skills/<name>/SKILL.md   ← プロジェクト固有
-  2. ~/.taskp/skills/<name>/SKILL.md   ← グローバル（個人）
+  1. <cwd>/.taskp/skills/<name>/SKILL.md
+  2. 親ディレクトリを上方向にたどった各 .taskp/skills/<name>/SKILL.md
+  3. ~/.taskp/skills/<name>/SKILL.md   ← グローバル（個人）
 ```
+
+- cwd に近いスキルほど優先される
+- `--local` は現在の作業ディレクトリから見つかったプロジェクトスキルを含む
+- 親ディレクトリのスコープは、現在の作業ディレクトリがホーム/グローバル境界の配下にある場合のみ探索される
 
 ### 5. MCP サーバー自動生成
 

--- a/docs/SKILL-SPEC.md
+++ b/docs/SKILL-SPEC.md
@@ -331,18 +331,21 @@ MCP サーバーの接続設定は `config.toml` の `[mcp.servers]` で定義�
 ### 探索順序
 
 ```
-1. ./.taskp/skills/<name>/SKILL.md     ← プロジェクトローカル
-2. ~/.taskp/skills/<name>/SKILL.md     ← グローバル
+1. <cwd>/.taskp/skills/<name>/SKILL.md            ← 現在地直下
+2. 親ディレクトリを上方向にたどった各 .taskp/skills/<name>/SKILL.md
+3. ~/.taskp/skills/<name>/SKILL.md                ← グローバル（最後）
 ```
 
-- プロジェクトローカルが優先される（上書きセマンティクス）
+- cwd に近いスキルほど優先される（深い方が勝つ）
+- `~/.taskp/skills` は常に最低優先度
 - 見つからない場合はエラー
 
 ### 一覧取得時
 
-- 両方のディレクトリをスキャン
-- 同名スキルはプロジェクトローカルを優先表示
-- グローバルのみのスキルも表示（ソース表示で区別）
+- `<cwd>` から見つかった `.taskp/skills` をスキャンし、ホーム/グローバル境界の配下にある場合は上方向の親ディレクトリもスキャンしたうえで、最後に `~/.taskp/skills` をスキャンする
+- 同名スキルは探索順序で最初に見つかったものだけを表示する
+- スコープは `local` / `parent` / `global` として区別される
+- `taskp list --local` は現在の作業ディレクトリから見つかったプロジェクトスコープ（必要に応じて `local` と `parent`）を含み、`--global` は `global` のみを表示する
 
 ## 変数展開
 

--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -1,6 +1,7 @@
+import { realpathSync } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import type { Skill, SkillLogger, SkillScope } from "../core/skill/skill";
 import { parseSkill } from "../core/skill/skill";
 import type { ParseError } from "../core/types/errors";
@@ -25,16 +26,23 @@ type SkillLoaderDeps = {
 	readonly logger?: SkillLogger;
 };
 
+type SkillDirectory = {
+	readonly path: string;
+	readonly scope: SkillScope;
+};
+
 export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
-	const localSkillsDir = resolve(deps.localRoot, SKILL_DIR_NAME);
-	const globalSkillsDir = resolve(deps.globalRoot, SKILL_DIR_NAME);
+	const canonicalLocalRoot = canonicalizePath(deps.localRoot);
+	const canonicalGlobalRoot = canonicalizePath(deps.globalRoot);
+	const projectSkillDirs = discoverProjectSkillDirs(canonicalLocalRoot, canonicalGlobalRoot);
+	const globalSkillDir = createGlobalSkillDir(canonicalGlobalRoot);
 
 	const { logger } = deps;
 	return {
-		findByName: (name) => findByName(name, localSkillsDir, globalSkillsDir, logger),
-		listAll: () => listAll(localSkillsDir, globalSkillsDir, logger),
-		listLocal: () => scanDirectory(localSkillsDir, "local", logger),
-		listGlobal: () => scanDirectory(globalSkillsDir, "global", logger),
+		findByName: (name) => findByName(name, [...projectSkillDirs, globalSkillDir], logger),
+		listAll: () => listAll([...projectSkillDirs, globalSkillDir], logger),
+		listLocal: () => listAll(projectSkillDirs, logger),
+		listGlobal: () => scanDirectory(globalSkillDir.path, globalSkillDir.scope, logger),
 	};
 }
 
@@ -47,48 +55,100 @@ export async function createDefaultSkillLoader(projectRoot: string): Promise<Ski
 
 async function findByName(
 	name: string,
-	localSkillsDir: string,
-	globalSkillsDir: string,
+	skillDirs: readonly SkillDirectory[],
 	logger?: SkillLogger,
 ): Promise<Result<Skill, SkillNotFoundError>> {
-	const localPath = join(localSkillsDir, name, SKILL_FILE_NAME);
-	const localResult = await tryLoadSkill(localPath, "local", logger);
-	if (localResult.type === "found") {
-		return localResult;
-	}
-	if (localResult.type === "error") {
-		logger?.warn(`Failed to load skill "${name}" from local: ${localResult.error.message}`);
-	}
-
-	const globalPath = join(globalSkillsDir, name, SKILL_FILE_NAME);
-	const globalResult = await tryLoadSkill(globalPath, "global", logger);
-	if (globalResult.type === "found") {
-		return globalResult;
-	}
-	if (globalResult.type === "error") {
-		logger?.warn(`Failed to load skill "${name}" from global: ${globalResult.error.message}`);
+	for (const skillDir of skillDirs) {
+		const skillPath = join(skillDir.path, name, SKILL_FILE_NAME);
+		const result = await tryLoadSkill(skillPath, skillDir.scope, logger);
+		if (result.type === "found") {
+			return result;
+		}
+		if (result.type === "error") {
+			logger?.warn(
+				`Failed to load skill "${name}" from ${skillDir.scope}: ${result.error.message}`,
+			);
+		}
 	}
 
 	return err(skillNotFoundError(name));
 }
 
 async function listAll(
-	localSkillsDir: string,
-	globalSkillsDir: string,
+	skillDirs: readonly SkillDirectory[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
-	const [localResult, globalResult] = await Promise.all([
-		scanDirectory(localSkillsDir, "local", logger),
-		scanDirectory(globalSkillsDir, "global", logger),
-	]);
+	const results = await Promise.all(
+		skillDirs.map((skillDir) => scanDirectory(skillDir.path, skillDir.scope, logger)),
+	);
 
-	const localNames = new Set(localResult.skills.map((s) => s.metadata.name));
-	const uniqueGlobalSkills = globalResult.skills.filter((s) => !localNames.has(s.metadata.name));
+	return mergeSkillLoadResults(results);
+}
 
+function mergeSkillLoadResults(results: readonly SkillLoadResult[]): SkillLoadResult {
+	const skills: Skill[] = [];
+	const failures = results.flatMap((result) => result.failures);
+	const seen = new Set<string>();
+
+	for (const result of results) {
+		for (const skill of result.skills) {
+			if (seen.has(skill.metadata.name)) {
+				continue;
+			}
+			seen.add(skill.metadata.name);
+			skills.push(skill);
+		}
+	}
+
+	return { skills, failures };
+}
+
+function createGlobalSkillDir(globalRoot: string): SkillDirectory {
 	return {
-		skills: [...localResult.skills, ...uniqueGlobalSkills],
-		failures: [...localResult.failures, ...globalResult.failures],
+		path: join(globalRoot, SKILL_DIR_NAME),
+		scope: "global",
 	};
+}
+
+function discoverProjectSkillDirs(
+	localRoot: string,
+	globalRoot: string,
+): readonly SkillDirectory[] {
+	if (!isWithinPath(localRoot, globalRoot)) {
+		return [{ path: join(localRoot, SKILL_DIR_NAME), scope: "local" }];
+	}
+
+	const discovered: SkillDirectory[] = [];
+	let current = localRoot;
+	let scope: Exclude<SkillScope, "global"> = "local";
+
+	while (current !== globalRoot) {
+		discovered.push({ path: join(current, SKILL_DIR_NAME), scope });
+
+		const parent = dirname(current);
+		if (parent === current) {
+			break;
+		}
+
+		current = parent;
+		scope = "parent";
+	}
+
+	return discovered;
+}
+
+function canonicalizePath(path: string): string {
+	const resolvedPath = resolve(path);
+	try {
+		return realpathSync(resolvedPath);
+	} catch {
+		return resolvedPath;
+	}
+}
+
+function isWithinPath(path: string, boundary: string): boolean {
+	const relation = relative(boundary, path);
+	return relation === "" || (!relation.startsWith("..") && relation !== "..");
 }
 
 async function scanDirectory(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
+import { dirname, relative } from "node:path";
 import { Cli, z } from "incur";
 import { createAgentExecutor } from "./adapter/agent-executor";
 import { createLanguageModel, resolveModelSpec } from "./adapter/ai-provider";
@@ -28,7 +29,7 @@ import { validateActionExists, validateActionRequired } from "./core/skill/valid
 import { type DomainError, domainErrorMessage, EXIT_CODE } from "./core/types/errors";
 import type { Result } from "./core/types/result";
 import { type InitOutput, initSkill } from "./usecase/init-skill";
-import { createListSkillsUseCase } from "./usecase/list-skills";
+import { createListSkillsUseCase, type ListSkillScopeFilter } from "./usecase/list-skills";
 import { runAgentSkill } from "./usecase/run-agent-skill";
 import type { RunOutput } from "./usecase/run-skill";
 import { runSkill } from "./usecase/run-skill";
@@ -230,7 +231,10 @@ const cli = Cli.create("taskp", {
 		description: "List available skills",
 		options: z.object({
 			global: z.boolean().optional().describe("Show global skills only"),
-			local: z.boolean().optional().describe("Show project-local skills only"),
+			local: z
+				.boolean()
+				.optional()
+				.describe("Show project skills discovered from the current working directory"),
 		}),
 		async run(c) {
 			const scope = resolveScope(c.options.global, c.options.local);
@@ -430,9 +434,9 @@ async function runAgentMode(
 function resolveScope(
 	global: boolean | undefined,
 	local: boolean | undefined,
-): SkillScope | undefined {
+): ListSkillScopeFilter | undefined {
 	if (global) return "global";
-	if (local) return "local";
+	if (local) return "project";
 	return undefined;
 }
 
@@ -461,10 +465,27 @@ function printSkillTable(
 		const actionsLabel = formatActionsLabel(skill.metadata.actions);
 		console.log(`${ansi.bold(ansi.cyan(skill.metadata.name))} ${scopeLabel}`);
 		console.log(`  ${skill.metadata.description}`);
+		console.log(`  Source: ${formatSkillSource(skill.location)}`);
 		if (actionsLabel) {
 			console.log(`  Actions: ${actionsLabel}`);
 		}
 	}
+}
+
+function formatSkillSource(location: string): string {
+	const skillDir = dirname(location);
+	const home = homedir();
+
+	if (skillDir === home || skillDir.startsWith(`${home}/`)) {
+		return `~${skillDir.slice(home.length)}`;
+	}
+
+	const relativePath = relative(process.cwd(), skillDir);
+	if (relativePath === "") {
+		return ".";
+	}
+
+	return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }
 
 function formatActionsLabel(actions: Record<string, Action> | undefined): string | undefined {

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import matter from "gray-matter";
 import type { ParseError } from "../types/errors";
 import { parseError } from "../types/errors";
@@ -13,7 +15,7 @@ export type SkillLogger = {
 	readonly warn: (message: string) => void;
 };
 
-export type SkillScope = "local" | "global";
+export type SkillScope = "local" | "parent" | "global";
 
 export type Skill = {
 	readonly metadata: SkillMetadata;
@@ -114,5 +116,10 @@ function validateActionSections(
 }
 
 function inferScope(location: string): SkillScope {
+	const globalSkillsRoot = resolve(homedir(), ".taskp", "skills");
+	const resolvedLocation = resolve(location);
+	if (resolvedLocation.startsWith(`${globalSkillsRoot}/`)) {
+		return "global";
+	}
 	return location.includes("/.taskp/skills/") ? "local" : "global";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,12 @@ export { err, flatMap, isErr, isOk, map, ok } from "./core/types/result";
 export type { InitOutput, InitSkillInput } from "./usecase/init-skill";
 // Use cases
 export { initSkill } from "./usecase/init-skill";
-export type { ListOutput, ListSkillsFilter, ListSkillsUseCase } from "./usecase/list-skills";
+export type {
+	ListOutput,
+	ListSkillScopeFilter,
+	ListSkillsFilter,
+	ListSkillsUseCase,
+} from "./usecase/list-skills";
 export { createListSkillsUseCase } from "./usecase/list-skills";
 export type {
 	AgentExecutorInput,

--- a/src/tui/screens/skill-selector.ts
+++ b/src/tui/screens/skill-selector.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { dirname, relative } from "node:path";
 import {
 	BoxRenderable,
 	type CliRenderer,
@@ -35,7 +37,7 @@ export async function showSkillSelector(
 		const allOptions = buildSkillOptionsWithActions(
 			skills.map((s) => ({
 				name: s.metadata.name,
-				description: s.metadata.description,
+				description: `${s.metadata.description} (${s.scope}) — ${formatSkillSource(s.location)}`,
 				actions: s.metadata.actions,
 			})),
 		);
@@ -170,6 +172,22 @@ export async function showSkillSelector(
 
 		searchInput.focus();
 	});
+}
+
+function formatSkillSource(location: string): string {
+	const skillDir = dirname(location);
+	const home = homedir();
+
+	if (skillDir === home || skillDir.startsWith(`${home}/`)) {
+		return `~${skillDir.slice(home.length)}`;
+	}
+
+	const relativePath = relative(process.cwd(), skillDir);
+	if (relativePath === "") {
+		return ".";
+	}
+
+	return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }
 
 function getExpandIndicator(

--- a/src/usecase/list-skills.ts
+++ b/src/usecase/list-skills.ts
@@ -1,8 +1,10 @@
-import type { Skill, SkillScope } from "../core/skill/skill";
+import type { Skill } from "../core/skill/skill";
 import type { SkillLoadFailure, SkillLoadResult, SkillRepository } from "./port/skill-repository";
 
+export type ListSkillScopeFilter = "project" | "global";
+
 export type ListSkillsFilter = {
-	readonly scope?: SkillScope;
+	readonly scope?: ListSkillScopeFilter;
 };
 
 export type ListOutput = {
@@ -19,7 +21,7 @@ export function createListSkillsUseCase(repository: SkillRepository): ListSkills
 		execute: async (filter) => {
 			const result = await fetchByScope(repository, filter.scope);
 			return {
-				skills: deduplicateByLocalPriority(result.skills),
+				skills: deduplicateByDiscoveryOrder(result.skills),
 				failures: result.failures,
 			};
 		},
@@ -28,10 +30,10 @@ export function createListSkillsUseCase(repository: SkillRepository): ListSkills
 
 async function fetchByScope(
 	repository: SkillRepository,
-	scope: SkillScope | undefined,
+	scope: ListSkillScopeFilter | undefined,
 ): Promise<SkillLoadResult> {
 	switch (scope) {
-		case "local":
+		case "project":
 			return repository.listLocal();
 		case "global":
 			return repository.listGlobal();
@@ -41,12 +43,11 @@ async function fetchByScope(
 }
 
 // listAll は loader 側でも重複除去しているが、usecase 層でも保証する
-// （ポートの実装が変わっても usecase の契約を維持するため）
-function deduplicateByLocalPriority(skills: readonly Skill[]): readonly Skill[] {
+// （ポートの実装が変わっても discovery 順序の契約を維持するため）
+function deduplicateByDiscoveryOrder(skills: readonly Skill[]): readonly Skill[] {
 	const seen = new Map<string, Skill>();
 	for (const skill of skills) {
-		const existing = seen.get(skill.metadata.name);
-		if (!existing || skill.scope === "local") {
+		if (!seen.has(skill.metadata.name)) {
 			seen.set(skill.metadata.name, skill);
 		}
 	}

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -25,6 +25,7 @@ function makeSkillMd(name: string, description: string): string {
 describe("SkillLoader", () => {
 	let localRoot: string;
 	let globalRoot: string;
+	const extraCleanup: string[] = [];
 
 	beforeEach(() => {
 		localRoot = mkdtempSync(join(tmpdir(), "taskp-local-"));
@@ -34,6 +35,10 @@ describe("SkillLoader", () => {
 	afterEach(() => {
 		rmSync(localRoot, { recursive: true, force: true });
 		rmSync(globalRoot, { recursive: true, force: true });
+		for (const path of extraCleanup) {
+			rmSync(path, { recursive: true, force: true });
+		}
+		extraCleanup.length = 0;
 	});
 
 	describe("findByName", () => {
@@ -84,6 +89,48 @@ describe("SkillLoader", () => {
 			expect(result.error.type).toBe("SKILL_NOT_FOUND");
 			expect(result.error.name).toBe("nonexistent");
 		});
+
+		it("複数の親ディレクトリに同名スキルがある場合は最も近いものを優先する", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(
+				join(globalRoot, "workspace"),
+				"deploy",
+				makeSkillMd("deploy", "ワークスペース版"),
+			);
+			createSkillFile(
+				join(globalRoot, "workspace", "packages", "frontend"),
+				"deploy",
+				makeSkillMd("deploy", "フロントエンド版"),
+			);
+			createSkillFile(globalRoot, "deploy", makeSkillMd("deploy", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("deploy");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.description).toBe("フロントエンド版");
+			expect(result.value.scope).toBe("parent");
+		});
+
+		it("プロジェクト側で見つからない場合は最後にグローバルへフォールバックする", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const result = await loader.findByName("lint");
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.metadata.description).toBe("グローバル版");
+			expect(result.value.scope).toBe("global");
+		});
 	});
 
 	describe("listAll", () => {
@@ -119,6 +166,89 @@ describe("SkillLoader", () => {
 			expect(skills).toEqual([]);
 			expect(failures).toEqual([]);
 		});
+
+		it("親ディレクトリをまたいだ同名スキルは最初に見つかったものだけを残す", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(
+				join(globalRoot, "workspace"),
+				"deploy",
+				makeSkillMd("deploy", "ワークスペース版"),
+			);
+			createSkillFile(
+				join(globalRoot, "workspace", "packages", "frontend"),
+				"deploy",
+				makeSkillMd("deploy", "フロントエンド版"),
+			);
+			createSkillFile(
+				join(globalRoot, "workspace"),
+				"review",
+				makeSkillMd("review", "親ディレクトリ固有"),
+			);
+			createSkillFile(globalRoot, "deploy", makeSkillMd("deploy", "グローバル版"));
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "グローバル固有"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listAll();
+
+			expect(skills.map((skill) => [skill.metadata.name, skill.metadata.description])).toEqual([
+				["deploy", "フロントエンド版"],
+				["review", "親ディレクトリ固有"],
+				["lint", "グローバル固有"],
+			]);
+		});
+
+		it("globalRoot 配下にいない場合は無関係な親ディレクトリまで探索しない", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			const outsideRoot = mkdtempSync(join(tmpdir(), "taskp-outside-"));
+			extraCleanup.push(outsideRoot);
+			localRoot = join(outsideRoot, "project", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(localRoot, "build", makeSkillMd("build", "カレントディレクトリ版"));
+			createSkillFile(
+				join(outsideRoot, "project"),
+				"review",
+				makeSkillMd("review", "親ディレクトリ版"),
+			);
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listAll();
+
+			expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
+				["build", "local"],
+				["lint", "global"],
+			]);
+		});
+
+		it("シンボリックリンク経由の cwd でもグローバルスキルを parent と誤分類しない", async () => {
+			const realHome = mkdtempSync(join(tmpdir(), "taskp-real-home-"));
+			const linkedHome = join(tmpdir(), `taskp-linked-home-${Date.now()}`);
+			extraCleanup.push(realHome, linkedHome);
+			mkdirSync(join(realHome, "workspace", "packages", "app", "src"), { recursive: true });
+			symlinkSync(realHome, linkedHome);
+
+			globalRoot = linkedHome;
+			localRoot = join(linkedHome, "workspace", "packages", "app", "src");
+
+			createSkillFile(
+				join(realHome, "workspace", "packages", "app"),
+				"deploy",
+				makeSkillMd("deploy", "アプリ版"),
+			);
+			createSkillFile(realHome, "lint", makeSkillMd("lint", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listAll();
+
+			expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
+				["deploy", "parent"],
+				["lint", "global"],
+			]);
+		});
 	});
 
 	describe("listLocal", () => {
@@ -131,6 +261,32 @@ describe("SkillLoader", () => {
 
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("deploy");
+		});
+
+		it("現在地に近いスコープと親スコープを含み、グローバルは含めない", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(
+				join(globalRoot, "workspace", "packages", "frontend"),
+				"deploy",
+				makeSkillMd("deploy", "フロントエンド版"),
+			);
+			createSkillFile(
+				join(globalRoot, "workspace"),
+				"review",
+				makeSkillMd("review", "ワークスペース版"),
+			);
+			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listLocal();
+
+			expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
+				["deploy", "parent"],
+				["review", "parent"],
+			]);
 		});
 	});
 
@@ -224,6 +380,42 @@ describe("SkillLoader", () => {
 			const { failures } = await loader.listGlobal();
 
 			expect(failures).toHaveLength(1);
+		});
+
+		it("複数の親スコープとグローバルの failures をまとめて返す", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(join(globalRoot, "workspace"), "broken-parent", "---\nbad: [\n---\n# Broken");
+			createSkillFile(
+				join(globalRoot, "workspace", "packages", "frontend"),
+				"broken-local",
+				"---\nbad: [\n---\n# Broken",
+			);
+			createSkillFile(globalRoot, "broken-global", "---\nbad: [\n---\n# Broken");
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { failures } = await loader.listAll();
+
+			expect(failures).toHaveLength(3);
+			expect(failures.some((failure) => failure.path.includes("broken-local"))).toBe(true);
+			expect(failures.some((failure) => failure.path.includes("broken-parent"))).toBe(true);
+			expect(failures.some((failure) => failure.path.includes("broken-global"))).toBe(true);
+		});
+
+		it("ホームディレクトリ配下でもグローバルスコープを二重に数えない", async () => {
+			globalRoot = mkdtempSync(join(tmpdir(), "taskp-home-"));
+			localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+			mkdirSync(localRoot, { recursive: true });
+
+			createSkillFile(globalRoot, "deploy", makeSkillMd("deploy", "グローバル版"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listAll();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].scope).toBe("global");
 		});
 	});
 

--- a/tests/core/skill/skill.test.ts
+++ b/tests/core/skill/skill.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parseSkill } from "../../../src/core/skill/skill";
@@ -46,6 +47,30 @@ describe("parseSkill", () => {
 		if (!result.ok) return;
 
 		expect(result.value.scope).toBe("local");
+	});
+
+	it("ホーム配下の .taskp/skills は global scope として推論される", () => {
+		const raw = ["---", "name: test", 'description: "テスト"', "---", "", "# Test"].join("\n");
+
+		const result = parseSkill(raw, `${homedir()}/.taskp/skills/test/SKILL.md`);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		expect(result.value.scope).toBe("global");
+	});
+
+	it("明示的に parent scope を渡した場合はその値を保持する", () => {
+		const raw = ["---", "name: test", 'description: "テスト"', "---", "", "# Test"].join("\n");
+
+		const result = parseSkill(
+			raw,
+			"/project/packages/frontend/.taskp/skills/test/SKILL.md",
+			"parent",
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		expect(result.value.scope).toBe("parent");
 	});
 
 	it("フロントマターエラーが伝播する", () => {

--- a/tests/integration/list-command.test.ts
+++ b/tests/integration/list-command.test.ts
@@ -62,13 +62,13 @@ describe("taskp list E2E", () => {
 		expect(skills[0].metadata.name).toBe("lint");
 	});
 
-	it("--local フィルタでローカルスキルのみ表示する", async () => {
+	it("project フィルタでプロジェクトスキルのみ表示する", async () => {
 		createSkillFile(localRoot, "deploy", "アプリをデプロイする");
 		createSkillFile(globalRoot, "lint", "コードをリントする");
 
 		const repository = createSkillLoader({ localRoot, globalRoot });
 		const usecase = createListSkillsUseCase(repository);
-		const { skills } = await usecase.execute({ scope: "local" });
+		const { skills } = await usecase.execute({ scope: "project" });
 
 		expect(skills).toHaveLength(1);
 		expect(skills[0].metadata.name).toBe("deploy");
@@ -85,6 +85,56 @@ describe("taskp list E2E", () => {
 		expect(skills).toHaveLength(1);
 		expect(skills[0].scope).toBe("local");
 		expect(skills[0].metadata.description).toBe("ローカル版デプロイ");
+	});
+
+	it("親ディレクトリのスキルは parent scope として一覧に含まれる", async () => {
+		globalRoot = mkdtempSync(join(tmpdir(), "taskp-list-home-"));
+		localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+		mkdirSync(localRoot, { recursive: true });
+
+		createSkillFile(
+			join(globalRoot, "workspace", "packages", "frontend"),
+			"deploy",
+			"フロントエンド版",
+		);
+		createSkillFile(join(globalRoot, "workspace"), "review", "ワークスペース版");
+		createSkillFile(globalRoot, "lint", "グローバル版");
+
+		const repository = createSkillLoader({ localRoot, globalRoot });
+		const usecase = createListSkillsUseCase(repository);
+		const { skills } = await usecase.execute({});
+
+		expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
+			["deploy", "parent"],
+			["review", "parent"],
+			["lint", "global"],
+		]);
+		expect(skills[0].location).toContain(
+			"workspace/packages/frontend/.taskp/skills/deploy/SKILL.md",
+		);
+	});
+
+	it("project フィルタは親ディレクトリのスキルも含む", async () => {
+		globalRoot = mkdtempSync(join(tmpdir(), "taskp-list-home-"));
+		localRoot = join(globalRoot, "workspace", "packages", "frontend", "src");
+		mkdirSync(localRoot, { recursive: true });
+
+		createSkillFile(
+			join(globalRoot, "workspace", "packages", "frontend"),
+			"deploy",
+			"フロントエンド版",
+		);
+		createSkillFile(join(globalRoot, "workspace"), "review", "ワークスペース版");
+		createSkillFile(globalRoot, "lint", "グローバル版");
+
+		const repository = createSkillLoader({ localRoot, globalRoot });
+		const usecase = createListSkillsUseCase(repository);
+		const { skills } = await usecase.execute({ scope: "project" });
+
+		expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
+			["deploy", "parent"],
+			["review", "parent"],
+		]);
 	});
 
 	it("スキルが存在しない場合は空配列を返す", async () => {

--- a/tests/usecase/list-skills.test.ts
+++ b/tests/usecase/list-skills.test.ts
@@ -37,13 +37,17 @@ function createInMemoryRepository(skills: readonly Skill[]): SkillRepository {
 			return found ? ok(found) : err(skillNotFoundError(name));
 		},
 		listAll: async () => ({ skills: [...skills], failures: [] }),
-		listLocal: async () => ({ skills: skills.filter((s) => s.scope === "local"), failures: [] }),
+		listLocal: async () => ({
+			skills: skills.filter((s) => s.scope !== "global"),
+			failures: [],
+		}),
 		listGlobal: async () => ({ skills: skills.filter((s) => s.scope === "global"), failures: [] }),
 	};
 }
 
 describe("ListSkillsUseCase", () => {
 	const localDeploy = createSkill("deploy", "local");
+	const parentDeploy = createSkill("deploy", "parent");
 	const globalDeploy = createSkill("deploy", "global");
 	const globalLint = createSkill("lint", "global");
 	const localTest = createSkill("test", "local");
@@ -61,7 +65,7 @@ describe("ListSkillsUseCase", () => {
 	});
 
 	it("同名スキルはローカルを優先する", async () => {
-		const repo = createInMemoryRepository([globalDeploy, localDeploy, globalLint]);
+		const repo = createInMemoryRepository([localDeploy, globalDeploy, globalLint]);
 		const usecase = createListSkillsUseCase(repo);
 
 		const result = await usecase.execute({});
@@ -83,16 +87,36 @@ describe("ListSkillsUseCase", () => {
 		}
 	});
 
-	it("--local フィルタでローカルスキルのみ返す", async () => {
+	it("project フィルタでプロジェクトスキルのみ返す", async () => {
 		const repo = createInMemoryRepository([localTest, globalLint, localDeploy]);
 		const usecase = createListSkillsUseCase(repo);
 
-		const result = await usecase.execute({ scope: "local" });
+		const result = await usecase.execute({ scope: "project" });
 
 		expect(result.skills).toHaveLength(2);
 		for (const skill of result.skills) {
-			expect(skill.scope).toBe("local");
+			expect(skill.scope).not.toBe("global");
 		}
+	});
+
+	it("project フィルタで親スコープのスキルも返す", async () => {
+		const repo = createInMemoryRepository([localTest, parentDeploy, globalLint]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({ scope: "project" });
+
+		expect(result.skills).toHaveLength(2);
+		expect(result.skills.map((skill) => skill.scope)).toEqual(["local", "parent"]);
+	});
+
+	it("同名スキルは先に返された順序を維持して重複排除する", async () => {
+		const repo = createInMemoryRepository([parentDeploy, localDeploy, globalLint]);
+		const usecase = createListSkillsUseCase(repo);
+
+		const result = await usecase.execute({});
+
+		expect(result.skills).toHaveLength(2);
+		expect(result.skills[0].scope).toBe("parent");
 	});
 
 	it("スキルが0件の場合は空配列を返す", async () => {


### PR DESCRIPTION
## Summary
- discover `.taskp/skills` from the current working directory, walking ancestor scopes only within the home/global boundary and keeping global skills last
- separate project listing filters from skill scopes, and surface resolved scope/source information in the CLI and TUI
- add regression coverage for canonical path boundaries and symlinked cwd handling, then update specs and READMEs to match the bounded discovery contract

## Verification
- bun run test
- bun run typecheck
- bun run build
- bun run check