### PR TITLE
feat: add MCP skill description budgeting

### DIFF
--- a/.taskp/config.schema.json
+++ b/.taskp/config.schema.json
@@ -101,6 +101,18 @@
       "description": "MCP server settings",
       "type": "object",
       "properties": {
+        "skill_description_budget": {
+          "description": "Character budget for skill descriptions exposed by taskp serve MCP tools",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "max_skill_description_chars": {
+          "description": "Maximum characters allowed for a single skill description",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
         "servers": {
           "description": "MCP server definitions keyed by server name",
           "type": "object",

--- a/README.ja.md
+++ b/README.ja.md
@@ -362,7 +362,7 @@ actions:                # マルチアクション定義（省略可）
 
 `actions` フィールドで1つのスキルに複数のアクションを定義できます。各アクションは `mode`、`model`、`inputs`、`tools`、`context`、`timeout` を個別に上書き可能で、未指定のフィールドはスキルレベルの値を継承します。
 
-`actions` が定義されている場合、スキルレベルの `inputs` は無視されます。
+アクション側で `inputs` を省略した場合は、スキルレベルの `inputs` を継承します。
 
 アクションの実行手順は本文中の `## action:<name>` セクションで定義します：
 
@@ -604,12 +604,13 @@ taskp は MCP（Model Context Protocol）サーバーとして動作し、Claude
 taskp serve
 ```
 
-公開されるツール:
+公開されるツールは、登録済みスキルとアクションから自動生成されます。
 
-- `taskp_run` — スキルを実行
-- `taskp_list` — スキル一覧を取得
-- `taskp_init` — スキルの雛形を生成
-- `taskp_show` — スキルの詳細を表示
+例:
+
+- `deploy` — `deploy` スキルを実行
+- `review__fix` — `review` スキルの `fix` アクションを実行
+- `task__add` — `task` スキルの `add` アクションを実行
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ actions:                # Multi-action definitions (optional)
 
 A skill can define multiple actions via the `actions` field. Each action can override `mode`, `model`, `inputs`, `tools`, `context`, and `timeout` — unspecified fields inherit from the skill level.
 
-When `actions` is defined, the skill-level `inputs` is ignored.
+If an action omits `inputs`, it inherits the skill-level `inputs`.
 
 Action bodies are defined in the Markdown body using `## action:<name>` sections:
 
@@ -632,12 +632,13 @@ taskp can run as an MCP (Model Context Protocol) server, making it accessible fr
 taskp serve
 ```
 
-Exposed tools:
+Exposed tools are generated from registered skills and actions.
 
-- `taskp_run` — Run a skill
-- `taskp_list` — List available skills
-- `taskp_init` — Generate a skill scaffold
-- `taskp_show` — Show skill details
+Examples:
+
+- `deploy` — Run the `deploy` skill
+- `review__fix` — Run the `fix` action of the `review` skill
+- `task__add` — Run the `add` action of the `task` skill
 
 ## Documentation
 

--- a/docs/CLI-SPEC.md
+++ b/docs/CLI-SPEC.md
@@ -228,6 +228,10 @@ interface SetupOutput {
 # [cli]
 # command_timeout_ms = 30000
 
+# [mcp]
+# skill_description_budget = 8000
+# max_skill_description_chars = 250
+
 # [hooks]
 # on_success = []
 # on_failure = []
@@ -395,12 +399,12 @@ MCP サーバーへの接続はスキル実行時に遅延的に行われ、実�
 
 ## MCP サーバーモード
 
-incur により、すべてのコマンドが MCP ツールとしても公開される。
+`taskp serve` は登録済みスキルを MCP ツールとして公開する。
 
 ```bash
 # MCP サーバーとして起動
 taskp serve
 
 # Claude Code / pi から利用
-# → taskp_run, taskp_list, taskp_init, taskp_setup, taskp_show がツールとして利用可能
+# → deploy, review__fix, task__add のようなスキル/アクション単位のツールが利用可能
 ```

--- a/docs/CONFIG-SPEC.md
+++ b/docs/CONFIG-SPEC.md
@@ -179,6 +179,12 @@ max_agent_steps = 100
 ## `[mcp]` — MCP サーバー設定
 
 外部 MCP サーバーの接続情報を定義する。agent モードで `mcp:` プレフィックス付きのツールを使用する際に必要。
+`taskp serve` の description バジェット設定もこのセクションで扱う。agent モードの `taskp_run` description バジェットは設定値ではなく、選択モデルの推定コンテキスト長から算出する。
+
+| フィールド | 型 | 必須 | デフォルト | 説明 |
+|-----------|-----|:---:|----------|------|
+| `skill_description_budget` | `integer` | - | `8000` | `taskp serve` で公開する MCP ツール description 全体に使う文字数バジェット |
+| `max_skill_description_chars` | `integer` | - | `250` | 1 スキルあたりの description 上限文字数 |
 
 ### `[mcp.servers.<name>]` — サーバー定義
 
@@ -216,6 +222,10 @@ transport の値によって必要なフィールドが異なる（discriminated
 ### 設定例
 
 ```toml
+[mcp]
+skill_description_budget = 8000
+max_skill_description_chars = 250
+
 # stdio: ローカルコマンドで MCP サーバーを起動
 [mcp.servers.github]
 transport = "stdio"

--- a/docs/MCP-SPEC.md
+++ b/docs/MCP-SPEC.md
@@ -36,6 +36,21 @@ LLM が GitHub でリリースを作成し、Slack に通知する。
 
 グローバル（`~/.taskp/config.toml`）またはプロジェクト（`.taskp/config.toml`）に MCP サーバーの接続情報を定義する。
 
+`taskp serve` では登録スキル（およびアクション付きスキルはアクション単位）が MCP ツールとして公開される。
+このとき各ツール description には、以下のバジェット設定を使う。
+
+```toml
+[mcp]
+skill_description_budget = 8000
+max_skill_description_chars = 250
+```
+
+- `skill_description_budget`: MCP ツール description 全体の文字数上限
+- `max_skill_description_chars`: 1 スキルあたりの description 上限
+- バジェット超過時は段階的に description を短縮し、必要なら名前のみまで縮小する
+
+agent モードの `taskp_run` description は、設定値ではなく選択モデルの推定コンテキスト長からバジェットを算出する。
+
 #### stdio トランスポート
 
 ```toml

--- a/docs/SKILL-SPEC.md
+++ b/docs/SKILL-SPEC.md
@@ -58,7 +58,7 @@ npm run deploy:{{environment}}
 | フィールド | 型 | デフォルト | 説明 |
 |-----------|-----|----------|------|
 | `mode` | `"template" \| "agent"` | `"template"` | 実行モード |
-| `inputs` | `Input[]` | `[]` | 入力定義（質問リスト）。`actions` が定義されている場合は無視される |
+| `inputs` | `Input[]` | `[]` | 入力定義（質問リスト）。アクションが `inputs` を省略した場合の共通デフォルトとして使われる |
 | `model` | `string` | 設定ファイルのデフォルト | 使用する LLM モデル。`provider/model` 形式でプロバイダも同時に指定可能 |
 | `timeout` | `number` | `30000` | template モードのコマンド実行タイムアウト（ミリ秒、最大: 3,600,000）。agent モードでは無視される |
 | `tools` | `string[]` | `["bash", "read", "write"]` | agent モードで使用するツール。組み込み: `bash`, `read`, `write`, `edit`, `glob`, `grep`, `fetch`, `ask_user`, `taskp_run`。MCP: `mcp:<server>`, `mcp:<server>/<tool>` |
@@ -68,14 +68,14 @@ npm run deploy:{{environment}}
 
 ### Action 型
 
-`actions` フィールドで定義する各アクションの型。すべてのフィールドは省略可能で、省略時はスキルレベルの値を継承する（`inputs` を除く）。
+`actions` フィールドで定義する各アクションの型。すべてのフィールドは省略可能で、省略時はスキルレベルの値を継承する。
 
 | フィールド | 型 | 継承元 | 説明 |
 |-----------|-----|--------|------|
 | `description` | `string` | **必須** | アクションの説明 |
 | `mode` | `"template" \| "agent"` | `skill.mode` → `"template"` | 実行モード |
 | `model` | `string` | `skill.model` → config default | LLM モデル |
-| `inputs` | `Input[]` | なし（デフォルト: `[]`） | 入力定義。アクション間で共有しない |
+| `inputs` | `Input[]` | `skill.inputs` → `[]` | 入力定義。未指定時はスキルレベルの入力を継承 |
 | `context` | `ContextSource[]` | `skill.context` → `[]` | コンテキストソース |
 | `tools` | `string[]` | `skill.tools` → `["bash", "read", "write"]` | agent モード用ツール |
 | `timeout` | `number` | `skill.timeout` → コマンドランナーのデフォルト | template モードのタイムアウト（ms） |
@@ -86,19 +86,20 @@ npm run deploy:{{environment}}
 ```
 action.mode    ?? skill.mode    ?? "template"
 action.model   ?? skill.model   ?? undefined
+action.inputs  ?? skill.inputs  ?? []
 action.context ?? skill.context ?? []
 action.tools   ?? skill.tools   ?? ["bash", "read", "write"]
 action.timeout ?? skill.timeout ?? undefined
 action.hooks   ?? skill.hooks   ?? undefined
 ```
 
-`inputs` は継承しない。各アクションが独立した入力セットを持つため、スキルレベルの `inputs` からの暗黙の継承は混乱を招く。
+`inputs` は明示定義がなければスキルレベルから継承される。アクションごとに個別入力が必要な場合だけ `action.inputs` を定義する。
 
 `hooks` はオブジェクト単位で置き換える。アクションが `hooks` を定義した場合、スキルレベルの `hooks` は完全に無視される（フィールド単位マージはしない）。これは `tools`, `context` と同じ戦略。
 
-#### スキルレベルの `inputs` との排他
+#### スキルレベルの `inputs` との関係
 
-`actions` が定義されている場合、スキルレベルの `inputs` は無視される（警告をログ出力）。
+`actions` が定義されていても、スキルレベルの `inputs` は各アクションのデフォルト入力セットとして有効である。アクション側で `inputs` を定義した場合のみ、そのアクションでは上書きされる。
 
 ### アクションセクション
 

--- a/src/adapter/config-loader.ts
+++ b/src/adapter/config-loader.ts
@@ -80,6 +80,18 @@ export const mcpServerConfigSchema = z.discriminatedUnion("transport", [
 ]);
 
 export const mcpConfigSchema = z.object({
+	skill_description_budget: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe("Character budget for skill descriptions exposed by taskp serve MCP tools"),
+	max_skill_description_chars: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe("Maximum characters allowed for a single skill description"),
 	servers: z
 		.record(z.string(), mcpServerConfigSchema)
 		.optional()
@@ -233,6 +245,7 @@ export function mergeCliConfig(global: CliConfig, project: CliConfig): CliConfig
 // 同名サーバーは project 側が丸ごと上書き（フィールド単位マージしない）
 export function mergeMcpConfig(global: McpConfig, project: McpConfig): McpConfig {
 	return {
+		...mergeByProjectPriority(global, project),
 		servers: mergeOptional(global.servers, project.servers, (g, p) => ({ ...g, ...p })),
 	};
 }

--- a/src/adapter/console-logger.ts
+++ b/src/adapter/console-logger.ts
@@ -1,8 +1,12 @@
 import type { Logger } from "../usecase/port/logger";
 
-export function createConsoleLogger(): Logger {
+export function createConsoleLogger(options?: { readonly verbose?: boolean }): Logger {
+	const verbose = options?.verbose ?? false;
 	return {
-		debug: (msg) => console.debug(`[taskp] ${msg}`),
+		debug: (msg) => {
+			if (!verbose) return;
+			console.debug(`[taskp] ${msg}`);
+		},
 		warn: (msg) => console.warn(`[taskp] ${msg}`),
 		error: (msg) => console.error(`[taskp] ${msg}`),
 	};

--- a/src/adapter/project-initializer.ts
+++ b/src/adapter/project-initializer.ts
@@ -34,6 +34,10 @@ const CONFIG_TEMPLATE = `# taskp — 設定ファイル
 # [cli]
 # command_timeout_ms = 30000
 
+# [mcp]
+# skill_description_budget = 8000
+# max_skill_description_chars = 250
+
 # [hooks]
 # on_success = []
 # on_failure = []
@@ -54,6 +58,10 @@ const GLOBAL_CONFIG_TEMPLATE = `# taskp — グローバル設定ファイル
 
 # [cli]
 # command_timeout_ms = 30000
+
+# [mcp]
+# skill_description_budget = 8000
+# max_skill_description_chars = 250
 
 # [hooks]
 # on_success = []

--- a/src/adapter/skill-mcp-server.ts
+++ b/src/adapter/skill-mcp-server.ts
@@ -1,11 +1,11 @@
 import { Cli } from "incur";
 import { z } from "zod";
+import type { Skill } from "../core/skill/skill";
 import type {
 	DescriptionBudgetOptions,
 	DescriptionEntry,
 } from "../core/skill/skill-description-budget";
 import { formatDescriptionEntriesWithinBudget } from "../core/skill/skill-description-budget";
-import type { Skill } from "../core/skill/skill";
 import type { SkillInput } from "../core/skill/skill-input";
 
 export type SkillMcpTool = {

--- a/src/adapter/skill-mcp-server.ts
+++ b/src/adapter/skill-mcp-server.ts
@@ -1,0 +1,207 @@
+import { Cli } from "incur";
+import { z } from "zod";
+import type {
+	DescriptionBudgetOptions,
+	DescriptionEntry,
+} from "../core/skill/skill-description-budget";
+import { formatDescriptionEntriesWithinBudget } from "../core/skill/skill-description-budget";
+import type { Skill } from "../core/skill/skill";
+import type { SkillInput } from "../core/skill/skill-input";
+
+export type SkillMcpTool = {
+	readonly toolName: string;
+	readonly skillName: string;
+	readonly actionName?: string;
+	readonly description?: string;
+	readonly inputs: readonly SkillInput[];
+};
+
+type RawSkillMcpTool = {
+	readonly toolName: string;
+	readonly skillName: string;
+	readonly actionName?: string;
+	readonly description: string;
+	readonly inputs: readonly SkillInput[];
+};
+
+export type SkillMcpToolsResult = {
+	readonly tools: readonly SkillMcpTool[];
+	readonly phase: 1 | 2 | 3 | 4;
+	readonly truncatedEntryCount: number;
+	readonly omittedEntryCount: number;
+};
+
+export type CreateSkillMcpCliOptions = {
+	readonly version: string;
+	readonly skills: readonly Skill[];
+	readonly budgetOptions: DescriptionBudgetOptions;
+	readonly executeSkill: (input: {
+		readonly skillName: string;
+		readonly actionName?: string;
+		readonly presets: Readonly<Record<string, string>>;
+	}) => Promise<unknown>;
+};
+
+export function createSkillMcpCli(options: CreateSkillMcpCliOptions) {
+	const { tools } = buildSkillMcpToolsResult(options.skills, options.budgetOptions);
+	const cli = Cli.create("taskp", {
+		version: options.version,
+		description: "taskp skill MCP server",
+	});
+
+	for (const tool of tools) {
+		(cli as ReturnType<typeof Cli.create>).command(tool.toolName, {
+			description: tool.description,
+			options: buildInputSchema(tool.inputs),
+			async run(c) {
+				return options.executeSkill({
+					skillName: tool.skillName,
+					actionName: tool.actionName,
+					presets: toPresetRecord(c.options),
+				});
+			},
+		});
+	}
+
+	return cli;
+}
+
+export function buildSkillMcpTools(
+	skills: readonly Skill[],
+	budgetOptions: DescriptionBudgetOptions,
+): readonly SkillMcpTool[] {
+	return buildSkillMcpToolsResult(skills, budgetOptions).tools;
+}
+
+export function buildSkillMcpToolsResult(
+	skills: readonly Skill[],
+	budgetOptions: DescriptionBudgetOptions,
+): SkillMcpToolsResult {
+	const rawTools: RawSkillMcpTool[] = skills.flatMap((skill) => flattenSkillTools(skill));
+	assertUniqueToolNames(rawTools);
+	const budgetedDescriptions = budgetSkillDescriptions(
+		rawTools.map((tool) => ({ label: tool.toolName, description: tool.description })),
+		budgetOptions,
+	);
+
+	return {
+		tools: rawTools.map((tool) => ({
+			...tool,
+			description: budgetedDescriptions.descriptions.get(tool.toolName),
+		})),
+		phase: budgetedDescriptions.phase,
+		truncatedEntryCount: budgetedDescriptions.truncatedEntryCount,
+		omittedEntryCount: budgetedDescriptions.omittedEntryCount,
+	};
+}
+
+function flattenSkillTools(skill: Skill): readonly RawSkillMcpTool[] {
+	if (!skill.metadata.actions || Object.keys(skill.metadata.actions).length === 0) {
+		return [
+			{
+				toolName: toMcpToolName(skill.metadata.name),
+				skillName: skill.metadata.name,
+				description: skill.metadata.description,
+				inputs: skill.metadata.inputs,
+			},
+		];
+	}
+
+	return Object.entries(skill.metadata.actions).map(([actionName, action]) => ({
+		toolName: toMcpToolName(skill.metadata.name, actionName),
+		skillName: skill.metadata.name,
+		actionName,
+		description: action.description,
+		inputs: action.inputs ?? skill.metadata.inputs,
+	}));
+}
+
+function budgetSkillDescriptions(
+	entries: readonly DescriptionEntry[],
+	budgetOptions: DescriptionBudgetOptions,
+): {
+	readonly descriptions: ReadonlyMap<string, string | undefined>;
+	readonly phase: 1 | 2 | 3 | 4;
+	readonly truncatedEntryCount: number;
+	readonly omittedEntryCount: number;
+} {
+	const result = formatDescriptionEntriesWithinBudget(entries, budgetOptions);
+	const lines = result.text === "" ? [] : result.text.split("\n");
+	const descriptions = new Map<string, string | undefined>();
+
+	for (const entry of entries) {
+		const prefix = `${entry.label}: `;
+		const line = lines.find(
+			(candidate) => candidate === entry.label || candidate.startsWith(prefix),
+		);
+		if (line === undefined || line === entry.label) {
+			descriptions.set(entry.label, undefined);
+			continue;
+		}
+		descriptions.set(entry.label, line.slice(prefix.length));
+	}
+
+	return {
+		descriptions,
+		phase: result.phase,
+		truncatedEntryCount: result.truncatedEntryCount,
+		omittedEntryCount: result.omittedEntryCount,
+	};
+}
+
+function assertUniqueToolNames(tools: readonly RawSkillMcpTool[]): void {
+	const seen = new Map<string, string>();
+	for (const tool of tools) {
+		const ref =
+			tool.actionName === undefined ? tool.skillName : `${tool.skillName}:${tool.actionName}`;
+		const previous = seen.get(tool.toolName);
+		if (previous !== undefined) {
+			throw new Error(
+				`Duplicate MCP tool name after normalization: ${tool.toolName} (${previous}, ${ref})`,
+			);
+		}
+		seen.set(tool.toolName, ref);
+	}
+}
+
+function buildInputSchema(inputs: readonly SkillInput[]) {
+	const shape: Record<string, z.ZodTypeAny> = {};
+	for (const input of inputs) {
+		shape[input.name] = toInputSchema(input);
+	}
+	return z.object(shape);
+}
+
+function toInputSchema(input: SkillInput): z.ZodTypeAny {
+	let schema: z.ZodTypeAny;
+	if (input.type === "number") {
+		schema = z.coerce.number();
+	} else if (input.type === "confirm") {
+		schema = z.coerce.boolean();
+	} else if (input.type === "select" && input.choices && input.choices.length > 0) {
+		schema = z.enum(input.choices as [string, ...string[]]);
+	} else {
+		schema = z.string();
+	}
+
+	if (input.required === false || input.default !== undefined) {
+		schema = schema.optional();
+	}
+
+	return schema.describe(input.message);
+}
+
+function toPresetRecord(values: Record<string, unknown>): Readonly<Record<string, string>> {
+	return Object.fromEntries(
+		Object.entries(values)
+			.filter(([, value]) => value !== undefined)
+			.map(([key, value]) => [key, String(value)]),
+	);
+}
+
+function toMcpToolName(skillName: string, actionName?: string): string {
+	const normalize = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "_");
+	return actionName === undefined
+		? normalize(skillName)
+		: `${normalize(skillName)}__${normalize(actionName)}`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
 import { dirname, relative } from "node:path";
+import { Writable } from "node:stream";
 import { Cli, z } from "incur";
 import { createAgentExecutor } from "./adapter/agent-executor";
 import { createLanguageModel, resolveModelSpec } from "./adapter/ai-provider";
@@ -16,11 +17,17 @@ import { createCliProgressWriter } from "./adapter/progress-formatter";
 import { createProjectInitializer } from "./adapter/project-initializer";
 import { createPromptRunner } from "./adapter/prompt-runner";
 import { generateSessionId } from "./adapter/session-id-generator";
+import { buildSkillMcpToolsResult, createSkillMcpCli } from "./adapter/skill-mcp-server";
 import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
 import { createStreamWriter } from "./adapter/stream-writer";
 import { createSystemPromptResolver } from "./adapter/system-prompt-resolver";
 import type { Action } from "./core/skill/action";
+import {
+	deriveAgentSkillDescriptionBudget,
+	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+	DEFAULT_SKILL_DESCRIPTION_BUDGET,
+} from "./core/skill/skill-description-budget";
 import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
@@ -136,6 +143,11 @@ function exitOnError<T>(result: Result<T, DomainError>): T {
 	process.exit(EXIT_CODE[result.error.type]);
 }
 
+function unwrapOrThrow<T>(result: Result<T, DomainError>): T {
+	if (result.ok) return result.value;
+	throw new Error(domainErrorMessage(result.error));
+}
+
 const cli = Cli.create("taskp", {
 	version: "0.1.14",
 	description:
@@ -198,7 +210,7 @@ const cli = Cli.create("taskp", {
 			const progressWriter = createCliProgressWriter(process.stdout);
 
 			const hooksConfig = config?.hooks;
-			const logger = createConsoleLogger();
+			const logger = createConsoleLogger({ verbose: c.options.verbose ?? false });
 			const hookExecutor = createHookExecutor(commandExecutor, logger);
 			const outputFileStore = createOutputFileStore();
 
@@ -341,8 +353,11 @@ const cli = Cli.create("taskp", {
 	})
 	.command("serve", {
 		description: "Start as MCP stdio server",
-		async run() {
-			await cli.serve(["--mcp"]);
+		options: z.object({
+			verbose: z.boolean().optional().describe("Show detailed logs"),
+		}),
+		async run(c) {
+			await runServeMode(c.options.verbose ?? false);
 		},
 	});
 
@@ -384,7 +399,7 @@ async function runAgentMode(
 
 	writer.writeHeader();
 
-	const logger = createConsoleLogger();
+	const logger = createConsoleLogger({ verbose: c.options.verbose ?? false });
 	const contextCollectorDeps = await createDefaultContextCollectorDeps();
 	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
 	const agentExecutor = createAgentExecutor(writer, logger);
@@ -426,9 +441,142 @@ async function runAgentMode(
 			mcpToolResolver,
 			outputFileStore,
 			logger,
+			skillDescriptionBudget: {
+				budgetChars: deriveAgentSkillDescriptionBudget(modelSpec),
+				maxDescriptionChars:
+					config.mcp?.max_skill_description_chars ?? DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+			},
 		},
 	);
 	exitOnError(result);
+}
+
+async function runServeMode(verbose: boolean): Promise<void> {
+	const configLoader = createDefaultConfigLoader(process.cwd());
+	const config = exitOnError(await configLoader.load());
+	const logger = createConsoleLogger({ verbose });
+	const skillRepository = await createDefaultSkillLoader(process.cwd());
+	const { skills, failures } = await skillRepository.listAll();
+	for (const failure of failures) {
+		logger.warn(`Failed to load skill for MCP server: ${failure.path} (${failure.error})`);
+	}
+
+	const promptCollector = createPromptRunner();
+	const budgetOptions = {
+		budgetChars: config.mcp?.skill_description_budget ?? DEFAULT_SKILL_DESCRIPTION_BUDGET,
+		maxDescriptionChars:
+			config.mcp?.max_skill_description_chars ?? DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+	};
+	const toolBudgetResult = buildSkillMcpToolsResult(skills, budgetOptions);
+	if (toolBudgetResult.truncatedEntryCount > 0 || toolBudgetResult.omittedEntryCount > 0) {
+		logger.debug(
+			`[skills] Budget exceeded for MCP descriptions. Truncated ${toolBudgetResult.truncatedEntryCount} entries and omitted ${toolBudgetResult.omittedEntryCount} entries (phase ${toolBudgetResult.phase})`,
+		);
+	}
+	const commandExecutor = createCommandRunner({
+		defaultTimeoutMs: config.cli?.command_timeout_ms,
+	});
+	const hookExecutor = createHookExecutor(commandExecutor, logger);
+	const outputFileStore = createOutputFileStore();
+	const systemPromptResolver = createSystemPromptResolver(process.cwd());
+	const contextCollectorDeps = await createDefaultContextCollectorDeps();
+	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
+	const mcpToolResolver = config.mcp?.servers
+		? (await import("./adapter/mcp-tool-resolver")).createMcpToolResolver(
+				config.mcp.servers,
+				logger,
+			)
+		: undefined;
+
+	const skillMcpCli = createSkillMcpCli({
+		version: "0.1.14",
+		skills,
+		budgetOptions,
+		executeSkill: async ({ skillName, actionName, presets }) => {
+			const skill = unwrapOrThrow(await skillRepository.findByName(skillName));
+			const action = actionName
+				? unwrapOrThrow(validateActionExists(skill, actionName))
+				: undefined;
+			const resolvedAction = action ? resolveActionConfig(action, skill.metadata) : undefined;
+			const effectiveMode = resolvedAction?.mode ?? skill.metadata.mode;
+
+			if (effectiveMode === "agent") {
+				const modelSpec = unwrapOrThrow(
+					resolveModelSpec({
+						cliModel: resolvedAction?.model ?? skill.metadata.model,
+						config: config.ai ?? {},
+					}),
+				);
+				const languageModel = unwrapOrThrow(createLanguageModel(modelSpec, config.ai ?? {}));
+				const sessionId = generateSessionId();
+				const writer = createStreamWriter({
+					verbose: false,
+					output: new Writable({
+						write(_chunk, _encoding, callback) {
+							callback();
+						},
+					}),
+					sessionId,
+				});
+				const agentExecutor = createAgentExecutor(writer, logger);
+				const result = await runAgentSkill(
+					{
+						name: skillName,
+						action: actionName,
+						presets,
+						model: languageModel,
+						noInput: true,
+						maxAgentSteps: config.cli?.max_agent_steps,
+						sessionId,
+					},
+					{
+						skillRepository,
+						promptCollector,
+						contextCollector,
+						agentExecutor,
+						systemPromptResolver,
+						commandExecutor,
+						hookExecutor,
+						hooksConfig: config.hooks,
+						mcpToolResolver,
+						outputFileStore,
+						logger,
+						skillDescriptionBudget: {
+							budgetChars: deriveAgentSkillDescriptionBudget(modelSpec),
+							maxDescriptionChars:
+								config.mcp?.max_skill_description_chars ?? DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+						},
+					},
+				);
+				return { output: unwrapOrThrow(result).result.output };
+			}
+
+			const result = await runSkill(
+				{
+					name: skillName,
+					action: actionName,
+					presets,
+					dryRun: false,
+					force: false,
+					noInput: true,
+					sessionId: generateSessionId(),
+				},
+				{
+					skillRepository,
+					promptCollector,
+					commandExecutor,
+					hookExecutor,
+					hooksConfig: config.hooks,
+					outputFileStore,
+					logger,
+				},
+			);
+
+			return { output: formatRunOutput(unwrapOrThrow(result)) };
+		},
+	});
+
+	await skillMcpCli.serve(["--mcp"]);
 }
 
 function resolveScope(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,20 +17,20 @@ import { createCliProgressWriter } from "./adapter/progress-formatter";
 import { createProjectInitializer } from "./adapter/project-initializer";
 import { createPromptRunner } from "./adapter/prompt-runner";
 import { generateSessionId } from "./adapter/session-id-generator";
-import { buildSkillMcpToolsResult, createSkillMcpCli } from "./adapter/skill-mcp-server";
 import { createSkillInitializer } from "./adapter/skill-initializer";
 import { createDefaultSkillLoader } from "./adapter/skill-loader";
+import { buildSkillMcpToolsResult, createSkillMcpCli } from "./adapter/skill-mcp-server";
 import { createStreamWriter } from "./adapter/stream-writer";
 import { createSystemPromptResolver } from "./adapter/system-prompt-resolver";
 import type { Action } from "./core/skill/action";
-import {
-	deriveAgentSkillDescriptionBudget,
-	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
-	DEFAULT_SKILL_DESCRIPTION_BUDGET,
-} from "./core/skill/skill-description-budget";
 import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
 import type { SkillScope } from "./core/skill/skill";
+import {
+	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+	DEFAULT_SKILL_DESCRIPTION_BUDGET,
+	deriveAgentSkillDescriptionBudget,
+} from "./core/skill/skill-description-budget";
 import { parseSkillRef } from "./core/skill/skill-ref";
 import { validateActionExists, validateActionRequired } from "./core/skill/validate-skill-action";
 import { type DomainError, domainErrorMessage, EXIT_CODE } from "./core/types/errors";

--- a/src/core/execution/agent-tools.ts
+++ b/src/core/execution/agent-tools.ts
@@ -15,6 +15,7 @@ export { MAX_FETCH_LENGTH, validateFetchUrl } from "./tools/fetch-tool";
 export { MAX_GREP_MATCHES } from "./tools/grep-tool";
 export {
 	buildTaskpRunDescription,
+	buildTaskpRunDescriptionResult,
 	MAX_NESTING_DEPTH,
 	resolveSkillMode,
 	validateTaskpRunCall,

--- a/src/core/execution/tools/taskp-run-tool.ts
+++ b/src/core/execution/tools/taskp-run-tool.ts
@@ -9,14 +9,14 @@ import type { SkillRepository } from "../../../usecase/port/skill-repository";
 import { type RunOutput, runSkill } from "../../../usecase/run-skill";
 import type { SessionId } from "../../execution/session";
 import type { Action } from "../../skill/action";
-import {
-	formatDescriptionEntriesWithinBudget,
-	type DescriptionBudgetResult,
-	type DescriptionBudgetOptions,
-	type DescriptionEntry,
-} from "../../skill/skill-description-budget";
 import { resolveActionConfig } from "../../skill/action";
 import type { Skill } from "../../skill/skill";
+import {
+	type DescriptionBudgetOptions,
+	type DescriptionBudgetResult,
+	type DescriptionEntry,
+	formatDescriptionEntriesWithinBudget,
+} from "../../skill/skill-description-budget";
 import { parseSkillRef } from "../../skill/skill-ref";
 import { domainErrorMessage } from "../../types/errors";
 import { err, ok, type Result } from "../../types/result";

--- a/src/core/execution/tools/taskp-run-tool.ts
+++ b/src/core/execution/tools/taskp-run-tool.ts
@@ -9,6 +9,12 @@ import type { SkillRepository } from "../../../usecase/port/skill-repository";
 import { type RunOutput, runSkill } from "../../../usecase/run-skill";
 import type { SessionId } from "../../execution/session";
 import type { Action } from "../../skill/action";
+import {
+	formatDescriptionEntriesWithinBudget,
+	type DescriptionBudgetResult,
+	type DescriptionBudgetOptions,
+	type DescriptionEntry,
+} from "../../skill/skill-description-budget";
 import { resolveActionConfig } from "../../skill/action";
 import type { Skill } from "../../skill/skill";
 import { parseSkillRef } from "../../skill/skill-ref";
@@ -158,18 +164,54 @@ const TASKP_RUN_BASE_DESCRIPTION =
 export function buildTaskpRunDescription(
 	skills: readonly Skill[],
 	currentSkillName?: string,
+	budgetOptions?: DescriptionBudgetOptions,
 ): string {
-	const lines = collectSkillLines(skills, currentSkillName);
-
-	if (lines.length === 0) {
-		return TASKP_RUN_BASE_DESCRIPTION;
-	}
-
-	return `${TASKP_RUN_BASE_DESCRIPTION}\n\nAvailable skills:\n${lines.join("\n")}`;
+	return buildTaskpRunDescriptionResult(skills, currentSkillName, budgetOptions).text;
 }
 
-function collectSkillLines(skills: readonly Skill[], currentSkillName?: string): readonly string[] {
-	const lines: string[] = [];
+export function buildTaskpRunDescriptionResult(
+	skills: readonly Skill[],
+	currentSkillName?: string,
+	budgetOptions?: DescriptionBudgetOptions,
+): DescriptionBudgetResult {
+	const entries = collectSkillEntries(skills, currentSkillName);
+	const formatted = formatLines(
+		entries,
+		budgetOptions,
+		TASKP_RUN_BASE_DESCRIPTION.length + "\n\nAvailable skills:\n".length,
+	);
+
+	if (formatted.lines.length === 0) {
+		const baseText = budgetOptions
+			? clampText(TASKP_RUN_BASE_DESCRIPTION, budgetOptions.budgetChars)
+			: TASKP_RUN_BASE_DESCRIPTION;
+		return {
+			text: baseText,
+			phase: budgetOptions ? 4 : 1,
+			truncatedEntryCount: budgetOptions ? entries.length : 0,
+			omittedEntryCount: budgetOptions ? entries.length : 0,
+		};
+	}
+
+	return {
+		text: `${TASKP_RUN_BASE_DESCRIPTION}\n\nAvailable skills:\n${formatted.lines.join("\n")}`,
+		phase: formatted.phase,
+		truncatedEntryCount: formatted.truncatedEntryCount,
+		omittedEntryCount: formatted.omittedEntryCount,
+	};
+}
+
+function clampText(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	if (maxChars <= 1) return "…";
+	return `${text.slice(0, maxChars - 1)}…`;
+}
+
+function collectSkillEntries(
+	skills: readonly Skill[],
+	currentSkillName?: string,
+): readonly DescriptionEntry[] {
+	const entries: DescriptionEntry[] = [];
 
 	for (const skill of skills) {
 		if (skill.metadata.name === currentSkillName) continue;
@@ -177,32 +219,75 @@ function collectSkillLines(skills: readonly Skill[], currentSkillName?: string):
 		const hasActions = skill.metadata.actions && Object.keys(skill.metadata.actions).length > 0;
 
 		if (hasActions) {
-			appendSkillWithActions(lines, skill);
+			appendSkillWithActions(entries, skill);
 		} else {
-			appendSimpleSkill(lines, skill);
+			appendSimpleSkill(entries, skill);
 		}
 	}
 
-	return lines;
+	return entries;
 }
 
-function appendSimpleSkill(lines: string[], skill: Skill): void {
+function appendSimpleSkill(entries: DescriptionEntry[], skill: Skill): void {
 	if (skill.metadata.mode === "agent") return;
-	lines.push(`- ${skill.metadata.name}: ${skill.metadata.description}`);
+	entries.push({ label: `- ${skill.metadata.name}`, description: skill.metadata.description });
 }
 
-function appendSkillWithActions(lines: string[], skill: Skill): void {
+function appendSkillWithActions(entries: DescriptionEntry[], skill: Skill): void {
 	const actions = skill.metadata.actions as Record<string, Action>;
-	const actionLines: string[] = [];
+	const actionEntries: DescriptionEntry[] = [];
 
 	for (const [actionName, action] of Object.entries(actions)) {
 		const resolved = resolveActionConfig(action, skill.metadata);
 		if (resolved.mode === "agent") continue;
-		actionLines.push(`  - ${skill.metadata.name}:${actionName}: ${resolved.description}`);
+		actionEntries.push({
+			label: `  - ${skill.metadata.name}:${actionName}`,
+			description: resolved.description,
+		});
 	}
 
-	if (actionLines.length === 0) return;
+	if (actionEntries.length === 0) return;
 
-	lines.push(`- ${skill.metadata.name}: ${skill.metadata.description}`);
-	lines.push(...actionLines);
+	entries.push({ label: `- ${skill.metadata.name}`, description: skill.metadata.description });
+	entries.push(...actionEntries);
+}
+
+function formatLines(
+	entries: readonly DescriptionEntry[],
+	budgetOptions?: DescriptionBudgetOptions,
+	baseLength = 0,
+): {
+	readonly lines: readonly string[];
+	readonly phase: 1 | 2 | 3 | 4;
+	readonly truncatedEntryCount: number;
+	readonly omittedEntryCount: number;
+} {
+	if (budgetOptions === undefined) {
+		return {
+			lines: entries.map((entry) => `${entry.label}: ${entry.description}`),
+			phase: 1,
+			truncatedEntryCount: 0,
+			omittedEntryCount: 0,
+		};
+	}
+
+	if (budgetOptions.budgetChars <= baseLength) {
+		return {
+			lines: [],
+			phase: 4,
+			truncatedEntryCount: entries.length,
+			omittedEntryCount: entries.length,
+		};
+	}
+
+	const result = formatDescriptionEntriesWithinBudget(entries, {
+		...budgetOptions,
+		budgetChars: budgetOptions.budgetChars - baseLength,
+	});
+	return {
+		lines: result.text === "" ? [] : result.text.split("\n"),
+		phase: result.phase,
+		truncatedEntryCount: result.truncatedEntryCount,
+		omittedEntryCount: result.omittedEntryCount,
+	};
 }

--- a/src/core/skill/skill-description-budget.ts
+++ b/src/core/skill/skill-description-budget.ts
@@ -1,0 +1,231 @@
+export type DescriptionEntry = {
+	readonly label: string;
+	readonly description: string;
+	readonly protected?: boolean;
+};
+
+export type DescriptionBudgetOptions = {
+	readonly budgetChars: number;
+	readonly maxDescriptionChars: number;
+	readonly minDescriptionChars?: number;
+};
+
+export type DescriptionBudgetResult = {
+	readonly text: string;
+	readonly phase: 1 | 2 | 3 | 4;
+	readonly truncatedEntryCount: number;
+	readonly omittedEntryCount: number;
+};
+
+export const DEFAULT_SKILL_DESCRIPTION_BUDGET = 8000;
+export const DEFAULT_MAX_SKILL_DESCRIPTION_CHARS = 250;
+const DEFAULT_MIN_DESCRIPTION_CHARS = 16;
+const SKILL_DESCRIPTION_BUDGET_CONTEXT_PERCENT = 0.01;
+
+type PreparedEntry = DescriptionEntry & {
+	readonly description: string;
+};
+
+export function formatDescriptionEntriesWithinBudget(
+	entries: readonly DescriptionEntry[],
+	options: DescriptionBudgetOptions,
+): DescriptionBudgetResult {
+	const prepared = entries.map((entry) => ({
+		...entry,
+		description: clampDescription(entry.description, options.maxDescriptionChars),
+	}));
+
+	const fullText = formatEntries(prepared, "full");
+	const initiallyTruncated = countChanged(entries, prepared);
+	if (fullText.length <= options.budgetChars) {
+		return {
+			text: fullText,
+			phase: 1,
+			truncatedEntryCount: initiallyTruncated,
+			omittedEntryCount: 0,
+		};
+	}
+
+	const phase2 = formatPhase2(prepared, options);
+	if (phase2 !== undefined) {
+		return {
+			text: phase2,
+			phase: 2,
+			truncatedEntryCount: countChanged(entries, parseFormattedEntries(prepared, phase2)),
+			omittedEntryCount: 0,
+		};
+	}
+
+	const phase3 = formatPhase3(prepared, options);
+	if (phase3 !== undefined) {
+		return {
+			text: phase3,
+			phase: 3,
+			truncatedEntryCount: countChanged(entries, parseFormattedEntries(prepared, phase3)),
+			omittedEntryCount: 0,
+		};
+	}
+
+	const labelOnly = fitLabelOnlyEntries(prepared, options.budgetChars);
+
+	return {
+		text: formatEntries(labelOnly.entries, "label-only"),
+		phase: 4,
+		truncatedEntryCount: prepared.length,
+		omittedEntryCount: prepared.length - labelOnly.entries.length,
+	};
+}
+
+export function deriveAgentSkillDescriptionBudget(model: {
+	readonly provider: string;
+	readonly model: string;
+}): number {
+	const contextWindowTokens = estimateContextWindowTokens(model);
+	if (contextWindowTokens === undefined) {
+		return DEFAULT_SKILL_DESCRIPTION_BUDGET;
+	}
+
+	return Math.floor(contextWindowTokens * 4 * SKILL_DESCRIPTION_BUDGET_CONTEXT_PERCENT);
+}
+
+function formatPhase2(
+	entries: readonly PreparedEntry[],
+	options: DescriptionBudgetOptions,
+): string | undefined {
+	const minDescriptionChars = options.minDescriptionChars ?? DEFAULT_MIN_DESCRIPTION_CHARS;
+	const protectedEntries = entries.filter((entry) => entry.protected === true);
+	const mutableEntries = entries.filter((entry) => entry.protected !== true);
+
+	if (mutableEntries.length === 0) return undefined;
+
+	const protectedText = formatEntries(protectedEntries, "full");
+	const separatorLength = protectedEntries.length > 0 ? 1 : 0;
+	const remainingBudget = options.budgetChars - protectedText.length - separatorLength;
+	if (remainingBudget <= 0) return undefined;
+
+	const mutableLabelsLength = mutableEntries.reduce(
+		(sum, entry) => sum + entry.label.length + 2,
+		0,
+	);
+	const mutableNewlines = Math.max(mutableEntries.length - 1, 0);
+	const availableDescriptionBudget = remainingBudget - mutableLabelsLength - mutableNewlines;
+	const eachDescriptionBudget = Math.floor(availableDescriptionBudget / mutableEntries.length);
+	if (eachDescriptionBudget < minDescriptionChars) return undefined;
+
+	const truncated = entries.map((entry) => {
+		if (entry.protected === true) return entry;
+		return { ...entry, description: clampDescription(entry.description, eachDescriptionBudget) };
+	});
+	const text = formatEntries(truncated, "full");
+	return text.length <= options.budgetChars ? text : undefined;
+}
+
+function formatPhase3(
+	entries: readonly PreparedEntry[],
+	options: DescriptionBudgetOptions,
+): string | undefined {
+	const totalLabelLength = entries.reduce((sum, entry) => sum + entry.label.length + 2, 0);
+	const totalNewlines = Math.max(entries.length - 1, 0);
+	const availableDescriptionBudget = options.budgetChars - totalLabelLength - totalNewlines;
+	if (availableDescriptionBudget <= 0) return undefined;
+
+	const eachDescriptionBudget = Math.floor(availableDescriptionBudget / entries.length);
+	if (eachDescriptionBudget <= 1) return undefined;
+
+	const truncated = entries.map((entry) => ({
+		...entry,
+		description: clampDescription(entry.description, eachDescriptionBudget),
+	}));
+	const text = formatEntries(truncated, "full");
+	return text.length <= options.budgetChars ? text : undefined;
+}
+
+function clampDescription(description: string, maxChars: number): string {
+	if (description.length <= maxChars) return description;
+	if (maxChars <= 1) return "…";
+	return `${description.slice(0, maxChars - 1)}…`;
+}
+
+function formatEntries(entries: readonly PreparedEntry[], mode: "full" | "label-only"): string {
+	return entries
+		.map((entry) => {
+			if (mode === "label-only") return entry.label;
+			return `${entry.label}: ${entry.description}`;
+		})
+		.join("\n");
+}
+
+function fitLabelOnlyEntries(
+	entries: readonly PreparedEntry[],
+	budgetChars: number,
+): { readonly entries: readonly PreparedEntry[] } {
+	const kept: PreparedEntry[] = [];
+	let used = 0;
+
+	for (const entry of entries) {
+		const nextLength = entry.label.length + (kept.length > 0 ? 1 : 0);
+		if (used + nextLength > budgetChars) break;
+		kept.push(entry);
+		used += nextLength;
+	}
+
+	return { entries: kept };
+}
+
+function estimateContextWindowTokens(model: {
+	readonly provider: string;
+	readonly model: string;
+}): number | undefined {
+	const normalizedProvider = model.provider.toLowerCase();
+	const normalizedModel = model.model.toLowerCase();
+
+	if (normalizedProvider === "anthropic") {
+		if (normalizedModel.includes("context-1m")) return 1_000_000;
+		return 200_000;
+	}
+
+	if (normalizedProvider === "google") {
+		if (normalizedModel.includes("gemini-1.5") || normalizedModel.includes("gemini-2.5")) {
+			return 1_000_000;
+		}
+		return 128_000;
+	}
+
+	if (normalizedProvider === "openai") {
+		if (normalizedModel.startsWith("gpt-4.1") || normalizedModel.startsWith("gpt-5")) {
+			return 1_000_000;
+		}
+		return 128_000;
+	}
+
+	return undefined;
+}
+
+function countChanged(
+	original: readonly DescriptionEntry[],
+	formatted: readonly PreparedEntry[],
+): number {
+	let changed = 0;
+	for (const [index, entry] of original.entries()) {
+		const next = formatted[index];
+		if (!next || entry.description !== next.description) {
+			changed += 1;
+		}
+	}
+	return changed;
+}
+
+function parseFormattedEntries(
+	entries: readonly PreparedEntry[],
+	formattedText: string,
+): readonly PreparedEntry[] {
+	const lines = formattedText.split("\n");
+	return entries.map((entry, index) => {
+		const line = lines[index] ?? entry.label;
+		const prefix = `${entry.label}: `;
+		if (!line.startsWith(prefix)) {
+			return { ...entry, description: "" };
+		}
+		return { ...entry, description: line.slice(prefix.length) };
+	});
+}

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -48,10 +48,6 @@ export function parseSkill(
 	const metadata = metadataResult.value;
 
 	if (metadata.actions) {
-		if (metadata.inputs.length > 0) {
-			logger?.warn('Skill-level "inputs" is ignored when "actions" is defined');
-		}
-
 		const validationResult = validateActionSections(parsed.content, metadata);
 		if (!validationResult.ok) {
 			return validationResult;

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -17,7 +17,6 @@ import { copyToClipboard } from "./clipboard";
 import { showEmptyState } from "./screens/empty-state";
 import {
 	createPresetPromptCollector,
-	createSingleSkillRepository,
 	type ExecutionDeps,
 	showExecution,
 } from "./screens/execution-view";
@@ -50,8 +49,15 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 			return;
 		}
 
-		const { model, modelSpec, hooksConfig, commandTimeoutMs, maxAgentSteps, mcpServerConfigs } =
-			await resolveModelAndConfig(options);
+		const {
+			model,
+			modelSpec,
+			hooksConfig,
+			commandTimeoutMs,
+			maxAgentSteps,
+			mcpServerConfigs,
+			maxSkillDescriptionChars,
+		} = await resolveModelAndConfig(options);
 
 		const commandExecutor = createCommandRunner({ defaultTimeoutMs: commandTimeoutMs });
 		const logger = createConsoleLogger();
@@ -62,11 +68,13 @@ export async function startTui(options?: TuiOptions): Promise<void> {
 			hookExecutor,
 			hooksConfig,
 			outputFileStore,
-			skillRepositoryFactory: createSingleSkillRepository,
+			skillRepositoryFactory: () => skillRepository,
 			promptCollectorFactory: createPresetPromptCollector,
 			systemPromptResolver: createSystemPromptResolver(process.cwd()),
 			maxAgentSteps,
 			mcpServerConfigs,
+			modelSpec: modelSpec ?? undefined,
+			maxSkillDescriptionChars,
 		};
 
 		while (true) {
@@ -99,6 +107,7 @@ type ModelAndConfig = {
 	readonly commandTimeoutMs: number | undefined;
 	readonly maxAgentSteps: number | undefined;
 	readonly mcpServerConfigs: Readonly<Record<string, McpServerConfig>> | undefined;
+	readonly maxSkillDescriptionChars: number | undefined;
 };
 
 // config.toml からデフォルトの LLM モデルとフック設定を解決する。
@@ -114,12 +123,14 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 			commandTimeoutMs: undefined,
 			maxAgentSteps: undefined,
 			mcpServerConfigs: undefined,
+			maxSkillDescriptionChars: undefined,
 		};
 
 	const hooksConfig = configResult.value.hooks;
 	const commandTimeoutMs = configResult.value.cli?.command_timeout_ms;
 	const maxAgentSteps = configResult.value.cli?.max_agent_steps;
 	const mcpServerConfigs = configResult.value.mcp?.servers;
+	const maxSkillDescriptionChars = configResult.value.mcp?.max_skill_description_chars;
 
 	const aiConfig = configResult.value.ai ?? {};
 	const specResult = resolveModelSpec({
@@ -134,6 +145,7 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 			commandTimeoutMs,
 			maxAgentSteps,
 			mcpServerConfigs,
+			maxSkillDescriptionChars,
 		};
 
 	const modelResult = createLanguageModel(specResult.value, aiConfig);
@@ -145,6 +157,7 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 			commandTimeoutMs,
 			maxAgentSteps,
 			mcpServerConfigs,
+			maxSkillDescriptionChars,
 		};
 
 	return {
@@ -154,6 +167,7 @@ async function resolveModelAndConfig(options?: TuiOptions): Promise<ModelAndConf
 		commandTimeoutMs,
 		maxAgentSteps,
 		mcpServerConfigs,
+		maxSkillDescriptionChars,
 	};
 }
 

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -1,18 +1,18 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { createAgentExecutor } from "../../adapter/agent-executor";
+import type { ModelSpec } from "../../adapter/ai-provider";
 import type { McpServerConfig } from "../../adapter/config-loader";
 import { createConsoleLogger } from "../../adapter/console-logger";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
 import { createPromptRunner } from "../../adapter/prompt-runner";
-import type { ModelSpec } from "../../adapter/ai-provider";
 import type { SessionId } from "../../core/execution/session";
 import { resolveActionConfig } from "../../core/skill/action";
+import type { Skill } from "../../core/skill/skill";
 import {
 	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
 	deriveAgentSkillDescriptionBudget,
 } from "../../core/skill/skill-description-budget";
-import type { Skill } from "../../core/skill/skill";
 import { domainErrorMessage } from "../../core/types/errors";
 import { ok } from "../../core/types/result";
 import type { HooksConfig } from "../../usecase/hook-runner";

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -4,8 +4,14 @@ import type { McpServerConfig } from "../../adapter/config-loader";
 import { createConsoleLogger } from "../../adapter/console-logger";
 import { createContextCollector } from "../../adapter/context-collector";
 import { createDefaultContextCollectorDeps } from "../../adapter/context-collector-deps";
+import { createPromptRunner } from "../../adapter/prompt-runner";
+import type { ModelSpec } from "../../adapter/ai-provider";
 import type { SessionId } from "../../core/execution/session";
 import { resolveActionConfig } from "../../core/skill/action";
+import {
+	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+	deriveAgentSkillDescriptionBudget,
+} from "../../core/skill/skill-description-budget";
 import type { Skill } from "../../core/skill/skill";
 import { domainErrorMessage } from "../../core/types/errors";
 import { ok } from "../../core/types/result";
@@ -39,6 +45,8 @@ export type ExecutionDeps = {
 	readonly systemPromptResolver: SystemPromptResolver;
 	readonly maxAgentSteps?: number;
 	readonly mcpServerConfigs?: Readonly<Record<string, McpServerConfig>>;
+	readonly modelSpec?: ModelSpec;
+	readonly maxSkillDescriptionChars?: number;
 };
 
 export async function runExecution(
@@ -84,8 +92,14 @@ export function createSingleSkillRepository(skill: Skill): SkillRepository {
 export function createPresetPromptCollector(
 	variables: Readonly<Record<string, string>>,
 ): PromptCollector {
+	const promptRunner = createPromptRunner();
 	return {
-		collect: async () => ok(variables),
+		collect: async (inputs, presets, options) =>
+			promptRunner.collect(
+				inputs,
+				{ ...variables, ...presets },
+				{ noInput: options?.noInput ?? true },
+			),
 	};
 }
 
@@ -142,6 +156,13 @@ async function executeAgentMode(
 			systemPromptResolver: deps.systemPromptResolver,
 			mcpToolResolver,
 			logger,
+			skillDescriptionBudget: deps.modelSpec
+				? {
+						budgetChars: deriveAgentSkillDescriptionBudget(deps.modelSpec),
+						maxDescriptionChars:
+							deps.maxSkillDescriptionChars ?? DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
+					}
+				: undefined,
 		},
 	);
 

--- a/src/usecase/run-agent-skill.ts
+++ b/src/usecase/run-agent-skill.ts
@@ -2,10 +2,11 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import type { ToolSet } from "ai";
 import { DEFAULT_MAX_AGENT_STEPS } from "../core/constants";
 import type { TaskpRunDeps } from "../core/execution/agent-tools";
-import { buildTaskpRunDescription, buildTools } from "../core/execution/agent-tools";
+import { buildTaskpRunDescriptionResult, buildTools } from "../core/execution/agent-tools";
 import type { ContentPart } from "../core/execution/content-part";
 import { partitionToolRefs } from "../core/execution/mcp-tool-ref";
 import type { SessionId } from "../core/execution/session";
+import type { DescriptionBudgetOptions } from "../core/skill/skill-description-budget";
 import { resolveAgentExecution } from "../core/skill/skill-execution-resolver";
 import { configError, type DomainError, domainErrorMessage } from "../core/types/errors";
 import type { Result } from "../core/types/result";
@@ -60,6 +61,7 @@ export type RunAgentSkillDeps = {
 	readonly mcpToolResolver?: McpToolResolverPort;
 	readonly outputFileStore?: OutputFileStorePort;
 	readonly logger?: Logger;
+	readonly skillDescriptionBudget?: DescriptionBudgetOptions;
 };
 
 export async function runAgentSkill(
@@ -137,6 +139,8 @@ export async function runAgentSkill(
 		builtins,
 		deps.skillRepository,
 		skill.metadata.name,
+		deps.skillDescriptionBudget,
+		deps.logger,
 	);
 
 	const taskpRunDeps: TaskpRunDeps = {
@@ -374,11 +378,23 @@ async function buildToolDescriptions(
 	toolNames: readonly string[],
 	skillRepository: SkillRepository,
 	currentSkillName: string,
+	skillDescriptionBudget?: DescriptionBudgetOptions,
+	logger?: Logger,
 ): Promise<Record<string, string> | undefined> {
 	if (!toolNames.includes("taskp_run")) return undefined;
 
 	const { skills } = await skillRepository.listAll();
+	const descriptionResult = buildTaskpRunDescriptionResult(
+		skills,
+		currentSkillName,
+		skillDescriptionBudget,
+	);
+	if (descriptionResult.truncatedEntryCount > 0) {
+		logger?.debug(
+			`[skills] Description budget applied: truncated ${descriptionResult.truncatedEntryCount} entries (phase ${descriptionResult.phase})`,
+		);
+	}
 	return {
-		taskp_run: buildTaskpRunDescription(skills, currentSkillName),
+		taskp_run: descriptionResult.text,
 	};
 }

--- a/tests/adapter/config-loader.test.ts
+++ b/tests/adapter/config-loader.test.ts
@@ -7,6 +7,7 @@ import {
 	mergeAiConfig,
 	mergeCliConfig,
 	mergeHooksConfig,
+	mergeMcpConfig,
 	mergeOptional,
 	mergeProviders,
 } from "../../src/adapter/config-loader";
@@ -429,6 +430,60 @@ max_agent_steps = 201
 			expect(result.ok).toBe(false);
 		});
 	});
+
+	describe("[mcp] section", () => {
+		it("loads skill description budget settings", async () => {
+			writeConfig(
+				projectRoot,
+				`
+[mcp]
+skill_description_budget = 8000
+max_skill_description_chars = 250
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.mcp?.skill_description_budget).toBe(8000);
+			expect(result.value.mcp?.max_skill_description_chars).toBe(250);
+		});
+
+		it("merges project mcp fields over global while preserving server entries", async () => {
+			writeConfig(
+				globalRoot,
+				`
+[mcp]
+skill_description_budget = 8000
+
+[mcp.servers.global]
+transport = "stdio"
+command = "global-mcp"
+`,
+			);
+			writeConfig(
+				projectRoot,
+				`
+[mcp]
+max_skill_description_chars = 250
+
+[mcp.servers.project]
+transport = "stdio"
+command = "project-mcp"
+`,
+			);
+
+			const result = await createLoader().load();
+
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+			expect(result.value.mcp?.skill_description_budget).toBe(8000);
+			expect(result.value.mcp?.max_skill_description_chars).toBe(250);
+			expect(result.value.mcp?.servers?.global?.transport).toBe("stdio");
+			expect(result.value.mcp?.servers?.project?.transport).toBe("stdio");
+		});
+	});
 });
 
 describe("mergeOptional", () => {
@@ -546,5 +601,25 @@ describe("mergeCliConfig", () => {
 		const result = mergeCliConfig({ max_agent_steps: 50 }, {});
 
 		expect(result.max_agent_steps).toBe(50);
+	});
+});
+
+describe("mergeMcpConfig", () => {
+	it("merges budget fields by project priority while preserving merged servers", () => {
+		const result = mergeMcpConfig(
+			{
+				skill_description_budget: 8000,
+				servers: { global: { transport: "stdio", command: "global-mcp" } },
+			},
+			{
+				max_skill_description_chars: 250,
+				servers: { project: { transport: "stdio", command: "project-mcp" } },
+			},
+		);
+
+		expect(result.skill_description_budget).toBe(8000);
+		expect(result.max_skill_description_chars).toBe(250);
+		expect(result.servers?.global?.transport).toBe("stdio");
+		expect(result.servers?.project?.transport).toBe("stdio");
 	});
 });

--- a/tests/adapter/skill-mcp-server.test.ts
+++ b/tests/adapter/skill-mcp-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Skill } from "../../src/core/skill/skill";
 import { buildSkillMcpTools, createSkillMcpCli } from "../../src/adapter/skill-mcp-server";
+import type { Skill } from "../../src/core/skill/skill";
 
 function createSkill(
 	overrides: Partial<Skill["metadata"]> & { name: string; description: string },

--- a/tests/adapter/skill-mcp-server.test.ts
+++ b/tests/adapter/skill-mcp-server.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Skill } from "../../src/core/skill/skill";
+import { buildSkillMcpTools, createSkillMcpCli } from "../../src/adapter/skill-mcp-server";
+
+function createSkill(
+	overrides: Partial<Skill["metadata"]> & { name: string; description: string },
+): Skill {
+	return {
+		metadata: {
+			name: overrides.name,
+			description: overrides.description,
+			mode: overrides.mode ?? "template",
+			inputs: overrides.inputs ?? [],
+			model: overrides.model,
+			timeout: overrides.timeout,
+			tools: overrides.tools ?? [],
+			context: overrides.context ?? [],
+			actions: overrides.actions,
+			hooks: overrides.hooks,
+		},
+		body: {
+			content: "",
+			extractCodeBlocks: () => [],
+			extractActionSection: () => ({
+				ok: false,
+				error: { type: "EXECUTION_ERROR", message: "n/a" },
+			}),
+			extractActionCodeBlocks: () => [],
+		},
+		location: `/skills/${overrides.name}/SKILL.md`,
+		scope: "local",
+	};
+}
+
+async function mcpRequest(
+	cli: { fetch(req: Request): Promise<Response> },
+	body: unknown,
+	sessionId?: string,
+) {
+	const headers: Record<string, string> = {
+		"content-type": "application/json",
+		accept: "application/json, text/event-stream",
+	};
+	if (sessionId) headers["mcp-session-id"] = sessionId;
+	return cli.fetch(
+		new Request("http://localhost/mcp", {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		}),
+	);
+}
+
+async function initSession(cli: { fetch(req: Request): Promise<Response> }) {
+	const res = await mcpRequest(cli, {
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {
+			protocolVersion: "2025-03-26",
+			capabilities: {},
+			clientInfo: { name: "test-client", version: "1.0.0" },
+		},
+	});
+	const sessionId = res.headers.get("mcp-session-id");
+	await mcpRequest(
+		cli,
+		{ jsonrpc: "2.0", method: "notifications/initialized" },
+		sessionId ?? undefined,
+	);
+	return sessionId ?? "";
+}
+
+describe("buildSkillMcpTools", () => {
+	it("shrinks MCP tool descriptions under the shared budget", () => {
+		const tools = buildSkillMcpTools(
+			[
+				createSkill({
+					name: "deploy",
+					description: "アプリケーションを安全にデプロイするための長い説明文",
+				}),
+				createSkill({ name: "release", description: "リリース作業全体を実行するための長い説明文" }),
+			],
+			{ budgetChars: 22, maxDescriptionChars: 40, minDescriptionChars: 12 },
+		);
+
+		expect(tools[0]?.description === undefined || tools[0]?.description.includes("…")).toBe(true);
+		expect(tools[1]?.description === undefined || tools[1]?.description.includes("…")).toBe(true);
+	});
+
+	it("creates action-level MCP tools", () => {
+		const tools = buildSkillMcpTools(
+			[
+				createSkill({
+					name: "task",
+					description: "Task operations",
+					actions: {
+						add: { description: "Add task", mode: "template" },
+						list: { description: "List tasks", mode: "template" },
+					},
+				}),
+			],
+			{ budgetChars: 200, maxDescriptionChars: 80 },
+		);
+
+		expect(tools.map((tool) => tool.toolName)).toEqual(["task__add", "task__list"]);
+	});
+
+	it("fails fast on normalized MCP tool name collisions", () => {
+		expect(() =>
+			buildSkillMcpTools(
+				[
+					createSkill({ name: "review__fix", description: "Skill" }),
+					createSkill({
+						name: "review",
+						description: "Review",
+						actions: { fix: { description: "Fix", mode: "template" } },
+					}),
+				],
+				{ budgetChars: 200, maxDescriptionChars: 80 },
+			),
+		).toThrow("Duplicate MCP tool name after normalization");
+	});
+});
+
+describe("createSkillMcpCli", () => {
+	it("exposes budgeted skill tools through MCP tools/list", async () => {
+		const cli = createSkillMcpCli({
+			version: "0.1.14",
+			skills: [
+				createSkill({
+					name: "deploy",
+					description: "アプリケーションを安全にデプロイするための長い説明文",
+					inputs: [{ name: "env", type: "text", message: "Environment" }],
+				}),
+				createSkill({
+					name: "release",
+					description: "リリース作業全体を実行するための長い説明文",
+				}),
+			],
+			budgetOptions: { budgetChars: 50, maxDescriptionChars: 40, minDescriptionChars: 12 },
+			executeSkill: vi.fn().mockResolvedValue({ ok: true }),
+		});
+
+		const sessionId = await initSession(cli);
+		const res = await mcpRequest(
+			cli,
+			{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+			sessionId,
+		);
+		const body = (await res.json()) as {
+			result: {
+				tools: Array<{
+					name: string;
+					description?: string;
+					inputSchema?: { properties?: Record<string, unknown> };
+				}>;
+			};
+		};
+		const tools = body.result.tools.map(
+			(tool: {
+				name: string;
+				description?: string;
+				inputSchema?: { properties?: Record<string, unknown> };
+			}) => ({
+				name: tool.name,
+				description: tool.description,
+				hasInputSchema: Object.keys(tool.inputSchema?.properties ?? {}).length > 0,
+			}),
+		);
+
+		expect(tools).toEqual([
+			{ name: "deploy", description: expect.any(String), hasInputSchema: true },
+			{ name: "release", description: expect.any(String), hasInputSchema: false },
+		]);
+		expect(tools[0]?.description).toContain("…");
+	});
+
+	it("returns MCP tool errors without crashing when skill execution throws", async () => {
+		const cli = createSkillMcpCli({
+			version: "0.1.14",
+			skills: [createSkill({ name: "deploy", description: "Deploy" })],
+			budgetOptions: { budgetChars: 200, maxDescriptionChars: 80 },
+			executeSkill: vi.fn().mockRejectedValue(new Error("skill failed")),
+		});
+
+		const sessionId = await initSession(cli);
+		const res = await mcpRequest(
+			cli,
+			{
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: { name: "deploy", arguments: {} },
+			},
+			sessionId,
+		);
+		const body = (await res.json()) as {
+			result: { content: Array<{ text: string }>; isError?: boolean };
+		};
+
+		expect(res.status).toBe(200);
+		expect(body.result.isError).toBe(true);
+		expect(body.result.content[0]?.text).toContain("skill failed");
+	});
+});

--- a/tests/core/execution/agent-tools.test.ts
+++ b/tests/core/execution/agent-tools.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	buildTaskpRunDescription,
+	buildTaskpRunDescriptionResult,
 	buildTools,
 	getPrimaryArgKey,
 	MAX_FETCH_LENGTH,
@@ -775,6 +776,74 @@ describe("buildTaskpRunDescription", () => {
 		const result = buildTaskpRunDescription(skills);
 
 		expect(result).not.toContain("agent-only");
+	});
+
+	it("description budget を指定すると Available skills を段階的に短縮する", () => {
+		const skills = [
+			createSkillFixture({
+				name: "deploy",
+				description: "アプリケーションを安全にデプロイするための長い説明文",
+			}),
+			createSkillFixture({
+				name: "release",
+				description: "リリース作業全体を実行するための長い説明文",
+			}),
+		];
+
+		const result = buildTaskpRunDescription(skills, undefined, {
+			budgetChars: 120,
+			maxDescriptionChars: 40,
+			minDescriptionChars: 12,
+		});
+
+		expect(result).toContain("Available skills:");
+		expect(result).toContain("deploy");
+		expect(result).toContain("release");
+		expect(result).not.toContain("アプリケーションを安全にデプロイするための長い説明文");
+	});
+
+	it("description budget は taskp_run の最終 description 全体に適用される", () => {
+		const skills = [
+			createSkillFixture({
+				name: "deploy",
+				description: "アプリケーションを安全にデプロイするための長い説明文",
+			}),
+			createSkillFixture({
+				name: "release",
+				description: "リリース作業全体を実行するための長い説明文",
+			}),
+		];
+
+		const result = buildTaskpRunDescription(skills, undefined, {
+			budgetChars: 78,
+			maxDescriptionChars: 40,
+			minDescriptionChars: 12,
+		});
+
+		expect(result.length).toBeLessThanOrEqual(78);
+	});
+
+	it("budget がベース description より小さい場合も最終文字数を超えない", () => {
+		const result = buildTaskpRunDescription([], undefined, {
+			budgetChars: 40,
+			maxDescriptionChars: 40,
+		});
+
+		expect(result.length).toBeLessThanOrEqual(40);
+	});
+
+	it("全スキル行が省略された場合は omittedEntryCount に件数を反映する", () => {
+		const skills = [
+			createSkillFixture({ name: "deploy", description: "Deploy the application" }),
+			createSkillFixture({ name: "release", description: "Release the application" }),
+		];
+
+		const result = buildTaskpRunDescriptionResult(skills, undefined, {
+			budgetChars: 40,
+			maxDescriptionChars: 40,
+		});
+
+		expect(result.omittedEntryCount).toBe(2);
 	});
 });
 

--- a/tests/core/skill/skill-description-budget.test.ts
+++ b/tests/core/skill/skill-description-budget.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	type DescriptionEntry,
 	deriveAgentSkillDescriptionBudget,
 	formatDescriptionEntriesWithinBudget,
-	type DescriptionEntry,
 } from "../../../src/core/skill/skill-description-budget";
 
 function createEntry(label: string, description: string, protectedEntry = false): DescriptionEntry {

--- a/tests/core/skill/skill-description-budget.test.ts
+++ b/tests/core/skill/skill-description-budget.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+	deriveAgentSkillDescriptionBudget,
+	formatDescriptionEntriesWithinBudget,
+	type DescriptionEntry,
+} from "../../../src/core/skill/skill-description-budget";
+
+function createEntry(label: string, description: string, protectedEntry = false): DescriptionEntry {
+	return { label, description, protected: protectedEntry };
+}
+
+describe("formatDescriptionEntriesWithinBudget", () => {
+	it("keeps full descriptions when they fit within budget", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- deploy", "Deploy the application"),
+				createEntry("- test", "Run the test suite"),
+			],
+			{ budgetChars: 200, maxDescriptionChars: 80 },
+		);
+
+		expect(result.phase).toBe(1);
+		expect(result.text).toContain("- deploy: Deploy the application");
+		expect(result.text).toContain("- test: Run the test suite");
+		expect(result.truncatedEntryCount).toBe(0);
+	});
+
+	it("applies the per-entry description cap before budget reduction", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[createEntry("- long", "abcdefghijklmnopqrstuvwxyz")],
+			{ budgetChars: 200, maxDescriptionChars: 10 },
+		);
+
+		expect(result.phase).toBe(1);
+		expect(result.text).toBe("- long: abcdefghi…");
+		expect(result.truncatedEntryCount).toBe(1);
+	});
+
+	it("falls back to phase 2 and preserves protected entries", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- bundled", "Bundled skill description", true),
+				createEntry("- local", "Local skill description that must shrink"),
+			],
+			{ budgetChars: 70, maxDescriptionChars: 80, minDescriptionChars: 12 },
+		);
+
+		expect(result.phase).toBe(2);
+		expect(result.text).toContain("- bundled: Bundled skill description");
+		expect(result.text).toContain("- local: ");
+		expect(result.text).toContain("…");
+		expect(result.truncatedEntryCount).toBe(1);
+	});
+
+	it("falls back to phase 3 when equal truncation cannot keep the minimum length", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- alpha", "Alpha description is very long"),
+				createEntry("- beta", "Beta description is also very long"),
+			],
+			{ budgetChars: 35, maxDescriptionChars: 80, minDescriptionChars: 12 },
+		);
+
+		expect(result.phase).toBe(3);
+		expect(result.text).toContain("- alpha:");
+		expect(result.text).toContain("- beta:");
+		expect(result.text).toContain("…");
+	});
+
+	it("falls back to phase 4 names only when even prefixes do not fit", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- very-long-skill-name", "Alpha description"),
+				createEntry("- another-long-skill", "Beta description"),
+			],
+			{ budgetChars: 43, maxDescriptionChars: 80, minDescriptionChars: 12 },
+		);
+
+		expect(result.phase).toBe(4);
+		expect(result.text).toBe("- very-long-skill-name\n- another-long-skill");
+		expect(result.truncatedEntryCount).toBe(2);
+	});
+
+	it("omits trailing entries in phase 4 when name-only output still exceeds budget", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- very-long-skill-name", "Alpha description"),
+				createEntry("- another-long-skill", "Beta description"),
+			],
+			{ budgetChars: 22, maxDescriptionChars: 80, minDescriptionChars: 12 },
+		);
+
+		expect(result.phase).toBe(4);
+		expect(result.text).toBe("- very-long-skill-name");
+	});
+});
+
+describe("deriveAgentSkillDescriptionBudget", () => {
+	it("derives budget from known model context windows", () => {
+		expect(
+			deriveAgentSkillDescriptionBudget({
+				provider: "anthropic",
+				model: "claude-sonnet-4-20250514",
+			}),
+		).toBe(8000);
+		expect(deriveAgentSkillDescriptionBudget({ provider: "google", model: "gemini-2.5-pro" })).toBe(
+			40000,
+		);
+	});
+
+	it("falls back to default for unknown providers", () => {
+		expect(
+			deriveAgentSkillDescriptionBudget({ provider: "ollama", model: "qwen2.5-coder:32b" }),
+		).toBe(8000);
+	});
+});

--- a/tests/tui/screens/execution-view.test.ts
+++ b/tests/tui/screens/execution-view.test.ts
@@ -122,7 +122,21 @@ describe("createPresetPromptCollector", () => {
 		const vars = { key: "value" };
 		const collector = createPresetPromptCollector(vars);
 		const result = await collector.collect([], {});
-		expect(result).toEqual(ok({ key: "value" }));
+		expect(result).toEqual(ok({}));
+	});
+
+	it("merges parent variables with taskp_run presets for child inputs", async () => {
+		const collector = createPresetPromptCollector({ parent: "from-parent" });
+		const result = await collector.collect(
+			[
+				{ name: "parent", type: "text", message: "Parent" },
+				{ name: "child", type: "text", message: "Child", default: "fallback" },
+			],
+			{ child: "from-set" },
+			{ noInput: true },
+		);
+
+		expect(result).toEqual(ok({ parent: "from-parent", child: "from-set" }));
 	});
 });
 

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -255,6 +255,81 @@ describe("runAgentSkill", () => {
 		});
 	});
 
+	it("applies skill description budget to taskp_run tool descriptions", async () => {
+		const skill = createAgentSkill({ tools: ["taskp_run"] });
+		const deps = createMockDeps(skill);
+		deps.skillRepository = {
+			...deps.skillRepository,
+			listAll: vi.fn().mockResolvedValue({
+				skills: [
+					createAgentSkill({
+						name: "deploy",
+						mode: "template",
+						description: "アプリケーションを安全にデプロイするための長い説明文",
+						tools: ["bash"],
+					}),
+					createAgentSkill({
+						name: "release",
+						mode: "template",
+						description: "リリース作業全体を実行するための長い説明文",
+						tools: ["bash"],
+					}),
+				],
+				failures: [],
+			}),
+		};
+
+		await runAgentSkill(
+			{ name: "test-agent", presets: {}, model: mockModel, sessionId: TEST_SESSION_ID },
+			{ ...deps, skillDescriptionBudget: { budgetChars: 120, maxDescriptionChars: 40 } },
+		);
+
+		const executorCall = (deps.agentExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+		expect(executorCall.tools.taskp_run.description).toContain("Available skills:");
+		expect(executorCall.tools.taskp_run.description).not.toContain(
+			"アプリケーションを安全にデプロイするための長い説明文",
+		);
+	});
+
+	it("logs when taskp_run descriptions are truncated by budget", async () => {
+		const skill = createAgentSkill({ tools: ["taskp_run"] });
+		const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const deps = createMockDeps(skill);
+		deps.skillRepository = {
+			...deps.skillRepository,
+			listAll: vi.fn().mockResolvedValue({
+				skills: [
+					createAgentSkill({
+						name: "deploy",
+						mode: "template",
+						description: "アプリケーションを安全にデプロイするための長い説明文",
+						tools: ["bash"],
+					}),
+					createAgentSkill({
+						name: "release",
+						mode: "template",
+						description: "リリース作業全体を実行するための長い説明文",
+						tools: ["bash"],
+					}),
+				],
+				failures: [],
+			}),
+		};
+
+		await runAgentSkill(
+			{ name: "test-agent", presets: {}, model: mockModel, sessionId: TEST_SESSION_ID },
+			{
+				...deps,
+				logger,
+				skillDescriptionBudget: { budgetChars: 120, maxDescriptionChars: 40 },
+			},
+		);
+
+		expect(logger.debug).toHaveBeenCalledWith(
+			expect.stringContaining("Description budget applied"),
+		);
+	});
+
 	it("skips context collection when no context sources defined", async () => {
 		const skill = createAgentSkill({ context: [] });
 		const deps = createMockDeps(skill);


### PR DESCRIPTION
## Summary
- add shared skill-description budgeting with phased truncation for agent-mode `taskp_run` listings and model-derived agent budgets
- expose registered skills and actions as budgeted MCP tools in `taskp serve`, including safe MCP error handling and collision detection
- add config/schema/docs/README updates plus TUI parity and regression coverage for merge, MCP exposure, and nested execution

## Verification
- bun run test
- bun run typecheck
- bun run build