### PR TITLE
refactor: post-review improvements for issues 510/511/512

### DIFF
--- a/docs/specs/2026-03-20-tui-mode-design.md
+++ b/docs/specs/2026-03-20-tui-mode-design.md
@@ -382,7 +382,7 @@ async function executeSkill(
     await runAgentSkill(
       { name: skill.metadata.name, presets: variables, model },
       {
-        skillRepository: { findByName: async () => ok(skill), listAll: async () => [], listLocal: async () => [], listGlobal: async () => [] },
+        skillRepository: { findByName: async () => ok(skill), listAll: async () => [], listProject: async () => [], listGlobal: async () => [] },
         promptCollector,
         contextCollector,
         agentExecutor,
@@ -398,7 +398,7 @@ async function executeSkill(
     const result = await runSkill(
       { name: skill.metadata.name, presets: variables, dryRun: false, force: false },
       {
-        skillRepository: { findByName: async () => ok(skill), listAll: async () => [], listLocal: async () => [], listGlobal: async () => [] },
+        skillRepository: { findByName: async () => ok(skill), listAll: async () => [], listProject: async () => [], listGlobal: async () => [] },
         promptCollector,
         commandExecutor,
       },

--- a/docs/specs/2026-03-20-tui-mode-plan.md
+++ b/docs/specs/2026-03-20-tui-mode-plan.md
@@ -1125,7 +1125,7 @@ async function executeSkill(
         skillRepository: {
           findByName: async () => ok(skill),
           listAll: async () => [],
-          listLocal: async () => [],
+          listProject: async () => [],
           listGlobal: async () => [],
         },
         promptCollector: dummyPromptCollector,
@@ -1146,7 +1146,7 @@ async function executeSkill(
         skillRepository: {
           findByName: async () => ok(skill),
           listAll: async () => [],
-          listLocal: async () => [],
+          listProject: async () => [],
           listGlobal: async () => [],
         },
         promptCollector: dummyPromptCollector,

--- a/src/adapter/skill-loader.ts
+++ b/src/adapter/skill-loader.ts
@@ -43,10 +43,20 @@ export function createSkillLoader(deps: SkillLoaderDeps): SkillRepository {
 	const globalSkillDir = createGlobalSkillDir(canonicalGlobalRoot);
 
 	const { logger } = deps;
+
+	// listAll はエージェントモード実行中に複数回呼ばれるため、
+	// 同一インスタンス内ではキャッシュして I/O を節約する
+	let listAllCache: Promise<SkillLoadResult> | undefined;
+
 	return {
 		findByName: (name) => findByName(name, [...projectSkillDirs, globalSkillDir], logger),
-		listAll: () => loadFromDirectories([...projectSkillDirs, globalSkillDir], logger),
-		listLocal: () => loadFromDirectories(projectSkillDirs, logger),
+		listAll: () => {
+			if (listAllCache === undefined) {
+				listAllCache = loadFromDirectories([...projectSkillDirs, globalSkillDir], logger);
+			}
+			return listAllCache;
+		},
+		listProject: () => loadFromDirectories(projectSkillDirs, logger),
 		listGlobal: () => loadFromDirectories([globalSkillDir], logger),
 	};
 }

--- a/src/adapter/skill-mcp-server.ts
+++ b/src/adapter/skill-mcp-server.ts
@@ -4,6 +4,7 @@ import type { Skill } from "../core/skill/skill";
 import type {
 	DescriptionBudgetOptions,
 	DescriptionEntry,
+	FormattedEntry,
 } from "../core/skill/skill-description-budget";
 import { formatDescriptionEntriesWithinBudget } from "../core/skill/skill-description-budget";
 import type { SkillInput } from "../core/skill/skill-input";
@@ -126,20 +127,7 @@ function budgetSkillDescriptions(
 	readonly omittedEntryCount: number;
 } {
 	const result = formatDescriptionEntriesWithinBudget(entries, budgetOptions);
-	const lines = result.text === "" ? [] : result.text.split("\n");
-	const descriptions = new Map<string, string | undefined>();
-
-	for (const entry of entries) {
-		const prefix = `${entry.label}: `;
-		const line = lines.find(
-			(candidate) => candidate === entry.label || candidate.startsWith(prefix),
-		);
-		if (line === undefined || line === entry.label) {
-			descriptions.set(entry.label, undefined);
-			continue;
-		}
-		descriptions.set(entry.label, line.slice(prefix.length));
-	}
+	const descriptions = buildDescriptionMap(entries, result.entries);
 
 	return {
 		descriptions,
@@ -147,6 +135,23 @@ function budgetSkillDescriptions(
 		truncatedEntryCount: result.truncatedEntryCount,
 		omittedEntryCount: result.omittedEntryCount,
 	};
+}
+
+function buildDescriptionMap(
+	original: readonly DescriptionEntry[],
+	formatted: readonly FormattedEntry[],
+): ReadonlyMap<string, string | undefined> {
+	const formattedByLabel = new Map<string, FormattedEntry>();
+	for (const entry of formatted) {
+		formattedByLabel.set(entry.label, entry);
+	}
+
+	const descriptions = new Map<string, string | undefined>();
+	for (const entry of original) {
+		const matched = formattedByLabel.get(entry.label);
+		descriptions.set(entry.label, matched?.description);
+	}
+	return descriptions;
 }
 
 function assertUniqueToolNames(tools: readonly RawSkillMcpTool[]): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { homedir } from "node:os";
-import { dirname, relative } from "node:path";
 import { Writable } from "node:stream";
 import { Cli, z } from "incur";
 import { createAgentExecutor } from "./adapter/agent-executor";
@@ -25,6 +24,7 @@ import { createSystemPromptResolver } from "./adapter/system-prompt-resolver";
 import type { Action } from "./core/skill/action";
 import { resolveActionConfig } from "./core/skill/action";
 import type { ContextSource } from "./core/skill/context-source";
+import { formatSkillSource } from "./core/skill/format-skill-source";
 import type { SkillScope } from "./core/skill/skill";
 import {
 	DEFAULT_MAX_SKILL_DESCRIPTION_CHARS,
@@ -44,6 +44,7 @@ import type { SetupOutput } from "./usecase/setup-project";
 import { setupProject } from "./usecase/setup-project";
 import type { ShowOutput } from "./usecase/show-skill";
 import { showSkill } from "./usecase/show-skill";
+import { VERSION } from "./version";
 
 // --set key=value 形式の引数を Record に変換する。
 // "=" を含む値をサポートするため、最初の "=" のみで分割する
@@ -149,7 +150,7 @@ function unwrapOrThrow<T>(result: Result<T, DomainError>): T {
 }
 
 const cli = Cli.create("taskp", {
-	version: "0.1.14",
+	version: VERSION,
 	description:
 		"Markdown-defined skill runner with interactive argument collection and LLM execution",
 })
@@ -361,6 +362,37 @@ const cli = Cli.create("taskp", {
 		},
 	});
 
+async function buildSharedInfra(verbose: boolean) {
+	const configLoader = createDefaultConfigLoader(process.cwd());
+	const config = exitOnError(await configLoader.load());
+	const logger = createConsoleLogger({ verbose });
+	const commandExecutor = createCommandRunner({
+		defaultTimeoutMs: config.cli?.command_timeout_ms,
+	});
+	const hookExecutor = createHookExecutor(commandExecutor, logger);
+	const outputFileStore = createOutputFileStore();
+	const systemPromptResolver = createSystemPromptResolver(process.cwd());
+	const contextCollectorDeps = await createDefaultContextCollectorDeps();
+	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
+	const mcpToolResolver = config.mcp?.servers
+		? (await import("./adapter/mcp-tool-resolver")).createMcpToolResolver(
+				config.mcp.servers,
+				logger,
+			)
+		: undefined;
+
+	return {
+		config,
+		logger,
+		commandExecutor,
+		hookExecutor,
+		outputFileStore,
+		contextCollector,
+		systemPromptResolver,
+		mcpToolResolver,
+	};
+}
+
 type RunCommandContext = {
 	readonly args: { readonly skill: string; readonly action?: string };
 	readonly options: {
@@ -376,8 +408,17 @@ async function runAgentMode(
 	skillRepository: Awaited<ReturnType<typeof createDefaultSkillLoader>>,
 	promptCollector: ReturnType<typeof createPromptRunner>,
 ): Promise<void> {
-	const configLoader = createDefaultConfigLoader(process.cwd());
-	const config = exitOnError(await configLoader.load());
+	const infra = await buildSharedInfra(c.options.verbose ?? false);
+	const {
+		config,
+		logger,
+		commandExecutor,
+		hookExecutor,
+		outputFileStore,
+		contextCollector,
+		systemPromptResolver,
+		mcpToolResolver,
+	} = infra;
 
 	const aiConfig = config.ai ?? {};
 	const modelSpec = exitOnError(
@@ -399,24 +440,7 @@ async function runAgentMode(
 
 	writer.writeHeader();
 
-	const logger = createConsoleLogger({ verbose: c.options.verbose ?? false });
-	const contextCollectorDeps = await createDefaultContextCollectorDeps();
-	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
 	const agentExecutor = createAgentExecutor(writer, logger);
-
-	const commandExecutor = createCommandRunner({
-		defaultTimeoutMs: config.cli?.command_timeout_ms,
-	});
-	const hookExecutor = createHookExecutor(commandExecutor, logger);
-	const hooksConfig = config.hooks;
-	const outputFileStore = createOutputFileStore();
-
-	const mcpToolResolver = config.mcp?.servers
-		? (await import("./adapter/mcp-tool-resolver")).createMcpToolResolver(
-				config.mcp.servers,
-				logger,
-			)
-		: undefined;
 
 	const result = await runAgentSkill(
 		{
@@ -433,11 +457,11 @@ async function runAgentMode(
 			promptCollector,
 			contextCollector,
 			agentExecutor,
-			systemPromptResolver: createSystemPromptResolver(process.cwd()),
+			systemPromptResolver,
 			commandExecutor,
 			progressWriter: createCliProgressWriter(process.stdout),
 			hookExecutor,
-			hooksConfig,
+			hooksConfig: config.hooks,
 			mcpToolResolver,
 			outputFileStore,
 			logger,
@@ -452,9 +476,18 @@ async function runAgentMode(
 }
 
 async function runServeMode(verbose: boolean): Promise<void> {
-	const configLoader = createDefaultConfigLoader(process.cwd());
-	const config = exitOnError(await configLoader.load());
-	const logger = createConsoleLogger({ verbose });
+	const infra = await buildSharedInfra(verbose);
+	const {
+		config,
+		logger,
+		commandExecutor,
+		hookExecutor,
+		outputFileStore,
+		contextCollector,
+		systemPromptResolver,
+		mcpToolResolver,
+	} = infra;
+
 	const skillRepository = await createDefaultSkillLoader(process.cwd());
 	const { skills, failures } = await skillRepository.listAll();
 	for (const failure of failures) {
@@ -473,23 +506,9 @@ async function runServeMode(verbose: boolean): Promise<void> {
 			`[skills] Budget exceeded for MCP descriptions. Truncated ${toolBudgetResult.truncatedEntryCount} entries and omitted ${toolBudgetResult.omittedEntryCount} entries (phase ${toolBudgetResult.phase})`,
 		);
 	}
-	const commandExecutor = createCommandRunner({
-		defaultTimeoutMs: config.cli?.command_timeout_ms,
-	});
-	const hookExecutor = createHookExecutor(commandExecutor, logger);
-	const outputFileStore = createOutputFileStore();
-	const systemPromptResolver = createSystemPromptResolver(process.cwd());
-	const contextCollectorDeps = await createDefaultContextCollectorDeps();
-	const contextCollector = createContextCollector({ ...contextCollectorDeps, logger });
-	const mcpToolResolver = config.mcp?.servers
-		? (await import("./adapter/mcp-tool-resolver")).createMcpToolResolver(
-				config.mcp.servers,
-				logger,
-			)
-		: undefined;
 
 	const skillMcpCli = createSkillMcpCli({
-		version: "0.1.14",
+		version: VERSION,
 		skills,
 		budgetOptions,
 		executeSkill: async ({ skillName, actionName, presets }) => {
@@ -618,22 +637,6 @@ function printSkillTable(
 			console.log(`  Actions: ${actionsLabel}`);
 		}
 	}
-}
-
-function formatSkillSource(location: string): string {
-	const skillDir = dirname(location);
-	const home = homedir();
-
-	if (skillDir === home || skillDir.startsWith(`${home}/`)) {
-		return `~${skillDir.slice(home.length)}`;
-	}
-
-	const relativePath = relative(process.cwd(), skillDir);
-	if (relativePath === "") {
-		return ".";
-	}
-
-	return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }
 
 function formatActionsLabel(actions: Record<string, Action> | undefined): string | undefined {

--- a/src/core/execution/tools/taskp-run-tool.ts
+++ b/src/core/execution/tools/taskp-run-tool.ts
@@ -15,6 +15,7 @@ import {
 	type DescriptionBudgetOptions,
 	type DescriptionBudgetResult,
 	type DescriptionEntry,
+	type FormattedEntry,
 	formatDescriptionEntriesWithinBudget,
 } from "../../skill/skill-description-budget";
 import { parseSkillRef } from "../../skill/skill-ref";
@@ -187,6 +188,7 @@ export function buildTaskpRunDescriptionResult(
 			: TASKP_RUN_BASE_DESCRIPTION;
 		return {
 			text: baseText,
+			entries: [],
 			phase: budgetOptions ? 4 : 1,
 			truncatedEntryCount: budgetOptions ? entries.length : 0,
 			omittedEntryCount: budgetOptions ? entries.length : 0,
@@ -195,6 +197,7 @@ export function buildTaskpRunDescriptionResult(
 
 	return {
 		text: `${TASKP_RUN_BASE_DESCRIPTION}\n\nAvailable skills:\n${formatted.lines.join("\n")}`,
+		entries: formatted.entries,
 		phase: formatted.phase,
 		truncatedEntryCount: formatted.truncatedEntryCount,
 		omittedEntryCount: formatted.omittedEntryCount,
@@ -258,6 +261,7 @@ function formatLines(
 	baseLength = 0,
 ): {
 	readonly lines: readonly string[];
+	readonly entries: readonly FormattedEntry[];
 	readonly phase: 1 | 2 | 3 | 4;
 	readonly truncatedEntryCount: number;
 	readonly omittedEntryCount: number;
@@ -265,6 +269,7 @@ function formatLines(
 	if (budgetOptions === undefined) {
 		return {
 			lines: entries.map((entry) => `${entry.label}: ${entry.description}`),
+			entries: entries.map((entry) => ({ label: entry.label, description: entry.description })),
 			phase: 1,
 			truncatedEntryCount: 0,
 			omittedEntryCount: 0,
@@ -274,6 +279,7 @@ function formatLines(
 	if (budgetOptions.budgetChars <= baseLength) {
 		return {
 			lines: [],
+			entries: [],
 			phase: 4,
 			truncatedEntryCount: entries.length,
 			omittedEntryCount: entries.length,
@@ -286,6 +292,7 @@ function formatLines(
 	});
 	return {
 		lines: result.text === "" ? [] : result.text.split("\n"),
+		entries: result.entries,
 		phase: result.phase,
 		truncatedEntryCount: result.truncatedEntryCount,
 		omittedEntryCount: result.omittedEntryCount,

--- a/src/core/skill/format-skill-source.ts
+++ b/src/core/skill/format-skill-source.ts
@@ -1,0 +1,22 @@
+import { homedir } from "node:os";
+import { dirname, relative } from "node:path";
+
+/**
+ * スキルファイルの location パスを、ホームディレクトリ相対（~/...）または
+ * cwd 相対（./...）の表示用文字列に変換する。
+ */
+export function formatSkillSource(location: string, cwd = process.cwd()): string {
+	const skillDir = dirname(location);
+	const home = homedir();
+
+	if (skillDir === home || skillDir.startsWith(`${home}/`)) {
+		return `~${skillDir.slice(home.length)}`;
+	}
+
+	const relativePath = relative(cwd, skillDir);
+	if (relativePath === "") {
+		return ".";
+	}
+
+	return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+}

--- a/src/core/skill/skill-description-budget.ts
+++ b/src/core/skill/skill-description-budget.ts
@@ -10,8 +10,14 @@ export type DescriptionBudgetOptions = {
 	readonly minDescriptionChars?: number;
 };
 
+export type FormattedEntry = {
+	readonly label: string;
+	readonly description?: string;
+};
+
 export type DescriptionBudgetResult = {
 	readonly text: string;
+	readonly entries: readonly FormattedEntry[];
 	readonly phase: 1 | 2 | 3 | 4;
 	readonly truncatedEntryCount: number;
 	readonly omittedEntryCount: number;
@@ -40,6 +46,7 @@ export function formatDescriptionEntriesWithinBudget(
 	if (fullText.length <= options.budgetChars) {
 		return {
 			text: fullText,
+			entries: toFormattedEntries(prepared, "full"),
 			phase: 1,
 			truncatedEntryCount: initiallyTruncated,
 			omittedEntryCount: 0,
@@ -48,20 +55,24 @@ export function formatDescriptionEntriesWithinBudget(
 
 	const phase2 = formatPhase2(prepared, options);
 	if (phase2 !== undefined) {
+		const phase2Entries = parseFormattedEntries(prepared, phase2);
 		return {
 			text: phase2,
+			entries: toFormattedEntries(phase2Entries, "full"),
 			phase: 2,
-			truncatedEntryCount: countChanged(entries, parseFormattedEntries(prepared, phase2)),
+			truncatedEntryCount: countChanged(entries, phase2Entries),
 			omittedEntryCount: 0,
 		};
 	}
 
 	const phase3 = formatPhase3(prepared, options);
 	if (phase3 !== undefined) {
+		const phase3Entries = parseFormattedEntries(prepared, phase3);
 		return {
 			text: phase3,
+			entries: toFormattedEntries(phase3Entries, "full"),
 			phase: 3,
-			truncatedEntryCount: countChanged(entries, parseFormattedEntries(prepared, phase3)),
+			truncatedEntryCount: countChanged(entries, phase3Entries),
 			omittedEntryCount: 0,
 		};
 	}
@@ -70,6 +81,7 @@ export function formatDescriptionEntriesWithinBudget(
 
 	return {
 		text: formatEntries(labelOnly.entries, "label-only"),
+		entries: toFormattedEntries(labelOnly.entries, "label-only"),
 		phase: 4,
 		truncatedEntryCount: prepared.length,
 		omittedEntryCount: prepared.length - labelOnly.entries.length,
@@ -213,6 +225,16 @@ function countChanged(
 		}
 	}
 	return changed;
+}
+
+function toFormattedEntries(
+	entries: readonly PreparedEntry[],
+	mode: "full" | "label-only",
+): readonly FormattedEntry[] {
+	return entries.map((entry) => ({
+		label: entry.label,
+		description: mode === "full" ? entry.description : undefined,
+	}));
 }
 
 function parseFormattedEntries(

--- a/src/tui/screens/execution-runner.ts
+++ b/src/tui/screens/execution-runner.ts
@@ -84,7 +84,7 @@ export function createSingleSkillRepository(skill: Skill): SkillRepository {
 	return {
 		findByName: async () => ok(skill),
 		listAll: async () => ({ skills: [], failures: [] }),
-		listLocal: async () => ({ skills: [], failures: [] }),
+		listProject: async () => ({ skills: [], failures: [] }),
 		listGlobal: async () => ({ skills: [], failures: [] }),
 	};
 }

--- a/src/tui/screens/skill-selector.ts
+++ b/src/tui/screens/skill-selector.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-import { dirname, relative } from "node:path";
 import {
 	BoxRenderable,
 	type CliRenderer,
@@ -10,6 +8,7 @@ import {
 	SelectRenderable,
 	SelectRenderableEvents,
 } from "@opentui/core";
+import { formatSkillSource } from "../../core/skill/format-skill-source";
 import type { Skill } from "../../core/skill/skill";
 import {
 	buildSkillOptionsWithActions,
@@ -172,22 +171,6 @@ export async function showSkillSelector(
 
 		searchInput.focus();
 	});
-}
-
-function formatSkillSource(location: string): string {
-	const skillDir = dirname(location);
-	const home = homedir();
-
-	if (skillDir === home || skillDir.startsWith(`${home}/`)) {
-		return `~${skillDir.slice(home.length)}`;
-	}
-
-	const relativePath = relative(process.cwd(), skillDir);
-	if (relativePath === "") {
-		return ".";
-	}
-
-	return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 }
 
 function getExpandIndicator(

--- a/src/usecase/list-skills.ts
+++ b/src/usecase/list-skills.ts
@@ -34,7 +34,7 @@ async function fetchByScope(
 ): Promise<SkillLoadResult> {
 	switch (scope) {
 		case "project":
-			return repository.listLocal();
+			return repository.listProject();
 		case "global":
 			return repository.listGlobal();
 		default:

--- a/src/usecase/port/skill-repository.ts
+++ b/src/usecase/port/skill-repository.ts
@@ -15,6 +15,6 @@ export type SkillLoadResult = {
 export type SkillRepository = {
 	readonly findByName: (name: string) => Promise<Result<Skill, SkillNotFoundError>>;
 	readonly listAll: () => Promise<SkillLoadResult>;
-	readonly listLocal: () => Promise<SkillLoadResult>;
+	readonly listProject: () => Promise<SkillLoadResult>;
 	readonly listGlobal: () => Promise<SkillLoadResult>;
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "0.1.14";

--- a/tests/adapter/skill-loader.test.ts
+++ b/tests/adapter/skill-loader.test.ts
@@ -269,13 +269,13 @@ describe("SkillLoader", () => {
 		});
 	});
 
-	describe("listLocal", () => {
+	describe("listProject", () => {
 		it("ローカルスキルのみリストする", async () => {
 			createSkillFile(localRoot, "deploy", makeSkillMd("deploy", "デプロイ"));
 			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "リント"));
 			const loader = createSkillLoader({ localRoot, globalRoot });
 
-			const { skills } = await loader.listLocal();
+			const { skills } = await loader.listProject();
 
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("deploy");
@@ -299,7 +299,7 @@ describe("SkillLoader", () => {
 			createSkillFile(globalRoot, "lint", makeSkillMd("lint", "グローバル版"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills } = await loader.listLocal();
+			const { skills } = await loader.listProject();
 
 			expect(skills.map((skill) => [skill.metadata.name, skill.scope])).toEqual([
 				["deploy", "parent"],
@@ -376,7 +376,7 @@ describe("SkillLoader", () => {
 			chmodSync(filePath, 0o000);
 			const loader = createSkillLoader({ localRoot, globalRoot });
 
-			const { skills, failures } = await loader.listLocal();
+			const { skills, failures } = await loader.listProject();
 
 			chmodSync(filePath, 0o644);
 			expect(skills).toHaveLength(0);
@@ -406,11 +406,11 @@ describe("SkillLoader", () => {
 			expect(failures.some((f) => f.path.includes("broken-global"))).toBe(true);
 		});
 
-		it("listLocal で failures を返す", async () => {
+		it("listProject で failures を返す", async () => {
 			createSkillFile(localRoot, "broken", "---\nbad: [\n---\n# Broken");
 			const loader = createSkillLoader({ localRoot, globalRoot });
 
-			const { failures } = await loader.listLocal();
+			const { failures } = await loader.listProject();
 
 			expect(failures).toHaveLength(1);
 		});
@@ -500,7 +500,7 @@ describe("SkillLoader", () => {
 			symlinkSync(actualDir, join(skillsDir, "my-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills } = await loader.listLocal();
+			const { skills } = await loader.listProject();
 
 			const mySkill = skills.find((s) => s.metadata.name === "my-skill");
 			expect(mySkill).toBeDefined();
@@ -554,7 +554,7 @@ describe("SkillLoader", () => {
 			symlinkSync("/nonexistent/path/to/skill", join(skillsDir, "broken-link"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills, failures } = await loader.listLocal();
+			const { skills, failures } = await loader.listProject();
 
 			expect(skills).toHaveLength(0);
 			expect(failures).toHaveLength(0);
@@ -606,7 +606,7 @@ describe("SkillLoader", () => {
 			symlinkSync(externalSkillDir, join(skillsDir, "external-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills, failures } = await loader.listLocal();
+			const { skills, failures } = await loader.listProject();
 
 			expect(skills).toHaveLength(1);
 			expect(skills[0].metadata.name).toBe("external-skill");
@@ -629,7 +629,7 @@ describe("SkillLoader", () => {
 			createSkillFile(localRoot, "valid-skill", makeSkillMd("valid-skill", "正常スキル"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills, failures } = await loader.listLocal();
+			const { skills, failures } = await loader.listProject();
 
 			expect(skills).toHaveLength(2);
 			const names = skills.map((s) => s.metadata.name);
@@ -695,7 +695,7 @@ describe("SkillLoader", () => {
 			symlinkSync(innerDir, join(skillsDir, "inner-skill"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills } = await loader.listLocal();
+			const { skills } = await loader.listProject();
 
 			const innerSkill = skills.find((s) => s.metadata.name === "inner-skill");
 			expect(innerSkill).toBeDefined();
@@ -712,10 +712,56 @@ describe("SkillLoader", () => {
 			symlinkSync(externalFile, join(skillsDir, "file-link"));
 
 			const loader = createSkillLoader({ localRoot, globalRoot });
-			const { skills, failures } = await loader.listLocal();
+			const { skills, failures } = await loader.listProject();
 
 			expect(skills).toHaveLength(0);
 			expect(failures).toHaveLength(0);
+		});
+	});
+
+	describe("localRoot equals globalRoot", () => {
+		it("listProject returns empty when localRoot equals globalRoot", async () => {
+			createSkillFile(globalRoot, "home-skill", makeSkillMd("home-skill", "Home skill"));
+			const loader = createSkillLoader({ localRoot: globalRoot, globalRoot });
+
+			const projectResult = await loader.listProject();
+			expect(projectResult.skills).toHaveLength(0);
+
+			const allResult = await loader.listAll();
+			expect(allResult.skills).toHaveLength(1);
+			expect(allResult.skills[0]?.scope).toBe("global");
+		});
+	});
+
+	describe("multi-scope symlink dedup", () => {
+		it("deduplicates when parent and local both symlink to the same global skill", async () => {
+			// Create nested: globalRoot/projects/team/app (localRoot = app)
+			const teamDir = join(globalRoot, "projects", "team");
+			const appDir = join(teamDir, "app");
+			mkdirSync(appDir, { recursive: true });
+
+			// Global has the real skill
+			createSkillFile(globalRoot, "shared", makeSkillMd("shared", "Shared skill"));
+			const globalSkillDir = join(globalRoot, ".taskp", "skills", "shared");
+
+			// Team-level (parent) symlinks to global skill
+			const teamSkillsDir = join(teamDir, ".taskp", "skills");
+			mkdirSync(teamSkillsDir, { recursive: true });
+			symlinkSync(globalSkillDir, join(teamSkillsDir, "shared"));
+
+			// App-level (local) also symlinks to same global skill
+			const appSkillsDir = join(appDir, ".taskp", "skills");
+			mkdirSync(appSkillsDir, { recursive: true });
+			symlinkSync(globalSkillDir, join(appSkillsDir, "shared"));
+
+			const loader = createSkillLoader({ localRoot: appDir, globalRoot });
+			const { skills } = await loader.listAll();
+
+			// Should have only one "shared" skill (deduplicated)
+			const sharedSkills = skills.filter((s) => s.metadata.name === "shared");
+			expect(sharedSkills).toHaveLength(1);
+			// Local scope wins (first discovered)
+			expect(sharedSkills[0]?.scope).toBe("local");
 		});
 	});
 });

--- a/tests/adapter/skill-mcp-server.test.ts
+++ b/tests/adapter/skill-mcp-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildSkillMcpTools, createSkillMcpCli } from "../../src/adapter/skill-mcp-server";
+import {
+	buildSkillMcpTools,
+	buildSkillMcpToolsResult,
+	createSkillMcpCli,
+} from "../../src/adapter/skill-mcp-server";
 import type { Skill } from "../../src/core/skill/skill";
 
 function createSkill(
@@ -120,6 +124,71 @@ describe("buildSkillMcpTools", () => {
 				{ budgetChars: 200, maxDescriptionChars: 80 },
 			),
 		).toThrow("Duplicate MCP tool name after normalization");
+	});
+
+	it("returns phase and count metadata from buildSkillMcpToolsResult", () => {
+		const result = buildSkillMcpToolsResult(
+			[
+				createSkill({ name: "deploy", description: "Deploy app with very long description text" }),
+				createSkill({ name: "release", description: "Release with another very long description" }),
+			],
+			{ budgetChars: 20, maxDescriptionChars: 40, minDescriptionChars: 12 },
+		);
+
+		expect(result.phase).toBeGreaterThanOrEqual(2);
+		expect(result.tools).toHaveLength(2);
+		expect(typeof result.truncatedEntryCount).toBe("number");
+		expect(typeof result.omittedEntryCount).toBe("number");
+	});
+
+	it("maps number, confirm, and select input types to correct schemas", async () => {
+		const cli = createSkillMcpCli({
+			version: "0.1.14",
+			skills: [
+				createSkill({
+					name: "typed-skill",
+					description: "Test types",
+					inputs: [
+						{ name: "count", type: "number", message: "How many?" },
+						{ name: "confirm", type: "confirm", message: "Are you sure?" },
+						{
+							name: "env",
+							type: "select",
+							message: "Environment",
+							choices: ["dev", "staging", "prod"],
+						},
+						{ name: "name", type: "text", message: "Name" },
+					],
+				}),
+			],
+			budgetOptions: { budgetChars: 500, maxDescriptionChars: 80 },
+			executeSkill: vi.fn().mockResolvedValue({ ok: true }),
+		});
+
+		const sessionId = await initSession(cli);
+		const res = await mcpRequest(
+			cli,
+			{ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} },
+			sessionId,
+		);
+		const body = (await res.json()) as {
+			result: {
+				tools: Array<{
+					name: string;
+					inputSchema: {
+						properties: Record<string, { type?: string; enum?: string[]; description?: string }>;
+					};
+				}>;
+			};
+		};
+		const tool = body.result.tools[0];
+		expect(tool).toBeDefined();
+
+		const props = tool?.inputSchema?.properties ?? {};
+		expect(props.count?.description).toBe("How many?");
+		expect(props.confirm?.description).toBe("Are you sure?");
+		expect(props.env?.enum).toEqual(["dev", "staging", "prod"]);
+		expect(props.name?.description).toBe("Name");
 	});
 });
 

--- a/tests/core/skill/format-skill-source.test.ts
+++ b/tests/core/skill/format-skill-source.test.ts
@@ -1,0 +1,32 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { formatSkillSource } from "../../../src/core/skill/format-skill-source";
+
+describe("formatSkillSource", () => {
+	const home = homedir();
+
+	it("returns home-relative path for skills under home directory", () => {
+		const location = join(home, ".taskp", "skills", "deploy", "SKILL.md");
+		expect(formatSkillSource(location)).toBe("~/.taskp/skills/deploy");
+	});
+
+	it("returns cwd-relative path for project skills", () => {
+		const cwd = "/tmp/my-project";
+		const location = "/tmp/my-project/.taskp/skills/test/SKILL.md";
+		expect(formatSkillSource(location, cwd)).toBe(".taskp/skills/test");
+	});
+
+	it("returns dot for skill dir equal to cwd", () => {
+		const cwd = "/tmp/project";
+		const location = "/tmp/project/SKILL.md";
+		expect(formatSkillSource(location, cwd)).toBe(".");
+	});
+
+	it("returns parent-relative path when skill is above cwd", () => {
+		const cwd = "/tmp/project/src";
+		const location = "/tmp/project/.taskp/skills/deploy/SKILL.md";
+		const result = formatSkillSource(location, cwd);
+		expect(result).toBe("../.taskp/skills/deploy");
+	});
+});

--- a/tests/core/skill/skill-description-budget.test.ts
+++ b/tests/core/skill/skill-description-budget.test.ts
@@ -93,6 +93,19 @@ describe("formatDescriptionEntriesWithinBudget", () => {
 		expect(result.phase).toBe(4);
 		expect(result.text).toBe("- very-long-skill-name");
 	});
+
+	it("skips phase 2 when all entries are protected", () => {
+		const result = formatDescriptionEntriesWithinBudget(
+			[
+				createEntry("- alpha", "Alpha description is very long", true),
+				createEntry("- beta", "Beta description is also very long", true),
+			],
+			{ budgetChars: 35, maxDescriptionChars: 80, minDescriptionChars: 12 },
+		);
+
+		// Phase 2 cannot reduce protected entries, so it falls to phase 3
+		expect(result.phase).toBeGreaterThanOrEqual(3);
+	});
 });
 
 describe("deriveAgentSkillDescriptionBudget", () => {

--- a/tests/stubs/in-memory-skill-repository.ts
+++ b/tests/stubs/in-memory-skill-repository.ts
@@ -14,7 +14,7 @@ export function createInMemorySkillRepository(skills: readonly Skill[]): SkillRe
 			return found ? ok(found) : err(skillNotFoundError(name));
 		},
 		listAll: async (): Promise<SkillLoadResult> => ({ skills: [...store], failures: [] }),
-		listLocal: async (): Promise<SkillLoadResult> => ({
+		listProject: async (): Promise<SkillLoadResult> => ({
 			skills: store.filter((s) => s.scope === "local"),
 			failures: [],
 		}),

--- a/tests/stubs/stubs.test.ts
+++ b/tests/stubs/stubs.test.ts
@@ -46,14 +46,14 @@ describe("InMemorySkillRepository", () => {
 		expect(result.failures).toHaveLength(0);
 	});
 
-	it("listLocal/listGlobal filters by scope", async () => {
+	it("listProject/listGlobal filters by scope", async () => {
 		const skills = [
 			makeSkill({ name: "local-one", scope: "local" }),
 			makeSkill({ name: "global-one", scope: "global" }),
 		];
 		const repo = createInMemorySkillRepository(skills);
 
-		const localResult = await repo.listLocal();
+		const localResult = await repo.listProject();
 		const globalResult = await repo.listGlobal();
 		expect(localResult.skills).toHaveLength(1);
 		expect(globalResult.skills).toHaveLength(1);

--- a/tests/tui/screens/execution-view.test.ts
+++ b/tests/tui/screens/execution-view.test.ts
@@ -112,7 +112,7 @@ describe("createSingleSkillRepository", () => {
 		const skill = createSkill("test", "template");
 		const repo = createSingleSkillRepository(skill);
 		expect(await repo.listAll()).toEqual({ skills: [], failures: [] });
-		expect(await repo.listLocal()).toEqual({ skills: [], failures: [] });
+		expect(await repo.listProject()).toEqual({ skills: [], failures: [] });
 		expect(await repo.listGlobal()).toEqual({ skills: [], failures: [] });
 	});
 });

--- a/tests/usecase/init-skill.test.ts
+++ b/tests/usecase/init-skill.test.ts
@@ -10,7 +10,7 @@ function stubRepository(skills: Skill[] = []): SkillRepository {
 	return {
 		findByName: () => Promise.resolve(err({ type: ErrorType.SkillNotFound, name: "" })),
 		listAll: () => Promise.resolve({ skills, failures: [] }),
-		listLocal: () => Promise.resolve({ skills: [], failures: [] }),
+		listProject: () => Promise.resolve({ skills: [], failures: [] }),
 		listGlobal: () => Promise.resolve({ skills: [], failures: [] }),
 	};
 }

--- a/tests/usecase/list-skills.test.ts
+++ b/tests/usecase/list-skills.test.ts
@@ -37,7 +37,7 @@ function createInMemoryRepository(skills: readonly Skill[]): SkillRepository {
 			return found ? ok(found) : err(skillNotFoundError(name));
 		},
 		listAll: async () => ({ skills: [...skills], failures: [] }),
-		listLocal: async () => ({
+		listProject: async () => ({
 			skills: skills.filter((s) => s.scope !== "global"),
 			failures: [],
 		}),

--- a/tests/usecase/run-agent-skill.test.ts
+++ b/tests/usecase/run-agent-skill.test.ts
@@ -51,7 +51,7 @@ function createMockDeps(skill: Skill) {
 	const skillRepository: SkillRepository = {
 		findByName: vi.fn().mockResolvedValue(ok(skill)),
 		listAll: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
-		listLocal: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
+		listProject: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
 		listGlobal: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
 	};
 
@@ -353,7 +353,7 @@ describe("runAgentSkill", () => {
 						error: { type: "SKILL_NOT_FOUND", name: "missing" },
 					}),
 					listAll: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
-					listLocal: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
+					listProject: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
 					listGlobal: vi.fn().mockResolvedValue({ skills: [], failures: [] }),
 				},
 			},

--- a/tests/usecase/run-skill.test.ts
+++ b/tests/usecase/run-skill.test.ts
@@ -72,7 +72,7 @@ function stubRepository(skill?: Skill): SkillRepository {
 	return {
 		findByName: async (name: string) => (skill ? ok(skill) : err(skillNotFoundError(name))),
 		listAll: async () => ({ skills: skill ? [skill] : [], failures: [] }),
-		listLocal: async () => ({ skills: [], failures: [] }),
+		listProject: async () => ({ skills: [], failures: [] }),
 		listGlobal: async () => ({ skills: skill ? [skill] : [], failures: [] }),
 	};
 }

--- a/tests/usecase/show-skill.test.ts
+++ b/tests/usecase/show-skill.test.ts
@@ -58,7 +58,7 @@ function createRepository(skills: readonly Skill[]): SkillRepository {
 			return found ? ok(found) : err(skillNotFoundError(name));
 		},
 		listAll: async () => ({ skills: [...skills], failures: [] }),
-		listLocal: async () => ({ skills: skills.filter((s) => s.scope === "local"), failures: [] }),
+		listProject: async () => ({ skills: skills.filter((s) => s.scope === "local"), failures: [] }),
 		listGlobal: async () => ({ skills: skills.filter((s) => s.scope === "global"), failures: [] }),
 	};
 }


### PR DESCRIPTION
## Summary
- Extract duplicated `formatSkillSource` to `src/core/skill/format-skill-source.ts`
- Return structured `entries` from budget algorithm (eliminate fragile text re-parsing in MCP server)
- Rename `listLocal` → `listProject` in `SkillRepository` port to match actual semantics (local + parent)
- Extract version string `"0.1.14"` to `src/version.ts` single constant
- Extract shared dependency setup (`buildSharedInfra`) in `cli.ts` to reduce duplication between `runAgentMode` and `runServeMode`
- Add `listAll` memo cache to `SkillRepository` for reduced filesystem I/O during agent execution
- Add 9 new tests covering: `formatSkillSource`, `localRoot === globalRoot`, multi-scope symlink dedup, `buildSkillMcpToolsResult` metadata, input schema type variants, all-protected budget entries

## Test plan
- [x] All 933 tests pass (924 existing + 9 new)
- [x] TypeScript type check passes
- [x] Biome lint/format passes
- [x] Pre-push hooks (build, lint, test, typecheck, verify-config-schema) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)