### PR TITLE
fix: deduplicate shared skill files by canonical path

### DIFF
--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -31,6 +31,11 @@ type SkillDirectory = {
 	readonly scope: SkillScope;
 };
 
+type SkillCandidate = {
+	readonly path: string;
+	readonly scope: SkillScope;
+};
+
 export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const canonicalLocalRoot = canonicalizePath(deps.localRoot);
 	const canonicalGlobalRoot = canonicalizePath(deps.globalRoot);
@@ -40,9 +45,9 @@ export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const { logger } = deps;
 	return {
 		findByName: (name) => findByName(name, [...projectSkillDirs, globalSkillDir], logger),
-		listAll: () => listAll([...projectSkillDirs, globalSkillDir], logger),
-		listLocal: () => listAll(projectSkillDirs, logger),
-		listGlobal: () => scanDirectory(globalSkillDir.path, globalSkillDir.scope, logger),
+		listAll: () => loadFromDirectories([...projectSkillDirs, globalSkillDir], logger),
+		listLocal: () => loadFromDirectories(projectSkillDirs, logger),
+		listGlobal: () => loadFromDirectories([globalSkillDir], logger),
 	};
 }
 
@@ -74,30 +79,46 @@ async function findByName(
 	return err(skillNotFoundError(name));
 }
 
-async function listAll(
+async function loadFromDirectories(
 	skillDirs: readonly SkillDirectory[],
 	logger?: SkillLogger,
 ): Promise<SkillLoadResult> {
-	const results = await Promise.all(
-		skillDirs.map((skillDir) => scanDirectory(skillDir.path, skillDir.scope, logger)),
+	const candidateGroups = await Promise.all(
+		skillDirs.map((skillDir) => collectSkillCandidates(skillDir.path, skillDir.scope, logger)),
+	);
+	const candidates = deduplicateSkillCandidates(candidateGroups.flat(), logger);
+	const attempts = await Promise.all(
+		candidates.map((candidate) => tryLoadSkill(candidate.path, candidate.scope, logger)),
 	);
 
-	return mergeSkillLoadResults(results);
+	return createSkillLoadResult(candidates, attempts);
 }
 
-function mergeSkillLoadResults(results: readonly SkillLoadResult[]): SkillLoadResult {
+function createSkillLoadResult(
+	candidates: readonly SkillCandidate[],
+	attempts: readonly SkillLoadAttempt[],
+): SkillLoadResult {
 	const skills: Skill[] = [];
-	const failures = results.flatMap((result) => result.failures);
+	const failures: { path: string; error: string }[] = [];
 	const seen = new Set<string>();
 
-	for (const result of results) {
-		for (const skill of result.skills) {
-			if (seen.has(skill.metadata.name)) {
-				continue;
-			}
-			seen.add(skill.metadata.name);
-			skills.push(skill);
+	for (const [index, attempt] of attempts.entries()) {
+		if (attempt.type === "not_found") {
+			continue;
 		}
+
+		if (attempt.type === "error") {
+			failures.push({ path: candidates[index]?.path ?? "", error: attempt.error.message });
+			continue;
+		}
+
+		const skill = attempt.value;
+		if (seen.has(skill.metadata.name)) {
+			continue;
+		}
+
+		seen.add(skill.metadata.name);
+		skills.push(skill);
 	}
 
 	return { skills, failures };
@@ -151,15 +172,13 @@ function isWithinPath(path: string, boundary: string): boolean {
 	return relation === "" || (!relation.startsWith("..") && relation !== "..");
 }
 
-async function scanDirectory(
+async function collectSkillCandidates(
 	skillsDir: string,
 	scope: SkillScope,
 	logger?: SkillLogger,
-): Promise<SkillLoadResult> {
+): Promise<readonly SkillCandidate[]> {
 	const entries = await readdir(skillsDir, { withFileTypes: true }).catch(() => []);
-
-	const skills: Skill[] = [];
-	const failures: { path: string; error: string }[] = [];
+	const candidates: SkillCandidate[] = [];
 
 	// Node.js の readdir({ withFileTypes: true }) はシンボリックリンクを stat-follow しないため、
 	// symlink 先がディレクトリでも isDirectory() が false を返す。isSymbolicLink() を併用して
@@ -178,19 +197,46 @@ async function scanDirectory(
 			if (!isDir) continue;
 		}
 
-		const skillPath = join(skillsDir, entry.name, SKILL_FILE_NAME);
-		const result = await tryLoadSkill(skillPath, scope, logger);
-		if (result.type === "not_found") {
-			continue;
-		}
-		if (result.type === "found") {
-			skills.push(result.value);
-		} else {
-			failures.push({ path: skillPath, error: result.error.message });
-		}
+		candidates.push({ path: join(skillsDir, entry.name, SKILL_FILE_NAME), scope });
 	}
 
-	return { skills, failures };
+	return candidates;
+}
+
+function deduplicateSkillCandidates(
+	candidates: readonly SkillCandidate[],
+	logger?: SkillLogger,
+): readonly SkillCandidate[] {
+	const uniqueCandidates: SkillCandidate[] = [];
+	const seenCanonicalPaths = new Set<string>();
+
+	for (const candidate of candidates) {
+		const canonicalPath = getCanonicalPath(candidate.path);
+		if (canonicalPath === null) {
+			uniqueCandidates.push(candidate);
+			continue;
+		}
+
+		if (seenCanonicalPaths.has(canonicalPath)) {
+			logger?.debug?.(
+				`Skipping duplicate skill file: ${candidate.path} (canonical: ${canonicalPath})`,
+			);
+			continue;
+		}
+
+		seenCanonicalPaths.add(canonicalPath);
+		uniqueCandidates.push(candidate);
+	}
+
+	return uniqueCandidates;
+}
+
+function getCanonicalPath(path: string): string | null {
+	try {
+		return realpathSync(path);
+	} catch {
+		return null;
+	}
 }
 
 async function tryLoadSkill(

--- a/src/core/skill/skill.ts
+++ b/src/core/skill/skill.ts
@@ -12,6 +12,7 @@ import type { SkillMetadata } from "./skill-metadata";
 import { parseSkillMetadata } from "./skill-metadata";
 
 export type SkillLogger = {
+	readonly debug?: (message: string) => void;
 	readonly warn: (message: string) => void;
 };
 
@@ -28,7 +29,7 @@ export function parseSkill(
 	raw: string,
 	location: string,
 	scope?: SkillScope,
-	logger?: SkillLogger,
+	_logger?: SkillLogger,
 ): Result<Skill, ParseError> {
 	// gray-matter は不正な frontmatter に対して例外を投げるため、
 	// try-catch で捕捉して Result 型に変換する

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -1,7 +1,7 @@
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSkillLoader } from "../../src/adapter/skill-loader";
 
 function createSkillFile(baseDir: string, name: string, content: string): void {
@@ -158,6 +158,24 @@ describe("SkillLoader", () => {
 			expect(skills[0].metadata.description).toBe("ローカル版");
 		});
 
+		it("local と global が同じ SKILL.md を指す場合は discovery 順の先頭だけを残す", async () => {
+			createSkillFile(globalRoot, "shared-skill", makeSkillMd("shared-skill", "共有スキル"));
+
+			const localSkillsDir = join(localRoot, ".taskp", "skills");
+			mkdirSync(localSkillsDir, { recursive: true });
+			symlinkSync(
+				join(globalRoot, ".taskp", "skills", "shared-skill"),
+				join(localSkillsDir, "shared-skill"),
+			);
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills } = await loader.listAll();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("shared-skill");
+			expect(skills[0].scope).toBe("local");
+		});
+
 		it("スキルディレクトリが存在しない場合は空配列を返す", async () => {
 			const loader = createSkillLoader({ localRoot, globalRoot });
 
@@ -301,6 +319,30 @@ describe("SkillLoader", () => {
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("lint");
 		});
+
+		it("同じ SKILL.md を指すシンボリックリンクは listGlobal で重複排除する", async () => {
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+
+			const actualDir = join(skillsDir, "shared-skill");
+			mkdirSync(actualDir, { recursive: true });
+			writeFileSync(join(actualDir, "SKILL.md"), makeSkillMd("shared-skill", "共有スキル"));
+
+			symlinkSync(actualDir, join(skillsDir, "shared-skill-alias"));
+
+			const debug = vi.fn();
+			const loader = createSkillLoader({
+				localRoot,
+				globalRoot,
+				logger: { debug, warn: vi.fn() },
+			});
+
+			const { skills } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(1);
+			expect(skills[0].metadata.name).toBe("shared-skill");
+			expect(debug).toHaveBeenCalledWith(expect.stringContaining("Skipping duplicate skill file"));
+		});
 	});
 
 	describe("failures", () => {
@@ -402,6 +444,24 @@ describe("SkillLoader", () => {
 			expect(failures.some((failure) => failure.path.includes("broken-local"))).toBe(true);
 			expect(failures.some((failure) => failure.path.includes("broken-parent"))).toBe(true);
 			expect(failures.some((failure) => failure.path.includes("broken-global"))).toBe(true);
+		});
+
+		it("同じ壊れた SKILL.md を指すシンボリックリンクは failures でも重複排除する", async () => {
+			const skillsDir = join(globalRoot, ".taskp", "skills");
+			mkdirSync(skillsDir, { recursive: true });
+
+			const actualDir = join(skillsDir, "broken-shared");
+			mkdirSync(actualDir, { recursive: true });
+			writeFileSync(join(actualDir, "SKILL.md"), "---\ninvalid: :\n  bad: [\n---\n# Broken");
+
+			symlinkSync(actualDir, join(skillsDir, "broken-shared-alias"));
+
+			const loader = createSkillLoader({ localRoot, globalRoot });
+			const { skills, failures } = await loader.listGlobal();
+
+			expect(skills).toHaveLength(0);
+			expect(failures).toHaveLength(1);
+			expect(failures[0].path).toContain("broken-shared");
 		});
 
 		it("ホームディレクトリ配下でもグローバルスコープを二重に数えない", async () => {


### PR DESCRIPTION
## Summary
- deduplicate discovered skill candidates by canonical `SKILL.md` path before loading so shared files found through symlinks or multiple scopes only load once
- preserve existing discovery priority and name-based first-wins behavior after candidate deduplication, while also avoiding duplicated failure entries for the same broken shared file
- add regression coverage for global alias dedup, duplicate failure suppression, and cross-scope local/global alias handling

## Verification
- bun test tests/adapter/skill-loader.test.ts
- bun test tests/usecase/list-skills.test.ts
- bun run test
- bun run typecheck
- bun run build
- bun x biome check src/adapter/skill-loader.ts src/core/skill/skill.ts tests/adapter/skill-loader.test.ts