### PR TITLE
feat: add kimi and kimi-coding providers

### DIFF
--- a/docs/AI-SPEC.md
+++ b/docs/AI-SPEC.md
@@ -14,6 +14,8 @@ taskp の `agent` モードでは、Vercel AI SDK を使用して LLM と連携�
 | Anthropic | `@ai-sdk/anthropic` | `ANTHROPIC_API_KEY` |
 | OpenAI | `@ai-sdk/openai` | `OPENAI_API_KEY` |
 | Google | `@ai-sdk/google` | `GOOGLE_GENERATIVE_AI_KEY` |
+| Kimi | `@ai-sdk/openai`（OpenAI 互換） | `MOONSHOT_API_KEY` |
+| Kimi Coding | `@ai-sdk/openai`（OpenAI 互換） | `KIMI_CODING_API_KEY` |
 | Ollama | `@ai-sdk/openai`（OpenAI 互換） | 不要 |
 
 ### モデル指定の形式

--- a/docs/CONFIG-SPEC.md
+++ b/docs/CONFIG-SPEC.md
@@ -55,6 +55,8 @@ path = ".taskp/config.schema.json"
 | `anthropic` | クラウド | Anthropic API | `ANTHROPIC_API_KEY` |
 | `openai` | クラウド | OpenAI API | `OPENAI_API_KEY` |
 | `google` | クラウド | Google AI API | `GOOGLE_GENERATIVE_AI_KEY` |
+| `kimi` | クラウド | `https://api.moonshot.ai/v1` | `MOONSHOT_API_KEY` |
+| `kimi-coding` | クラウド | `https://api.kimi.com/coding/v1` | `KIMI_CODING_API_KEY` |
 | `ollama` | ローカル | `http://localhost:11434/v1` | 不要 |
 | `omlx` | ローカル | `http://localhost:8000/v1` | 不要 |
 | `lmstudio` | ローカル | `http://localhost:1234/v1` | 不要 |
@@ -134,6 +136,28 @@ taskp run code-review
 
 # Ollama に切り替え
 taskp run code-review --model ollama/qwen2.5-coder:32b
+```
+
+### Kimi（Moonshot AI 従量課金 API）
+
+```toml
+[ai]
+default_provider = "kimi"
+default_model = "kimi-k2.5"
+
+[ai.providers.kimi]
+api_key_env = "MOONSHOT_API_KEY"
+```
+
+### Kimi Coding プラン（サブスクリプション）
+
+```toml
+[ai]
+default_provider = "kimi-coding"
+default_model = "kimi-for-coding"
+
+[ai.providers.kimi-coding]
+api_key_env = "KIMI_CODING_API_KEY"
 ```
 
 ### カスタム OpenAI 互換サーバー

--- a/src/adapter/ai-provider.ts
+++ b/src/adapter/ai-provider.ts
@@ -35,6 +35,7 @@ export type ProviderRegistry = ReadonlyMap<string, ProviderFactory>;
 function createCloudFactory(
 	defaultEnvVar: string,
 	sdkFactory: (opts: { apiKey: string; baseURL?: string }) => (model: string) => LanguageModelV3,
+	defaultBaseUrl?: string,
 ): ProviderFactory {
 	return (model, config) => {
 		const apiKey = resolveApiKey(config?.api_key_env, defaultEnvVar);
@@ -42,9 +43,11 @@ function createCloudFactory(
 			return apiKey;
 		}
 
+		const baseURL = config?.base_url ?? defaultBaseUrl;
+
 		const provider = sdkFactory({
 			apiKey: apiKey.value,
-			...(config?.base_url !== undefined && { baseURL: config.base_url }),
+			...(baseURL !== undefined && { baseURL }),
 		});
 
 		return ok(provider(model));
@@ -108,6 +111,25 @@ export function createDefaultProviderRegistry(): ProviderRegistry {
 			const p = createGoogleGenerativeAI(opts);
 			return (model) => p(model);
 		}),
+	);
+
+	// Kimi (Moonshot AI) — OpenAI 互換 Chat Completions API
+	const openAIChatSdkFactory = (opts: { apiKey: string; baseURL?: string }) => {
+		const p = createOpenAI(opts);
+		return (model: string) => p.chat(model);
+	};
+
+	registry.set(
+		"kimi",
+		createCloudFactory("MOONSHOT_API_KEY", openAIChatSdkFactory, "https://api.moonshot.ai/v1"),
+	);
+	registry.set(
+		"kimi-coding",
+		createCloudFactory(
+			"KIMI_CODING_API_KEY",
+			openAIChatSdkFactory,
+			"https://api.kimi.com/coding/v1",
+		),
 	);
 
 	// Ollama はステートレス実装のため item_reference 非対応 → Chat Completions API を使う

--- a/tests/adapter/ai-provider.test.ts
+++ b/tests/adapter/ai-provider.test.ts
@@ -171,6 +171,8 @@ describe("createLanguageModel", () => {
 		process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
 		process.env.OPENAI_API_KEY = "test-openai-key";
 		process.env.GOOGLE_GENERATIVE_AI_KEY = "test-google-key";
+		process.env.MOONSHOT_API_KEY = "test-moonshot-key";
+		process.env.KIMI_CODING_API_KEY = "test-kimi-coding-key";
 	});
 
 	afterEach(() => {
@@ -325,6 +327,68 @@ describe("createLanguageModel", () => {
 		if (!result.ok) return;
 		expect(result.value.modelId).toBe("llama3");
 		expect(result.value.provider).toBe("openai.chat");
+	});
+
+	it("creates kimi model with default base URL", () => {
+		const result = createLanguageModel({ provider: "kimi", model: "kimi-k2.5" }, {});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("kimi-k2.5");
+		expect(result.value.provider).toBe("openai.chat");
+	});
+
+	it("creates kimi model with custom api_key_env", () => {
+		process.env.MY_MOONSHOT_KEY = "custom-moonshot-key";
+
+		const result = createLanguageModel(
+			{ provider: "kimi", model: "kimi-k2.5" },
+			{ providers: { kimi: { api_key_env: "MY_MOONSHOT_KEY" } } },
+		);
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("returns error when kimi API key is missing", () => {
+		delete process.env.MOONSHOT_API_KEY;
+
+		const result = createLanguageModel({ provider: "kimi", model: "kimi-k2.5" }, {});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("MOONSHOT_API_KEY");
+	});
+
+	it("creates kimi-coding model with default base URL", () => {
+		const result = createLanguageModel({ provider: "kimi-coding", model: "kimi-for-coding" }, {});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.modelId).toBe("kimi-for-coding");
+		expect(result.value.provider).toBe("openai.chat");
+	});
+
+	it("creates kimi-coding model with custom api_key_env", () => {
+		process.env.MY_KIMI_KEY = "custom-kimi-key";
+
+		const result = createLanguageModel(
+			{ provider: "kimi-coding", model: "kimi-for-coding" },
+			{ providers: { "kimi-coding": { api_key_env: "MY_KIMI_KEY" } } },
+		);
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("returns error when kimi-coding API key is missing", () => {
+		delete process.env.KIMI_CODING_API_KEY;
+
+		const result = createLanguageModel({ provider: "kimi-coding", model: "kimi-for-coding" }, {});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error.type).toBe("CONFIG_ERROR");
+		expect(result.error.message).toContain("KIMI_CODING_API_KEY");
 	});
 
 	it("returns error for unknown provider without base_url", () => {


### PR DESCRIPTION
## Summary
- Add `kimi` provider (Moonshot AI pay-per-token API at `api.moonshot.ai/v1`) and `kimi-coding` provider (subscription plan at `api.kimi.com/coding/v1`) as built-in cloud providers
- Extend `createCloudFactory` with optional `defaultBaseUrl` parameter for OpenAI-compatible cloud providers
- Add shared `openAIChatSdkFactory` helper to eliminate duplication between the two Kimi providers

## Changes
- `src/adapter/ai-provider.ts` — Register kimi/kimi-coding providers, add `defaultBaseUrl` to `createCloudFactory`
- `docs/AI-SPEC.md` — Add Kimi providers to supported providers table
- `docs/CONFIG-SPEC.md` — Add Kimi providers to provider list and config examples
- `tests/adapter/ai-provider.test.ts` — Add 6 test cases for both providers

## Test plan
- [x] All 939 existing tests pass
- [x] 6 new tests: default base URL, custom api_key_env, missing key error for both kimi and kimi-coding
- [x] biome lint/format pass
- [x] TypeScript typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)